### PR TITLE
Use Microsoft.CodeAnalysis.Common

### DIFF
--- a/Basic.Reference.Assemblies/BasicReferenceAssemblies.cs
+++ b/Basic.Reference.Assemblies/BasicReferenceAssemblies.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,6 +5,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.9.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Apparently just swapping `Microsoft.CodeAnalysis` with `Microsoft.CodeAnalysis.Common` still builds just fine as long as we remove a dangling unused namespace.

Fixes #10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaredpar/basic-reference-assemblies/11)
<!-- Reviewable:end -->
