### PR TITLE
Issue 43

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,13 +13,37 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
+
       - name: Restore dependencies
         run: dotnet restore
+
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build --no-restore -bl
+
+      - name: Pack Solution
+        run: dotnet pack -p:PackageOutputPath="${GITHUB_WORKSPACE}/packages" -p:IncludeSymbols=false -p:RepositoryCommit=${GITHUB_SHA} -p:PackageVersion="0.0.0.1"
+      
       - name: Test
         run: dotnet test --no-build --verbosity normal
+
+      - name: Upload Binary Log 
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: binary-log
+          path: msbuild.binlog
+        
+      - name: Upload Packages
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: nuget-packages
+          path: packages/*
+
+
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "dotnet",
+			"task": "build",
+			"problemMatcher": [
+				"$msCompile"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"label": "dotnet: build"
+		}
+	]
+}

--- a/Basic.Reference.Assemblies.Net461/Generated.targets
+++ b/Basic.Reference.Assemblies.Net461/Generated.targets
@@ -1,734 +1,734 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Accessibility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Accessibility.dll" WithCulture="false">
           <LogicalName>net461.Accessibility</LogicalName>
           <Link>Resources\net461\Accessibility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\CustomMarshalers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\CustomMarshalers.dll" WithCulture="false">
           <LogicalName>net461.CustomMarshalers</LogicalName>
           <Link>Resources\net461\CustomMarshalers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\ISymWrapper.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\ISymWrapper.dll" WithCulture="false">
           <LogicalName>net461.ISymWrapper</LogicalName>
           <Link>Resources\net461\ISymWrapper.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Activities.Build.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Activities.Build.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.Activities.Build</LogicalName>
           <Link>Resources\net461\Microsoft.Activities.Build.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Conversion.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Conversion.v4.0.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.Build.Conversion.v4.0</LogicalName>
           <Link>Resources\net461\Microsoft.Build.Conversion.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.Build</LogicalName>
           <Link>Resources\net461\Microsoft.Build.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Engine.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Engine.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.Build.Engine</LogicalName>
           <Link>Resources\net461\Microsoft.Build.Engine.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Framework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Framework.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.Build.Framework</LogicalName>
           <Link>Resources\net461\Microsoft.Build.Framework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Tasks.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Tasks.v4.0.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.Build.Tasks.v4.0</LogicalName>
           <Link>Resources\net461\Microsoft.Build.Tasks.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Utilities.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.Build.Utilities.v4.0.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.Build.Utilities.v4.0</LogicalName>
           <Link>Resources\net461\Microsoft.Build.Utilities.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.CSharp</LogicalName>
           <Link>Resources\net461\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.JScript.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.JScript.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.JScript</LogicalName>
           <Link>Resources\net461\Microsoft.JScript.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.Compatibility.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.Compatibility.Data.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.VisualBasic.Compatibility.Data</LogicalName>
           <Link>Resources\net461\Microsoft.VisualBasic.Compatibility.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.Compatibility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.Compatibility.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.VisualBasic.Compatibility</LogicalName>
           <Link>Resources\net461\Microsoft.VisualBasic.Compatibility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net461\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualC.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.VisualC</LogicalName>
           <Link>Resources\net461\Microsoft.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualC.STLCLR.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Microsoft.VisualC.STLCLR.dll" WithCulture="false">
           <LogicalName>net461.Microsoft.VisualC.STLCLR</LogicalName>
           <Link>Resources\net461\Microsoft.VisualC.STLCLR.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\mscorlib.dll" WithCulture="false">
           <LogicalName>net461.mscorlib</LogicalName>
           <Link>Resources\net461\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationBuildTasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationBuildTasks.dll" WithCulture="false">
           <LogicalName>net461.PresentationBuildTasks</LogicalName>
           <Link>Resources\net461\PresentationBuildTasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationCore.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationCore.dll" WithCulture="false">
           <LogicalName>net461.PresentationCore</LogicalName>
           <Link>Resources\net461\PresentationCore.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Aero.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Aero.dll" WithCulture="false">
           <LogicalName>net461.PresentationFramework.Aero</LogicalName>
           <Link>Resources\net461\PresentationFramework.Aero.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Aero2.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Aero2.dll" WithCulture="false">
           <LogicalName>net461.PresentationFramework.Aero2</LogicalName>
           <Link>Resources\net461\PresentationFramework.Aero2.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.AeroLite.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.AeroLite.dll" WithCulture="false">
           <LogicalName>net461.PresentationFramework.AeroLite</LogicalName>
           <Link>Resources\net461\PresentationFramework.AeroLite.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Classic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Classic.dll" WithCulture="false">
           <LogicalName>net461.PresentationFramework.Classic</LogicalName>
           <Link>Resources\net461\PresentationFramework.Classic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.dll" WithCulture="false">
           <LogicalName>net461.PresentationFramework</LogicalName>
           <Link>Resources\net461\PresentationFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Luna.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Luna.dll" WithCulture="false">
           <LogicalName>net461.PresentationFramework.Luna</LogicalName>
           <Link>Resources\net461\PresentationFramework.Luna.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Royale.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\PresentationFramework.Royale.dll" WithCulture="false">
           <LogicalName>net461.PresentationFramework.Royale</LogicalName>
           <Link>Resources\net461\PresentationFramework.Royale.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\ReachFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\ReachFramework.dll" WithCulture="false">
           <LogicalName>net461.ReachFramework</LogicalName>
           <Link>Resources\net461\ReachFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\sysglobl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\sysglobl.dll" WithCulture="false">
           <LogicalName>net461.sysglobl</LogicalName>
           <Link>Resources\net461\sysglobl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.Core.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.Core.Presentation.dll" WithCulture="false">
           <LogicalName>net461.System.Activities.Core.Presentation</LogicalName>
           <Link>Resources\net461\System.Activities.Core.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.dll" WithCulture="false">
           <LogicalName>net461.System.Activities</LogicalName>
           <Link>Resources\net461\System.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.DurableInstancing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.DurableInstancing.dll" WithCulture="false">
           <LogicalName>net461.System.Activities.DurableInstancing</LogicalName>
           <Link>Resources\net461\System.Activities.DurableInstancing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Activities.Presentation.dll" WithCulture="false">
           <LogicalName>net461.System.Activities.Presentation</LogicalName>
           <Link>Resources\net461\System.Activities.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.AddIn.Contract.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.AddIn.Contract.dll" WithCulture="false">
           <LogicalName>net461.System.AddIn.Contract</LogicalName>
           <Link>Resources\net461\System.AddIn.Contract.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.AddIn.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.AddIn.dll" WithCulture="false">
           <LogicalName>net461.System.AddIn</LogicalName>
           <Link>Resources\net461\System.AddIn.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ComponentModel.Composition.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ComponentModel.Composition.dll" WithCulture="false">
           <LogicalName>net461.System.ComponentModel.Composition</LogicalName>
           <Link>Resources\net461\System.ComponentModel.Composition.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ComponentModel.Composition.Registration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ComponentModel.Composition.Registration.dll" WithCulture="false">
           <LogicalName>net461.System.ComponentModel.Composition.Registration</LogicalName>
           <Link>Resources\net461\System.ComponentModel.Composition.Registration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net461.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net461\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Configuration.dll" WithCulture="false">
           <LogicalName>net461.System.Configuration</LogicalName>
           <Link>Resources\net461\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Configuration.Install.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Configuration.Install.dll" WithCulture="false">
           <LogicalName>net461.System.Configuration.Install</LogicalName>
           <Link>Resources\net461\System.Configuration.Install.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Core.dll" WithCulture="false">
           <LogicalName>net461.System.Core</LogicalName>
           <Link>Resources\net461\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net461.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net461\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.dll" WithCulture="false">
           <LogicalName>net461.System.Data</LogicalName>
           <Link>Resources\net461\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Entity.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Entity.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Data.Entity.Design</LogicalName>
           <Link>Resources\net461\System.Data.Entity.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Entity.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Entity.dll" WithCulture="false">
           <LogicalName>net461.System.Data.Entity</LogicalName>
           <Link>Resources\net461\System.Data.Entity.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Linq.dll" WithCulture="false">
           <LogicalName>net461.System.Data.Linq</LogicalName>
           <Link>Resources\net461\System.Data.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.OracleClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.OracleClient.dll" WithCulture="false">
           <LogicalName>net461.System.Data.OracleClient</LogicalName>
           <Link>Resources\net461\System.Data.OracleClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Services.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Services.Client.dll" WithCulture="false">
           <LogicalName>net461.System.Data.Services.Client</LogicalName>
           <Link>Resources\net461\System.Data.Services.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Services.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Services.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Data.Services.Design</LogicalName>
           <Link>Resources\net461\System.Data.Services.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.Services.dll" WithCulture="false">
           <LogicalName>net461.System.Data.Services</LogicalName>
           <Link>Resources\net461\System.Data.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.SqlXml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Data.SqlXml.dll" WithCulture="false">
           <LogicalName>net461.System.Data.SqlXml</LogicalName>
           <Link>Resources\net461\System.Data.SqlXml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Deployment.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Deployment.dll" WithCulture="false">
           <LogicalName>net461.System.Deployment</LogicalName>
           <Link>Resources\net461\System.Deployment.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Design</LogicalName>
           <Link>Resources\net461\System.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Device.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Device.dll" WithCulture="false">
           <LogicalName>net461.System.Device</LogicalName>
           <Link>Resources\net461\System.Device.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.DirectoryServices.AccountManagement.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.DirectoryServices.AccountManagement.dll" WithCulture="false">
           <LogicalName>net461.System.DirectoryServices.AccountManagement</LogicalName>
           <Link>Resources\net461\System.DirectoryServices.AccountManagement.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.DirectoryServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.DirectoryServices.dll" WithCulture="false">
           <LogicalName>net461.System.DirectoryServices</LogicalName>
           <Link>Resources\net461\System.DirectoryServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.DirectoryServices.Protocols.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.DirectoryServices.Protocols.dll" WithCulture="false">
           <LogicalName>net461.System.DirectoryServices.Protocols</LogicalName>
           <Link>Resources\net461\System.DirectoryServices.Protocols.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.dll" WithCulture="false">
           <LogicalName>net461.System</LogicalName>
           <Link>Resources\net461\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Drawing.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Drawing.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Drawing.Design</LogicalName>
           <Link>Resources\net461\System.Drawing.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Drawing.dll" WithCulture="false">
           <LogicalName>net461.System.Drawing</LogicalName>
           <Link>Resources\net461\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Dynamic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Dynamic.dll" WithCulture="false">
           <LogicalName>net461.System.Dynamic</LogicalName>
           <Link>Resources\net461\System.Dynamic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IdentityModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IdentityModel.dll" WithCulture="false">
           <LogicalName>net461.System.IdentityModel</LogicalName>
           <Link>Resources\net461\System.IdentityModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IdentityModel.Selectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IdentityModel.Selectors.dll" WithCulture="false">
           <LogicalName>net461.System.IdentityModel.Selectors</LogicalName>
           <Link>Resources\net461\System.IdentityModel.Selectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IdentityModel.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IdentityModel.Services.dll" WithCulture="false">
           <LogicalName>net461.System.IdentityModel.Services</LogicalName>
           <Link>Resources\net461\System.IdentityModel.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net461.System.IO.Compression</LogicalName>
           <Link>Resources\net461\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net461.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net461\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IO.Log.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.IO.Log.dll" WithCulture="false">
           <LogicalName>net461.System.IO.Log</LogicalName>
           <Link>Resources\net461\System.IO.Log.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Management.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Management.dll" WithCulture="false">
           <LogicalName>net461.System.Management</LogicalName>
           <Link>Resources\net461\System.Management.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Management.Instrumentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Management.Instrumentation.dll" WithCulture="false">
           <LogicalName>net461.System.Management.Instrumentation</LogicalName>
           <Link>Resources\net461\System.Management.Instrumentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Messaging.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Messaging.dll" WithCulture="false">
           <LogicalName>net461.System.Messaging</LogicalName>
           <Link>Resources\net461\System.Messaging.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Net.dll" WithCulture="false">
           <LogicalName>net461.System.Net</LogicalName>
           <Link>Resources\net461\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net461.System.Net.Http</LogicalName>
           <Link>Resources\net461\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Net.Http.WebRequest.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Net.Http.WebRequest.dll" WithCulture="false">
           <LogicalName>net461.System.Net.Http.WebRequest</LogicalName>
           <Link>Resources\net461\System.Net.Http.WebRequest.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Numerics.dll" WithCulture="false">
           <LogicalName>net461.System.Numerics</LogicalName>
           <Link>Resources\net461\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Numerics.Vectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Numerics.Vectors.dll" WithCulture="false">
           <LogicalName>net461.System.Numerics.Vectors</LogicalName>
           <Link>Resources\net461\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Printing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Printing.dll" WithCulture="false">
           <LogicalName>net461.System.Printing</LogicalName>
           <Link>Resources\net461\System.Printing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Reflection.Context.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Reflection.Context.dll" WithCulture="false">
           <LogicalName>net461.System.Reflection.Context</LogicalName>
           <Link>Resources\net461\System.Reflection.Context.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Caching.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Caching.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Caching</LogicalName>
           <Link>Resources\net461\System.Runtime.Caching.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.DurableInstancing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.DurableInstancing.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.DurableInstancing</LogicalName>
           <Link>Resources\net461\System.Runtime.DurableInstancing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Remoting.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Remoting.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Remoting</LogicalName>
           <Link>Resources\net461\System.Runtime.Remoting.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net461\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Serialization.Formatters.Soap.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Runtime.Serialization.Formatters.Soap.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Serialization.Formatters.Soap</LogicalName>
           <Link>Resources\net461\System.Runtime.Serialization.Formatters.Soap.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Security.dll" WithCulture="false">
           <LogicalName>net461.System.Security</LogicalName>
           <Link>Resources\net461\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Activation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Activation.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Activation</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Activation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Activities.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Activities</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Channels.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Channels</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Discovery.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Discovery.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Discovery</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Discovery.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel</LogicalName>
           <Link>Resources\net461\System.ServiceModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Routing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Routing.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Routing</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Routing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceProcess</LogicalName>
           <Link>Resources\net461\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Speech.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Speech.dll" WithCulture="false">
           <LogicalName>net461.System.Speech</LogicalName>
           <Link>Resources\net461\System.Speech.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Transactions.dll" WithCulture="false">
           <LogicalName>net461.System.Transactions</LogicalName>
           <Link>Resources\net461\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Abstractions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Abstractions.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Abstractions</LogicalName>
           <Link>Resources\net461\System.Web.Abstractions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.ApplicationServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.ApplicationServices.dll" WithCulture="false">
           <LogicalName>net461.System.Web.ApplicationServices</LogicalName>
           <Link>Resources\net461\System.Web.ApplicationServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DataVisualization.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DataVisualization.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Web.DataVisualization.Design</LogicalName>
           <Link>Resources\net461\System.Web.DataVisualization.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DataVisualization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DataVisualization.dll" WithCulture="false">
           <LogicalName>net461.System.Web.DataVisualization</LogicalName>
           <Link>Resources\net461\System.Web.DataVisualization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.dll" WithCulture="false">
           <LogicalName>net461.System.Web</LogicalName>
           <Link>Resources\net461\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DynamicData.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DynamicData.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Web.DynamicData.Design</LogicalName>
           <Link>Resources\net461\System.Web.DynamicData.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DynamicData.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.DynamicData.dll" WithCulture="false">
           <LogicalName>net461.System.Web.DynamicData</LogicalName>
           <Link>Resources\net461\System.Web.DynamicData.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Entity.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Entity.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Entity.Design</LogicalName>
           <Link>Resources\net461\System.Web.Entity.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Entity.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Entity.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Entity</LogicalName>
           <Link>Resources\net461\System.Web.Entity.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Extensions.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Extensions.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Extensions.Design</LogicalName>
           <Link>Resources\net461\System.Web.Extensions.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Extensions.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Extensions</LogicalName>
           <Link>Resources\net461\System.Web.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Mobile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Mobile.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Mobile</LogicalName>
           <Link>Resources\net461\System.Web.Mobile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net461.System.Web.RegularExpressions</LogicalName>
           <Link>Resources\net461\System.Web.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Routing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Routing.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Routing</LogicalName>
           <Link>Resources\net461\System.Web.Routing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Web.Services.dll" WithCulture="false">
           <LogicalName>net461.System.Web.Services</LogicalName>
           <Link>Resources\net461\System.Web.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Controls.Ribbon.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Controls.Ribbon.dll" WithCulture="false">
           <LogicalName>net461.System.Windows.Controls.Ribbon</LogicalName>
           <Link>Resources\net461\System.Windows.Controls.Ribbon.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.dll" WithCulture="false">
           <LogicalName>net461.System.Windows</LogicalName>
           <Link>Resources\net461\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Forms.DataVisualization.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Forms.DataVisualization.Design.dll" WithCulture="false">
           <LogicalName>net461.System.Windows.Forms.DataVisualization.Design</LogicalName>
           <Link>Resources\net461\System.Windows.Forms.DataVisualization.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Forms.DataVisualization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Forms.DataVisualization.dll" WithCulture="false">
           <LogicalName>net461.System.Windows.Forms.DataVisualization</LogicalName>
           <Link>Resources\net461\System.Windows.Forms.DataVisualization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Forms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Forms.dll" WithCulture="false">
           <LogicalName>net461.System.Windows.Forms</LogicalName>
           <Link>Resources\net461\System.Windows.Forms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Input.Manipulations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Input.Manipulations.dll" WithCulture="false">
           <LogicalName>net461.System.Windows.Input.Manipulations</LogicalName>
           <Link>Resources\net461\System.Windows.Input.Manipulations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Windows.Presentation.dll" WithCulture="false">
           <LogicalName>net461.System.Windows.Presentation</LogicalName>
           <Link>Resources\net461\System.Windows.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Workflow.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Workflow.Activities.dll" WithCulture="false">
           <LogicalName>net461.System.Workflow.Activities</LogicalName>
           <Link>Resources\net461\System.Workflow.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Workflow.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Workflow.ComponentModel.dll" WithCulture="false">
           <LogicalName>net461.System.Workflow.ComponentModel</LogicalName>
           <Link>Resources\net461\System.Workflow.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Workflow.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Workflow.Runtime.dll" WithCulture="false">
           <LogicalName>net461.System.Workflow.Runtime</LogicalName>
           <Link>Resources\net461\System.Workflow.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.WorkflowServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.WorkflowServices.dll" WithCulture="false">
           <LogicalName>net461.System.WorkflowServices</LogicalName>
           <Link>Resources\net461\System.WorkflowServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xaml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xaml.dll" WithCulture="false">
           <LogicalName>net461.System.Xaml</LogicalName>
           <Link>Resources\net461\System.Xaml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xml.dll" WithCulture="false">
           <LogicalName>net461.System.Xml</LogicalName>
           <Link>Resources\net461\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net461.System.Xml.Linq</LogicalName>
           <Link>Resources\net461\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net461.System.Xml.Serialization</LogicalName>
           <Link>Resources\net461\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationClient.dll" WithCulture="false">
           <LogicalName>net461.UIAutomationClient</LogicalName>
           <Link>Resources\net461\UIAutomationClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationClientsideProviders.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationClientsideProviders.dll" WithCulture="false">
           <LogicalName>net461.UIAutomationClientsideProviders</LogicalName>
           <Link>Resources\net461\UIAutomationClientsideProviders.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationProvider.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationProvider.dll" WithCulture="false">
           <LogicalName>net461.UIAutomationProvider</LogicalName>
           <Link>Resources\net461\UIAutomationProvider.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationTypes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\UIAutomationTypes.dll" WithCulture="false">
           <LogicalName>net461.UIAutomationTypes</LogicalName>
           <Link>Resources\net461\UIAutomationTypes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\WindowsBase.dll" WithCulture="false">
           <LogicalName>net461.WindowsBase</LogicalName>
           <Link>Resources\net461\WindowsBase.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\WindowsFormsIntegration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\WindowsFormsIntegration.dll" WithCulture="false">
           <LogicalName>net461.WindowsFormsIntegration</LogicalName>
           <Link>Resources\net461\WindowsFormsIntegration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\XamlBuildTask.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\XamlBuildTask.dll" WithCulture="false">
           <LogicalName>net461.XamlBuildTask</LogicalName>
           <Link>Resources\net461\XamlBuildTask.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net461.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net461\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Collections.dll" WithCulture="false">
           <LogicalName>net461.System.Collections</LogicalName>
           <Link>Resources\net461\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net461.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net461\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net461.System.ComponentModel</LogicalName>
           <Link>Resources\net461\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net461.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net461\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net461.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net461\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net461.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net461\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net461.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net461\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net461.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net461\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net461.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net461\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Globalization.dll" WithCulture="false">
           <LogicalName>net461.System.Globalization</LogicalName>
           <Link>Resources\net461\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.IO.dll" WithCulture="false">
           <LogicalName>net461.System.IO</LogicalName>
           <Link>Resources\net461\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.dll" WithCulture="false">
           <LogicalName>net461.System.Linq</LogicalName>
           <Link>Resources\net461\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net461.System.Linq.Expressions</LogicalName>
           <Link>Resources\net461\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net461.System.Linq.Parallel</LogicalName>
           <Link>Resources\net461\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net461.System.Linq.Queryable</LogicalName>
           <Link>Resources\net461\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net461.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net461\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net461.System.Net.Primitives</LogicalName>
           <Link>Resources\net461\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net461.System.Net.Requests</LogicalName>
           <Link>Resources\net461\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net461.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net461\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net461.System.ObjectModel</LogicalName>
           <Link>Resources\net461\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.dll" WithCulture="false">
           <LogicalName>net461.System.Reflection</LogicalName>
           <Link>Resources\net461\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net461.System.Reflection.Emit</LogicalName>
           <Link>Resources\net461\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net461.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net461\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net461.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net461\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net461.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net461\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net461.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net461\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net461.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net461\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime</LogicalName>
           <Link>Resources\net461\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net461\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Handles</LogicalName>
           <Link>Resources\net461\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net461\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.InteropServices.WindowsRuntime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.InteropServices.WindowsRuntime.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.InteropServices.WindowsRuntime</LogicalName>
           <Link>Resources\net461\System.Runtime.InteropServices.WindowsRuntime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net461\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net461\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net461\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net461.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net461\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net461.System.Security.Principal</LogicalName>
           <Link>Resources\net461\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Duplex.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Duplex.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Duplex</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Duplex.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Http.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Http</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.NetTcp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.NetTcp.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.NetTcp</LogicalName>
           <Link>Resources\net461\System.ServiceModel.NetTcp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Primitives.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Primitives</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.ServiceModel.Security.dll" WithCulture="false">
           <LogicalName>net461.System.ServiceModel.Security</LogicalName>
           <Link>Resources\net461\System.ServiceModel.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net461.System.Text.Encoding</LogicalName>
           <Link>Resources\net461\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net461.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net461\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net461.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net461\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.dll" WithCulture="false">
           <LogicalName>net461.System.Threading</LogicalName>
           <Link>Resources\net461\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net461.System.Threading.Tasks</LogicalName>
           <Link>Resources\net461\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net461.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net461\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net461.System.Threading.Timer</LogicalName>
           <Link>Resources\net461\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net461.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net461\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net461.System.Xml.XDocument</LogicalName>
           <Link>Resources\net461\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net461\1.0.2\build\.NETFramework\v4.6.1\Facades\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net461.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net461\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.Net472/Generated.targets
+++ b/Basic.Reference.Assemblies.Net472/Generated.targets
@@ -1,938 +1,938 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Accessibility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Accessibility.dll" WithCulture="false">
           <LogicalName>net472.Accessibility</LogicalName>
           <Link>Resources\net472\Accessibility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\CustomMarshalers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\CustomMarshalers.dll" WithCulture="false">
           <LogicalName>net472.CustomMarshalers</LogicalName>
           <Link>Resources\net472\CustomMarshalers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ISymWrapper.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ISymWrapper.dll" WithCulture="false">
           <LogicalName>net472.ISymWrapper</LogicalName>
           <Link>Resources\net472\ISymWrapper.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Activities.Build.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Activities.Build.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Activities.Build</LogicalName>
           <Link>Resources\net472\Microsoft.Activities.Build.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Conversion.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Conversion.v4.0.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Conversion.v4.0</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Conversion.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build</LogicalName>
           <Link>Resources\net472\Microsoft.Build.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Engine.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Engine.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Engine</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Engine.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Framework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Framework.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Framework</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Framework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Tasks.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Tasks.v4.0.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Tasks.v4.0</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Tasks.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Utilities.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Utilities.v4.0.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Utilities.v4.0</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Utilities.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.CSharp</LogicalName>
           <Link>Resources\net472\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.JScript.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.JScript.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.JScript</LogicalName>
           <Link>Resources\net472\Microsoft.JScript.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.Data.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualBasic.Compatibility.Data</LogicalName>
           <Link>Resources\net472\Microsoft.VisualBasic.Compatibility.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualBasic.Compatibility</LogicalName>
           <Link>Resources\net472\Microsoft.VisualBasic.Compatibility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net472\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualC</LogicalName>
           <Link>Resources\net472\Microsoft.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.STLCLR.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.STLCLR.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualC.STLCLR</LogicalName>
           <Link>Resources\net472\Microsoft.VisualC.STLCLR.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\mscorlib.dll" WithCulture="false">
           <LogicalName>net472.mscorlib</LogicalName>
           <Link>Resources\net472\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationBuildTasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationBuildTasks.dll" WithCulture="false">
           <LogicalName>net472.PresentationBuildTasks</LogicalName>
           <Link>Resources\net472\PresentationBuildTasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationCore.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationCore.dll" WithCulture="false">
           <LogicalName>net472.PresentationCore</LogicalName>
           <Link>Resources\net472\PresentationCore.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Aero</LogicalName>
           <Link>Resources\net472\PresentationFramework.Aero.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero2.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero2.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Aero2</LogicalName>
           <Link>Resources\net472\PresentationFramework.Aero2.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.AeroLite.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.AeroLite.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.AeroLite</LogicalName>
           <Link>Resources\net472\PresentationFramework.AeroLite.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Classic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Classic.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Classic</LogicalName>
           <Link>Resources\net472\PresentationFramework.Classic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework</LogicalName>
           <Link>Resources\net472\PresentationFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Luna.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Luna.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Luna</LogicalName>
           <Link>Resources\net472\PresentationFramework.Luna.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Royale.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Royale.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Royale</LogicalName>
           <Link>Resources\net472\PresentationFramework.Royale.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ReachFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ReachFramework.dll" WithCulture="false">
           <LogicalName>net472.ReachFramework</LogicalName>
           <Link>Resources\net472\ReachFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\sysglobl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\sysglobl.dll" WithCulture="false">
           <LogicalName>net472.sysglobl</LogicalName>
           <Link>Resources\net472\sysglobl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Core.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Core.Presentation.dll" WithCulture="false">
           <LogicalName>net472.System.Activities.Core.Presentation</LogicalName>
           <Link>Resources\net472\System.Activities.Core.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.dll" WithCulture="false">
           <LogicalName>net472.System.Activities</LogicalName>
           <Link>Resources\net472\System.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.DurableInstancing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.DurableInstancing.dll" WithCulture="false">
           <LogicalName>net472.System.Activities.DurableInstancing</LogicalName>
           <Link>Resources\net472\System.Activities.DurableInstancing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Presentation.dll" WithCulture="false">
           <LogicalName>net472.System.Activities.Presentation</LogicalName>
           <Link>Resources\net472\System.Activities.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.Contract.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.Contract.dll" WithCulture="false">
           <LogicalName>net472.System.AddIn.Contract</LogicalName>
           <Link>Resources\net472\System.AddIn.Contract.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.dll" WithCulture="false">
           <LogicalName>net472.System.AddIn</LogicalName>
           <Link>Resources\net472\System.AddIn.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Composition</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Composition.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.Registration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.Registration.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Composition.Registration</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Composition.Registration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net472\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.dll" WithCulture="false">
           <LogicalName>net472.System.Configuration</LogicalName>
           <Link>Resources\net472\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.Install.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.Install.dll" WithCulture="false">
           <LogicalName>net472.System.Configuration.Install</LogicalName>
           <Link>Resources\net472\System.Configuration.Install.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Core.dll" WithCulture="false">
           <LogicalName>net472.System.Core</LogicalName>
           <Link>Resources\net472\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net472.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net472\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.dll" WithCulture="false">
           <LogicalName>net472.System.Data</LogicalName>
           <Link>Resources\net472\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Entity.Design</LogicalName>
           <Link>Resources\net472\System.Data.Entity.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Entity</LogicalName>
           <Link>Resources\net472\System.Data.Entity.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Linq.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Linq</LogicalName>
           <Link>Resources\net472\System.Data.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.OracleClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.OracleClient.dll" WithCulture="false">
           <LogicalName>net472.System.Data.OracleClient</LogicalName>
           <Link>Resources\net472\System.Data.OracleClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Client.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Services.Client</LogicalName>
           <Link>Resources\net472\System.Data.Services.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Services.Design</LogicalName>
           <Link>Resources\net472\System.Data.Services.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Services</LogicalName>
           <Link>Resources\net472\System.Data.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.SqlXml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.SqlXml.dll" WithCulture="false">
           <LogicalName>net472.System.Data.SqlXml</LogicalName>
           <Link>Resources\net472\System.Data.SqlXml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Deployment.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Deployment.dll" WithCulture="false">
           <LogicalName>net472.System.Deployment</LogicalName>
           <Link>Resources\net472\System.Deployment.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Design</LogicalName>
           <Link>Resources\net472\System.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Device.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Device.dll" WithCulture="false">
           <LogicalName>net472.System.Device</LogicalName>
           <Link>Resources\net472\System.Device.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.AccountManagement.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.AccountManagement.dll" WithCulture="false">
           <LogicalName>net472.System.DirectoryServices.AccountManagement</LogicalName>
           <Link>Resources\net472\System.DirectoryServices.AccountManagement.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.dll" WithCulture="false">
           <LogicalName>net472.System.DirectoryServices</LogicalName>
           <Link>Resources\net472\System.DirectoryServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.Protocols.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.Protocols.dll" WithCulture="false">
           <LogicalName>net472.System.DirectoryServices.Protocols</LogicalName>
           <Link>Resources\net472\System.DirectoryServices.Protocols.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.dll" WithCulture="false">
           <LogicalName>net472.System</LogicalName>
           <Link>Resources\net472\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Drawing.Design</LogicalName>
           <Link>Resources\net472\System.Drawing.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.dll" WithCulture="false">
           <LogicalName>net472.System.Drawing</LogicalName>
           <Link>Resources\net472\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Dynamic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Dynamic.dll" WithCulture="false">
           <LogicalName>net472.System.Dynamic</LogicalName>
           <Link>Resources\net472\System.Dynamic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.dll" WithCulture="false">
           <LogicalName>net472.System.IdentityModel</LogicalName>
           <Link>Resources\net472\System.IdentityModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Selectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Selectors.dll" WithCulture="false">
           <LogicalName>net472.System.IdentityModel.Selectors</LogicalName>
           <Link>Resources\net472\System.IdentityModel.Selectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Services.dll" WithCulture="false">
           <LogicalName>net472.System.IdentityModel.Services</LogicalName>
           <Link>Resources\net472\System.IdentityModel.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Compression</LogicalName>
           <Link>Resources\net472\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net472\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Log.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Log.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Log</LogicalName>
           <Link>Resources\net472\System.IO.Log.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.dll" WithCulture="false">
           <LogicalName>net472.System.Management</LogicalName>
           <Link>Resources\net472\System.Management.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.Instrumentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.Instrumentation.dll" WithCulture="false">
           <LogicalName>net472.System.Management.Instrumentation</LogicalName>
           <Link>Resources\net472\System.Management.Instrumentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Messaging.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Messaging.dll" WithCulture="false">
           <LogicalName>net472.System.Messaging</LogicalName>
           <Link>Resources\net472\System.Messaging.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.dll" WithCulture="false">
           <LogicalName>net472.System.Net</LogicalName>
           <Link>Resources\net472\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Http</LogicalName>
           <Link>Resources\net472\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.WebRequest.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.WebRequest.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Http.WebRequest</LogicalName>
           <Link>Resources\net472\System.Net.Http.WebRequest.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Numerics.dll" WithCulture="false">
           <LogicalName>net472.System.Numerics</LogicalName>
           <Link>Resources\net472\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Printing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Printing.dll" WithCulture="false">
           <LogicalName>net472.System.Printing</LogicalName>
           <Link>Resources\net472\System.Printing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Reflection.Context.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Reflection.Context.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Context</LogicalName>
           <Link>Resources\net472\System.Reflection.Context.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Caching.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Caching.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Caching</LogicalName>
           <Link>Resources\net472\System.Runtime.Caching.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.DurableInstancing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.DurableInstancing.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.DurableInstancing</LogicalName>
           <Link>Resources\net472\System.Runtime.DurableInstancing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Remoting.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Remoting.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Remoting</LogicalName>
           <Link>Resources\net472\System.Runtime.Remoting.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.Formatters.Soap.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.Formatters.Soap.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Formatters.Soap</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Formatters.Soap.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Security.dll" WithCulture="false">
           <LogicalName>net472.System.Security</LogicalName>
           <Link>Resources\net472\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activation.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Activation</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Activation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activities.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Activities</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Channels.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Channels</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Discovery.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Discovery.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Discovery</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Discovery.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel</LogicalName>
           <Link>Resources\net472\System.ServiceModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Routing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Routing.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Routing</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Routing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceProcess</LogicalName>
           <Link>Resources\net472\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Speech.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Speech.dll" WithCulture="false">
           <LogicalName>net472.System.Speech</LogicalName>
           <Link>Resources\net472\System.Speech.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Transactions.dll" WithCulture="false">
           <LogicalName>net472.System.Transactions</LogicalName>
           <Link>Resources\net472\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Abstractions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Abstractions.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Abstractions</LogicalName>
           <Link>Resources\net472\System.Web.Abstractions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.ApplicationServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.ApplicationServices.dll" WithCulture="false">
           <LogicalName>net472.System.Web.ApplicationServices</LogicalName>
           <Link>Resources\net472\System.Web.ApplicationServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DataVisualization.Design</LogicalName>
           <Link>Resources\net472\System.Web.DataVisualization.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DataVisualization</LogicalName>
           <Link>Resources\net472\System.Web.DataVisualization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.dll" WithCulture="false">
           <LogicalName>net472.System.Web</LogicalName>
           <Link>Resources\net472\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DynamicData.Design</LogicalName>
           <Link>Resources\net472\System.Web.DynamicData.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DynamicData</LogicalName>
           <Link>Resources\net472\System.Web.DynamicData.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Entity.Design</LogicalName>
           <Link>Resources\net472\System.Web.Entity.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Entity</LogicalName>
           <Link>Resources\net472\System.Web.Entity.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Extensions.Design</LogicalName>
           <Link>Resources\net472\System.Web.Extensions.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Extensions</LogicalName>
           <Link>Resources\net472\System.Web.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Mobile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Mobile.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Mobile</LogicalName>
           <Link>Resources\net472\System.Web.Mobile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net472.System.Web.RegularExpressions</LogicalName>
           <Link>Resources\net472\System.Web.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Routing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Routing.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Routing</LogicalName>
           <Link>Resources\net472\System.Web.Routing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Services.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Services</LogicalName>
           <Link>Resources\net472\System.Web.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Controls.Ribbon.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Controls.Ribbon.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Controls.Ribbon</LogicalName>
           <Link>Resources\net472\System.Windows.Controls.Ribbon.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.dll" WithCulture="false">
           <LogicalName>net472.System.Windows</LogicalName>
           <Link>Resources\net472\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Forms.DataVisualization.Design</LogicalName>
           <Link>Resources\net472\System.Windows.Forms.DataVisualization.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Forms.DataVisualization</LogicalName>
           <Link>Resources\net472\System.Windows.Forms.DataVisualization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Forms</LogicalName>
           <Link>Resources\net472\System.Windows.Forms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Input.Manipulations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Input.Manipulations.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Input.Manipulations</LogicalName>
           <Link>Resources\net472\System.Windows.Input.Manipulations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Presentation.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Presentation</LogicalName>
           <Link>Resources\net472\System.Windows.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Activities.dll" WithCulture="false">
           <LogicalName>net472.System.Workflow.Activities</LogicalName>
           <Link>Resources\net472\System.Workflow.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.ComponentModel.dll" WithCulture="false">
           <LogicalName>net472.System.Workflow.ComponentModel</LogicalName>
           <Link>Resources\net472\System.Workflow.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Runtime.dll" WithCulture="false">
           <LogicalName>net472.System.Workflow.Runtime</LogicalName>
           <Link>Resources\net472\System.Workflow.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.WorkflowServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.WorkflowServices.dll" WithCulture="false">
           <LogicalName>net472.System.WorkflowServices</LogicalName>
           <Link>Resources\net472\System.WorkflowServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xaml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xaml.dll" WithCulture="false">
           <LogicalName>net472.System.Xaml</LogicalName>
           <Link>Resources\net472\System.Xaml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.dll" WithCulture="false">
           <LogicalName>net472.System.Xml</LogicalName>
           <Link>Resources\net472\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.Linq</LogicalName>
           <Link>Resources\net472\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.Serialization</LogicalName>
           <Link>Resources\net472\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClient.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationClient</LogicalName>
           <Link>Resources\net472\UIAutomationClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClientsideProviders.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClientsideProviders.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationClientsideProviders</LogicalName>
           <Link>Resources\net472\UIAutomationClientsideProviders.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationProvider.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationProvider.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationProvider</LogicalName>
           <Link>Resources\net472\UIAutomationProvider.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationTypes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationTypes.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationTypes</LogicalName>
           <Link>Resources\net472\UIAutomationTypes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsBase.dll" WithCulture="false">
           <LogicalName>net472.WindowsBase</LogicalName>
           <Link>Resources\net472\WindowsBase.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsFormsIntegration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsFormsIntegration.dll" WithCulture="false">
           <LogicalName>net472.WindowsFormsIntegration</LogicalName>
           <Link>Resources\net472\WindowsFormsIntegration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\XamlBuildTask.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\XamlBuildTask.dll" WithCulture="false">
           <LogicalName>net472.XamlBuildTask</LogicalName>
           <Link>Resources\net472\XamlBuildTask.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\net472\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\netstandard.dll" WithCulture="false">
           <LogicalName>net472.netstandard</LogicalName>
           <Link>Resources\net472\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.AppContext.dll" WithCulture="false">
           <LogicalName>net472.System.AppContext</LogicalName>
           <Link>Resources\net472\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net472.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net472\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.dll" WithCulture="false">
           <LogicalName>net472.System.Collections</LogicalName>
           <Link>Resources\net472\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>net472.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\net472\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>net472.System.Collections.Specialized</LogicalName>
           <Link>Resources\net472\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel</LogicalName>
           <Link>Resources\net472\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net472\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\net472\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Console.dll" WithCulture="false">
           <LogicalName>net472.System.Console</LogicalName>
           <Link>Resources\net472\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Data.Common.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Common</LogicalName>
           <Link>Resources\net472\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\net472\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Process</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\net472\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\net472\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\net472\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Drawing.Primitives</LogicalName>
           <Link>Resources\net472\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net472.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net472\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>net472.System.Globalization.Calendars</LogicalName>
           <Link>Resources\net472\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.dll" WithCulture="false">
           <LogicalName>net472.System.Globalization</LogicalName>
           <Link>Resources\net472\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Globalization.Extensions</LogicalName>
           <Link>Resources\net472\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\net472\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.dll" WithCulture="false">
           <LogicalName>net472.System.IO</LogicalName>
           <Link>Resources\net472\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>net472.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\net472\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>net472.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\net472\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Pipes</LogicalName>
           <Link>Resources\net472\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>net472.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\net472\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.dll" WithCulture="false">
           <LogicalName>net472.System.Linq</LogicalName>
           <Link>Resources\net472\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net472.System.Linq.Expressions</LogicalName>
           <Link>Resources\net472\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net472.System.Linq.Parallel</LogicalName>
           <Link>Resources\net472\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net472.System.Linq.Queryable</LogicalName>
           <Link>Resources\net472\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Http.Rtc.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Http.Rtc.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Http.Rtc</LogicalName>
           <Link>Resources\net472\System.Net.Http.Rtc.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>net472.System.Net.NameResolution</LogicalName>
           <Link>Resources\net472\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net472.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net472\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Ping</LogicalName>
           <Link>Resources\net472\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Primitives</LogicalName>
           <Link>Resources\net472\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Requests</LogicalName>
           <Link>Resources\net472\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Security.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Security</LogicalName>
           <Link>Resources\net472\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Sockets</LogicalName>
           <Link>Resources\net472\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net472.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net472\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>net472.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\net472\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>net472.System.Net.WebSockets</LogicalName>
           <Link>Resources\net472\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net472.System.ObjectModel</LogicalName>
           <Link>Resources\net472\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection</LogicalName>
           <Link>Resources\net472\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Emit</LogicalName>
           <Link>Resources\net472\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net472\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net472\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net472\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net472\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>net472.System.Resources.Reader</LogicalName>
           <Link>Resources\net472\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net472.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net472\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>net472.System.Resources.Writer</LogicalName>
           <Link>Resources\net472\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\net472\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime</LogicalName>
           <Link>Resources\net472\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net472\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Handles</LogicalName>
           <Link>Resources\net472\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net472\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\net472\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.WindowsRuntime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.WindowsRuntime.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.InteropServices.WindowsRuntime</LogicalName>
           <Link>Resources\net472\System.Runtime.InteropServices.WindowsRuntime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net472\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Claims</LogicalName>
           <Link>Resources\net472\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Principal</LogicalName>
           <Link>Resources\net472\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>net472.System.Security.SecureString</LogicalName>
           <Link>Resources\net472\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Duplex.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Duplex.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Duplex</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Duplex.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Http.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Http</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.NetTcp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.NetTcp.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.NetTcp</LogicalName>
           <Link>Resources\net472\System.ServiceModel.NetTcp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Primitives</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Security.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Security</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net472.System.Text.Encoding</LogicalName>
           <Link>Resources\net472\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net472\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net472.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net472\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.dll" WithCulture="false">
           <LogicalName>net472.System.Threading</LogicalName>
           <Link>Resources\net472\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Overlapped</LogicalName>
           <Link>Resources\net472\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Tasks</LogicalName>
           <Link>Resources\net472\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net472\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Thread</LogicalName>
           <Link>Resources\net472\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\net472\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Timer</LogicalName>
           <Link>Resources\net472\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>net472.System.ValueTuple</LogicalName>
           <Link>Resources\net472\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net472\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XDocument</LogicalName>
           <Link>Resources\net472\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\net472\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net472\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XPath</LogicalName>
           <Link>Resources\net472\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\net472\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.Net50/Generated.targets
+++ b/Basic.Reference.Assemblies.Net50/Generated.targets
@@ -1,610 +1,610 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net50.Microsoft.CSharp</LogicalName>
           <Link>Resources\net50\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.VisualBasic.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.VisualBasic.Core.dll" WithCulture="false">
           <LogicalName>net50.Microsoft.VisualBasic.Core</LogicalName>
           <Link>Resources\net50\Microsoft.VisualBasic.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net50.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net50\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>net50.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\net50\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\mscorlib.dll" WithCulture="false">
           <LogicalName>net50.mscorlib</LogicalName>
           <Link>Resources\net50\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\netstandard.dll" WithCulture="false">
           <LogicalName>net50.netstandard</LogicalName>
           <Link>Resources\net50\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.AppContext.dll" WithCulture="false">
           <LogicalName>net50.System.AppContext</LogicalName>
           <Link>Resources\net50\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Buffers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Buffers.dll" WithCulture="false">
           <LogicalName>net50.System.Buffers</LogicalName>
           <Link>Resources\net50\System.Buffers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net50.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net50\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.dll" WithCulture="false">
           <LogicalName>net50.System.Collections</LogicalName>
           <Link>Resources\net50\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.Immutable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.Immutable.dll" WithCulture="false">
           <LogicalName>net50.System.Collections.Immutable</LogicalName>
           <Link>Resources\net50\System.Collections.Immutable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>net50.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\net50\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>net50.System.Collections.Specialized</LogicalName>
           <Link>Resources\net50\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net50.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net50\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net50.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net50\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net50.System.ComponentModel</LogicalName>
           <Link>Resources\net50\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net50.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net50\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>net50.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\net50\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>net50.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\net50\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Configuration.dll" WithCulture="false">
           <LogicalName>net50.System.Configuration</LogicalName>
           <Link>Resources\net50\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Console.dll" WithCulture="false">
           <LogicalName>net50.System.Console</LogicalName>
           <Link>Resources\net50\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Core.dll" WithCulture="false">
           <LogicalName>net50.System.Core</LogicalName>
           <Link>Resources\net50\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Data.Common.dll" WithCulture="false">
           <LogicalName>net50.System.Data.Common</LogicalName>
           <Link>Resources\net50\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net50.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net50\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Data.dll" WithCulture="false">
           <LogicalName>net50.System.Data</LogicalName>
           <Link>Resources\net50\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net50\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net50\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.DiagnosticSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.DiagnosticSource</LogicalName>
           <Link>Resources\net50\System.Diagnostics.DiagnosticSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\net50\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.Process</LogicalName>
           <Link>Resources\net50\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\net50\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\net50\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net50\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\net50\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net50.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net50\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.dll" WithCulture="false">
           <LogicalName>net50.System</LogicalName>
           <Link>Resources\net50\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Drawing.dll" WithCulture="false">
           <LogicalName>net50.System.Drawing</LogicalName>
           <Link>Resources\net50\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>net50.System.Drawing.Primitives</LogicalName>
           <Link>Resources\net50\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net50.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net50\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Formats.Asn1.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Formats.Asn1.dll" WithCulture="false">
           <LogicalName>net50.System.Formats.Asn1</LogicalName>
           <Link>Resources\net50\System.Formats.Asn1.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>net50.System.Globalization.Calendars</LogicalName>
           <Link>Resources\net50\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Globalization.dll" WithCulture="false">
           <LogicalName>net50.System.Globalization</LogicalName>
           <Link>Resources\net50\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>net50.System.Globalization.Extensions</LogicalName>
           <Link>Resources\net50\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.Brotli.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.Brotli.dll" WithCulture="false">
           <LogicalName>net50.System.IO.Compression.Brotli</LogicalName>
           <Link>Resources\net50\System.IO.Compression.Brotli.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net50.System.IO.Compression</LogicalName>
           <Link>Resources\net50\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net50.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net50\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>net50.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\net50\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.dll" WithCulture="false">
           <LogicalName>net50.System.IO</LogicalName>
           <Link>Resources\net50\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>net50.System.IO.FileSystem</LogicalName>
           <Link>Resources\net50\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>net50.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\net50\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>net50.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\net50\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>net50.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\net50\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>net50.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\net50\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>net50.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\net50\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>net50.System.IO.Pipes</LogicalName>
           <Link>Resources\net50\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>net50.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\net50\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.dll" WithCulture="false">
           <LogicalName>net50.System.Linq</LogicalName>
           <Link>Resources\net50\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net50.System.Linq.Expressions</LogicalName>
           <Link>Resources\net50\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net50.System.Linq.Parallel</LogicalName>
           <Link>Resources\net50\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net50.System.Linq.Queryable</LogicalName>
           <Link>Resources\net50\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Memory.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Memory.dll" WithCulture="false">
           <LogicalName>net50.System.Memory</LogicalName>
           <Link>Resources\net50\System.Memory.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.dll" WithCulture="false">
           <LogicalName>net50.System.Net</LogicalName>
           <Link>Resources\net50\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Http</LogicalName>
           <Link>Resources\net50\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Http.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Http.Json.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Http.Json</LogicalName>
           <Link>Resources\net50\System.Net.Http.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.HttpListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.HttpListener.dll" WithCulture="false">
           <LogicalName>net50.System.Net.HttpListener</LogicalName>
           <Link>Resources\net50\System.Net.HttpListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Mail.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Mail.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Mail</LogicalName>
           <Link>Resources\net50\System.Net.Mail.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>net50.System.Net.NameResolution</LogicalName>
           <Link>Resources\net50\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net50.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net50\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Ping</LogicalName>
           <Link>Resources\net50\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Primitives</LogicalName>
           <Link>Resources\net50\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Requests</LogicalName>
           <Link>Resources\net50\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Security.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Security</LogicalName>
           <Link>Resources\net50\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.ServicePoint.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.ServicePoint.dll" WithCulture="false">
           <LogicalName>net50.System.Net.ServicePoint</LogicalName>
           <Link>Resources\net50\System.Net.ServicePoint.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>net50.System.Net.Sockets</LogicalName>
           <Link>Resources\net50\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebClient.dll" WithCulture="false">
           <LogicalName>net50.System.Net.WebClient</LogicalName>
           <Link>Resources\net50\System.Net.WebClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net50.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net50\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebProxy.dll" WithCulture="false">
           <LogicalName>net50.System.Net.WebProxy</LogicalName>
           <Link>Resources\net50\System.Net.WebProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>net50.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\net50\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>net50.System.Net.WebSockets</LogicalName>
           <Link>Resources\net50\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Numerics.dll" WithCulture="false">
           <LogicalName>net50.System.Numerics</LogicalName>
           <Link>Resources\net50\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Numerics.Vectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Numerics.Vectors.dll" WithCulture="false">
           <LogicalName>net50.System.Numerics.Vectors</LogicalName>
           <Link>Resources\net50\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net50.System.ObjectModel</LogicalName>
           <Link>Resources\net50\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.DispatchProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.DispatchProxy.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.DispatchProxy</LogicalName>
           <Link>Resources\net50\System.Reflection.DispatchProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection</LogicalName>
           <Link>Resources\net50\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.Emit</LogicalName>
           <Link>Resources\net50\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net50\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net50\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net50\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Metadata.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Metadata.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.Metadata</LogicalName>
           <Link>Resources\net50\System.Reflection.Metadata.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net50\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.TypeExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Reflection.TypeExtensions.dll" WithCulture="false">
           <LogicalName>net50.System.Reflection.TypeExtensions</LogicalName>
           <Link>Resources\net50\System.Reflection.TypeExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>net50.System.Resources.Reader</LogicalName>
           <Link>Resources\net50\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net50.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net50\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>net50.System.Resources.Writer</LogicalName>
           <Link>Resources\net50\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.CompilerServices.Unsafe.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.CompilerServices.Unsafe</LogicalName>
           <Link>Resources\net50\System.Runtime.CompilerServices.Unsafe.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\net50\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime</LogicalName>
           <Link>Resources\net50\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net50\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Handles</LogicalName>
           <Link>Resources\net50\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net50\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\net50\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Intrinsics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Intrinsics.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Intrinsics</LogicalName>
           <Link>Resources\net50\System.Runtime.Intrinsics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Loader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Loader.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Loader</LogicalName>
           <Link>Resources\net50\System.Runtime.Loader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net50\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net50\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\net50\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net50\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net50\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net50.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net50\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>net50.System.Security.Claims</LogicalName>
           <Link>Resources\net50\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>net50.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\net50\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>net50.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\net50\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>net50.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\net50\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>net50.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\net50\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>net50.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\net50\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.dll" WithCulture="false">
           <LogicalName>net50.System.Security</LogicalName>
           <Link>Resources\net50\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net50.System.Security.Principal</LogicalName>
           <Link>Resources\net50\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>net50.System.Security.SecureString</LogicalName>
           <Link>Resources\net50\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net50.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net50\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net50.System.ServiceProcess</LogicalName>
           <Link>Resources\net50\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encoding.CodePages.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encoding.CodePages.dll" WithCulture="false">
           <LogicalName>net50.System.Text.Encoding.CodePages</LogicalName>
           <Link>Resources\net50\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net50.System.Text.Encoding</LogicalName>
           <Link>Resources\net50\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net50.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net50\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encodings.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Encodings.Web.dll" WithCulture="false">
           <LogicalName>net50.System.Text.Encodings.Web</LogicalName>
           <Link>Resources\net50\System.Text.Encodings.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.Json.dll" WithCulture="false">
           <LogicalName>net50.System.Text.Json</LogicalName>
           <Link>Resources\net50\System.Text.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net50.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net50\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Channels.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Channels</LogicalName>
           <Link>Resources\net50\System.Threading.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.dll" WithCulture="false">
           <LogicalName>net50.System.Threading</LogicalName>
           <Link>Resources\net50\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Overlapped</LogicalName>
           <Link>Resources\net50\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.Dataflow.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Tasks.Dataflow</LogicalName>
           <Link>Resources\net50\System.Threading.Tasks.Dataflow.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Tasks</LogicalName>
           <Link>Resources\net50\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Tasks.Extensions</LogicalName>
           <Link>Resources\net50\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net50\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Thread</LogicalName>
           <Link>Resources\net50\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\net50\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net50.System.Threading.Timer</LogicalName>
           <Link>Resources\net50\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Transactions.dll" WithCulture="false">
           <LogicalName>net50.System.Transactions</LogicalName>
           <Link>Resources\net50\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Transactions.Local.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Transactions.Local.dll" WithCulture="false">
           <LogicalName>net50.System.Transactions.Local</LogicalName>
           <Link>Resources\net50\System.Transactions.Local.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>net50.System.ValueTuple</LogicalName>
           <Link>Resources\net50\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Web.dll" WithCulture="false">
           <LogicalName>net50.System.Web</LogicalName>
           <Link>Resources\net50\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Web.HttpUtility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Web.HttpUtility.dll" WithCulture="false">
           <LogicalName>net50.System.Web.HttpUtility</LogicalName>
           <Link>Resources\net50\System.Web.HttpUtility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Windows.dll" WithCulture="false">
           <LogicalName>net50.System.Windows</LogicalName>
           <Link>Resources\net50\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.dll" WithCulture="false">
           <LogicalName>net50.System.Xml</LogicalName>
           <Link>Resources\net50\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.Linq</LogicalName>
           <Link>Resources\net50\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net50\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.Serialization</LogicalName>
           <Link>Resources\net50\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.XDocument</LogicalName>
           <Link>Resources\net50\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\net50\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net50\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.XPath</LogicalName>
           <Link>Resources\net50\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>net50.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\net50\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\5.0.0\ref\net5.0\WindowsBase.dll" WithCulture="false">
           <LogicalName>net50.WindowsBase</LogicalName>
           <Link>Resources\net50\WindowsBase.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.Net60/Generated.targets
+++ b/Basic.Reference.Assemblies.Net60/Generated.targets
@@ -1,638 +1,638 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.CSharp</LogicalName>
           <Link>Resources\net60\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.Core.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.VisualBasic.Core</LogicalName>
           <Link>Resources\net60\Microsoft.VisualBasic.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net60\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\net60\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Registry.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Registry.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.Win32.Registry</LogicalName>
           <Link>Resources\net60\Microsoft.Win32.Registry.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\mscorlib.dll" WithCulture="false">
           <LogicalName>net60.mscorlib</LogicalName>
           <Link>Resources\net60\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\netstandard.dll" WithCulture="false">
           <LogicalName>net60.netstandard</LogicalName>
           <Link>Resources\net60\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.AppContext.dll" WithCulture="false">
           <LogicalName>net60.System.AppContext</LogicalName>
           <Link>Resources\net60\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Buffers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Buffers.dll" WithCulture="false">
           <LogicalName>net60.System.Buffers</LogicalName>
           <Link>Resources\net60\System.Buffers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net60\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.dll" WithCulture="false">
           <LogicalName>net60.System.Collections</LogicalName>
           <Link>Resources\net60\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Immutable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Immutable.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.Immutable</LogicalName>
           <Link>Resources\net60\System.Collections.Immutable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\net60\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.Specialized</LogicalName>
           <Link>Resources\net60\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net60\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net60\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel</LogicalName>
           <Link>Resources\net60\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net60\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\net60\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\net60\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Configuration.dll" WithCulture="false">
           <LogicalName>net60.System.Configuration</LogicalName>
           <Link>Resources\net60\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Console.dll" WithCulture="false">
           <LogicalName>net60.System.Console</LogicalName>
           <Link>Resources\net60\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Core.dll" WithCulture="false">
           <LogicalName>net60.System.Core</LogicalName>
           <Link>Resources\net60\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.Common.dll" WithCulture="false">
           <LogicalName>net60.System.Data.Common</LogicalName>
           <Link>Resources\net60\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net60.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net60\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.dll" WithCulture="false">
           <LogicalName>net60.System.Data</LogicalName>
           <Link>Resources\net60\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.DiagnosticSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.DiagnosticSource</LogicalName>
           <Link>Resources\net60\System.Diagnostics.DiagnosticSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\net60\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Process</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\net60\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\net60\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\net60\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.dll" WithCulture="false">
           <LogicalName>net60.System</LogicalName>
           <Link>Resources\net60\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.dll" WithCulture="false">
           <LogicalName>net60.System.Drawing</LogicalName>
           <Link>Resources\net60\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Drawing.Primitives</LogicalName>
           <Link>Resources\net60\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net60.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net60\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Formats.Asn1.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Formats.Asn1.dll" WithCulture="false">
           <LogicalName>net60.System.Formats.Asn1</LogicalName>
           <Link>Resources\net60\System.Formats.Asn1.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>net60.System.Globalization.Calendars</LogicalName>
           <Link>Resources\net60\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.dll" WithCulture="false">
           <LogicalName>net60.System.Globalization</LogicalName>
           <Link>Resources\net60\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Globalization.Extensions</LogicalName>
           <Link>Resources\net60\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.Brotli.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.Brotli.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression.Brotli</LogicalName>
           <Link>Resources\net60\System.IO.Compression.Brotli.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression</LogicalName>
           <Link>Resources\net60\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net60\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\net60\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.dll" WithCulture="false">
           <LogicalName>net60.System.IO</LogicalName>
           <Link>Resources\net60\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.AccessControl.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.AccessControl</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>net60.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\net60\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>net60.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\net60\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.AccessControl.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Pipes.AccessControl</LogicalName>
           <Link>Resources\net60\System.IO.Pipes.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Pipes</LogicalName>
           <Link>Resources\net60\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>net60.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\net60\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.dll" WithCulture="false">
           <LogicalName>net60.System.Linq</LogicalName>
           <Link>Resources\net60\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net60.System.Linq.Expressions</LogicalName>
           <Link>Resources\net60\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net60.System.Linq.Parallel</LogicalName>
           <Link>Resources\net60\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net60.System.Linq.Queryable</LogicalName>
           <Link>Resources\net60\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Memory.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Memory.dll" WithCulture="false">
           <LogicalName>net60.System.Memory</LogicalName>
           <Link>Resources\net60\System.Memory.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.dll" WithCulture="false">
           <LogicalName>net60.System.Net</LogicalName>
           <Link>Resources\net60\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Http</LogicalName>
           <Link>Resources\net60\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.Json.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Http.Json</LogicalName>
           <Link>Resources\net60\System.Net.Http.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.HttpListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.HttpListener.dll" WithCulture="false">
           <LogicalName>net60.System.Net.HttpListener</LogicalName>
           <Link>Resources\net60\System.Net.HttpListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Mail.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Mail.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Mail</LogicalName>
           <Link>Resources\net60\System.Net.Mail.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>net60.System.Net.NameResolution</LogicalName>
           <Link>Resources\net60\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net60.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net60\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Ping</LogicalName>
           <Link>Resources\net60\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Primitives</LogicalName>
           <Link>Resources\net60\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Requests</LogicalName>
           <Link>Resources\net60\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Security.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Security</LogicalName>
           <Link>Resources\net60\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.ServicePoint.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.ServicePoint.dll" WithCulture="false">
           <LogicalName>net60.System.Net.ServicePoint</LogicalName>
           <Link>Resources\net60\System.Net.ServicePoint.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Sockets</LogicalName>
           <Link>Resources\net60\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebClient.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebClient</LogicalName>
           <Link>Resources\net60\System.Net.WebClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net60\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebProxy.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebProxy</LogicalName>
           <Link>Resources\net60\System.Net.WebProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\net60\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebSockets</LogicalName>
           <Link>Resources\net60\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.dll" WithCulture="false">
           <LogicalName>net60.System.Numerics</LogicalName>
           <Link>Resources\net60\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.Vectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.Vectors.dll" WithCulture="false">
           <LogicalName>net60.System.Numerics.Vectors</LogicalName>
           <Link>Resources\net60\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net60.System.ObjectModel</LogicalName>
           <Link>Resources\net60\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.DispatchProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.DispatchProxy.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.DispatchProxy</LogicalName>
           <Link>Resources\net60\System.Reflection.DispatchProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection</LogicalName>
           <Link>Resources\net60\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Emit</LogicalName>
           <Link>Resources\net60\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net60\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net60\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net60\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Metadata.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Metadata.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Metadata</LogicalName>
           <Link>Resources\net60\System.Reflection.Metadata.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net60\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.TypeExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.TypeExtensions.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.TypeExtensions</LogicalName>
           <Link>Resources\net60\System.Reflection.TypeExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>net60.System.Resources.Reader</LogicalName>
           <Link>Resources\net60\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net60.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net60\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>net60.System.Resources.Writer</LogicalName>
           <Link>Resources\net60\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.Unsafe.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.CompilerServices.Unsafe</LogicalName>
           <Link>Resources\net60\System.Runtime.CompilerServices.Unsafe.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\net60\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime</LogicalName>
           <Link>Resources\net60\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net60\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Handles</LogicalName>
           <Link>Resources\net60\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net60\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\net60\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Intrinsics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Intrinsics.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Intrinsics</LogicalName>
           <Link>Resources\net60\System.Runtime.Intrinsics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Loader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Loader.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Loader</LogicalName>
           <Link>Resources\net60\System.Runtime.Loader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net60\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.AccessControl.dll" WithCulture="false">
           <LogicalName>net60.System.Security.AccessControl</LogicalName>
           <Link>Resources\net60\System.Security.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Claims</LogicalName>
           <Link>Resources\net60\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Cng.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Cng.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Cng</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Cng.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.OpenSsl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.OpenSsl.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.OpenSsl</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.OpenSsl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.dll" WithCulture="false">
           <LogicalName>net60.System.Security</LogicalName>
           <Link>Resources\net60\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Principal</LogicalName>
           <Link>Resources\net60\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.Windows.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Principal.Windows</LogicalName>
           <Link>Resources\net60\System.Security.Principal.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>net60.System.Security.SecureString</LogicalName>
           <Link>Resources\net60\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net60.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net60\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net60.System.ServiceProcess</LogicalName>
           <Link>Resources\net60\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.CodePages.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.CodePages.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encoding.CodePages</LogicalName>
           <Link>Resources\net60\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encoding</LogicalName>
           <Link>Resources\net60\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net60\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encodings.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encodings.Web.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encodings.Web</LogicalName>
           <Link>Resources\net60\System.Text.Encodings.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Json.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Json</LogicalName>
           <Link>Resources\net60\System.Text.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net60.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net60\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Channels.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Channels</LogicalName>
           <Link>Resources\net60\System.Threading.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.dll" WithCulture="false">
           <LogicalName>net60.System.Threading</LogicalName>
           <Link>Resources\net60\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Overlapped</LogicalName>
           <Link>Resources\net60\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Dataflow.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks.Dataflow</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.Dataflow.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks.Extensions</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Thread</LogicalName>
           <Link>Resources\net60\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\net60\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Timer</LogicalName>
           <Link>Resources\net60\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.dll" WithCulture="false">
           <LogicalName>net60.System.Transactions</LogicalName>
           <Link>Resources\net60\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.Local.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.Local.dll" WithCulture="false">
           <LogicalName>net60.System.Transactions.Local</LogicalName>
           <Link>Resources\net60\System.Transactions.Local.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>net60.System.ValueTuple</LogicalName>
           <Link>Resources\net60\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.dll" WithCulture="false">
           <LogicalName>net60.System.Web</LogicalName>
           <Link>Resources\net60\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.HttpUtility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.HttpUtility.dll" WithCulture="false">
           <LogicalName>net60.System.Web.HttpUtility</LogicalName>
           <Link>Resources\net60\System.Web.HttpUtility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Windows.dll" WithCulture="false">
           <LogicalName>net60.System.Windows</LogicalName>
           <Link>Resources\net60\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.dll" WithCulture="false">
           <LogicalName>net60.System.Xml</LogicalName>
           <Link>Resources\net60\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.Linq</LogicalName>
           <Link>Resources\net60\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net60\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.Serialization</LogicalName>
           <Link>Resources\net60\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XDocument</LogicalName>
           <Link>Resources\net60\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\net60\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net60\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XPath</LogicalName>
           <Link>Resources\net60\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\net60\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\WindowsBase.dll" WithCulture="false">
           <LogicalName>net60.WindowsBase</LogicalName>
           <Link>Resources\net60\WindowsBase.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.Net60Windows/Generated.targets
+++ b/Basic.Reference.Assemblies.Net60Windows/Generated.targets
@@ -1,190 +1,190 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Accessibility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Accessibility.dll" WithCulture="false">
           <LogicalName>net60windows.Accessibility</LogicalName>
           <Link>Resources\net60windows\Accessibility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net60windows.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net60windows\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.Forms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.Forms.dll" WithCulture="false">
           <LogicalName>net60windows.Microsoft.VisualBasic.Forms</LogicalName>
           <Link>Resources\net60windows\Microsoft.VisualBasic.Forms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Registry.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Registry.AccessControl.dll" WithCulture="false">
           <LogicalName>net60windows.Microsoft.Win32.Registry.AccessControl</LogicalName>
           <Link>Resources\net60windows\Microsoft.Win32.Registry.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.SystemEvents.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.SystemEvents.dll" WithCulture="false">
           <LogicalName>net60windows.Microsoft.Win32.SystemEvents</LogicalName>
           <Link>Resources\net60windows\Microsoft.Win32.SystemEvents.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationCore.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationCore.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationCore</LogicalName>
           <Link>Resources\net60windows\PresentationCore.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Aero.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Aero.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationFramework.Aero</LogicalName>
           <Link>Resources\net60windows\PresentationFramework.Aero.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Aero2.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Aero2.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationFramework.Aero2</LogicalName>
           <Link>Resources\net60windows\PresentationFramework.Aero2.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.AeroLite.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.AeroLite.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationFramework.AeroLite</LogicalName>
           <Link>Resources\net60windows\PresentationFramework.AeroLite.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Classic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Classic.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationFramework.Classic</LogicalName>
           <Link>Resources\net60windows\PresentationFramework.Classic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationFramework</LogicalName>
           <Link>Resources\net60windows\PresentationFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Luna.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Luna.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationFramework.Luna</LogicalName>
           <Link>Resources\net60windows\PresentationFramework.Luna.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Royale.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationFramework.Royale.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationFramework.Royale</LogicalName>
           <Link>Resources\net60windows\PresentationFramework.Royale.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationUI.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\PresentationUI.dll" WithCulture="false">
           <LogicalName>net60windows.PresentationUI</LogicalName>
           <Link>Resources\net60windows\PresentationUI.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\ReachFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\ReachFramework.dll" WithCulture="false">
           <LogicalName>net60windows.ReachFramework</LogicalName>
           <Link>Resources\net60windows\ReachFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.CodeDom.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.CodeDom.dll" WithCulture="false">
           <LogicalName>net60windows.System.CodeDom</LogicalName>
           <Link>Resources\net60windows\System.CodeDom.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Configuration.ConfigurationManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Configuration.ConfigurationManager.dll" WithCulture="false">
           <LogicalName>net60windows.System.Configuration.ConfigurationManager</LogicalName>
           <Link>Resources\net60windows\System.Configuration.ConfigurationManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Design.dll" WithCulture="false">
           <LogicalName>net60windows.System.Design</LogicalName>
           <Link>Resources\net60windows\System.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Diagnostics.EventLog.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Diagnostics.EventLog.dll" WithCulture="false">
           <LogicalName>net60windows.System.Diagnostics.EventLog</LogicalName>
           <Link>Resources\net60windows\System.Diagnostics.EventLog.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Diagnostics.PerformanceCounter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Diagnostics.PerformanceCounter.dll" WithCulture="false">
           <LogicalName>net60windows.System.Diagnostics.PerformanceCounter</LogicalName>
           <Link>Resources\net60windows\System.Diagnostics.PerformanceCounter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.DirectoryServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.DirectoryServices.dll" WithCulture="false">
           <LogicalName>net60windows.System.DirectoryServices</LogicalName>
           <Link>Resources\net60windows\System.DirectoryServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Drawing.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Drawing.Common.dll" WithCulture="false">
           <LogicalName>net60windows.System.Drawing.Common</LogicalName>
           <Link>Resources\net60windows\System.Drawing.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Drawing.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Drawing.Design.dll" WithCulture="false">
           <LogicalName>net60windows.System.Drawing.Design</LogicalName>
           <Link>Resources\net60windows\System.Drawing.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Drawing.dll" WithCulture="false">
           <LogicalName>net60windows.System.Drawing</LogicalName>
           <Link>Resources\net60windows\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.IO.Packaging.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.IO.Packaging.dll" WithCulture="false">
           <LogicalName>net60windows.System.IO.Packaging</LogicalName>
           <Link>Resources\net60windows\System.IO.Packaging.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Printing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Printing.dll" WithCulture="false">
           <LogicalName>net60windows.System.Printing</LogicalName>
           <Link>Resources\net60windows\System.Printing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Resources.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Resources.Extensions.dll" WithCulture="false">
           <LogicalName>net60windows.System.Resources.Extensions</LogicalName>
           <Link>Resources\net60windows\System.Resources.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Pkcs.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Pkcs.dll" WithCulture="false">
           <LogicalName>net60windows.System.Security.Cryptography.Pkcs</LogicalName>
           <Link>Resources\net60windows\System.Security.Cryptography.Pkcs.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.ProtectedData.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.ProtectedData.dll" WithCulture="false">
           <LogicalName>net60windows.System.Security.Cryptography.ProtectedData</LogicalName>
           <Link>Resources\net60windows\System.Security.Cryptography.ProtectedData.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Xml.dll" WithCulture="false">
           <LogicalName>net60windows.System.Security.Cryptography.Xml</LogicalName>
           <Link>Resources\net60windows\System.Security.Cryptography.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Permissions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Security.Permissions.dll" WithCulture="false">
           <LogicalName>net60windows.System.Security.Permissions</LogicalName>
           <Link>Resources\net60windows\System.Security.Permissions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Threading.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Threading.AccessControl.dll" WithCulture="false">
           <LogicalName>net60windows.System.Threading.AccessControl</LogicalName>
           <Link>Resources\net60windows\System.Threading.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Controls.Ribbon.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Controls.Ribbon.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Controls.Ribbon</LogicalName>
           <Link>Resources\net60windows\System.Windows.Controls.Ribbon.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Extensions.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Extensions</LogicalName>
           <Link>Resources\net60windows\System.Windows.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.Design.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Forms.Design</LogicalName>
           <Link>Resources\net60windows\System.Windows.Forms.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.Design.Editors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.Design.Editors.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Forms.Design.Editors</LogicalName>
           <Link>Resources\net60windows\System.Windows.Forms.Design.Editors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Forms</LogicalName>
           <Link>Resources\net60windows\System.Windows.Forms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Forms.Primitives.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Forms.Primitives</LogicalName>
           <Link>Resources\net60windows\System.Windows.Forms.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Input.Manipulations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Input.Manipulations.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Input.Manipulations</LogicalName>
           <Link>Resources\net60windows\System.Windows.Input.Manipulations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Windows.Presentation.dll" WithCulture="false">
           <LogicalName>net60windows.System.Windows.Presentation</LogicalName>
           <Link>Resources\net60windows\System.Windows.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Xaml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\System.Xaml.dll" WithCulture="false">
           <LogicalName>net60windows.System.Xaml</LogicalName>
           <Link>Resources\net60windows\System.Xaml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationClient.dll" WithCulture="false">
           <LogicalName>net60windows.UIAutomationClient</LogicalName>
           <Link>Resources\net60windows\UIAutomationClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationClientSideProviders.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationClientSideProviders.dll" WithCulture="false">
           <LogicalName>net60windows.UIAutomationClientSideProviders</LogicalName>
           <Link>Resources\net60windows\UIAutomationClientSideProviders.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationProvider.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationProvider.dll" WithCulture="false">
           <LogicalName>net60windows.UIAutomationProvider</LogicalName>
           <Link>Resources\net60windows\UIAutomationProvider.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationTypes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\UIAutomationTypes.dll" WithCulture="false">
           <LogicalName>net60windows.UIAutomationTypes</LogicalName>
           <Link>Resources\net60windows\UIAutomationTypes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\WindowsBase.dll" WithCulture="false">
           <LogicalName>net60windows.WindowsBase</LogicalName>
           <Link>Resources\net60windows\WindowsBase.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\WindowsFormsIntegration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.windowsdesktop.app.ref\6.0.9\ref\net6.0\WindowsFormsIntegration.dll" WithCulture="false">
           <LogicalName>net60windows.WindowsFormsIntegration</LogicalName>
           <Link>Resources\net60windows\WindowsFormsIntegration.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.Net70/Generated.targets
+++ b/Basic.Reference.Assemblies.Net70/Generated.targets
@@ -1,654 +1,654 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net70.Microsoft.CSharp</LogicalName>
           <Link>Resources\net70\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.VisualBasic.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.VisualBasic.Core.dll" WithCulture="false">
           <LogicalName>net70.Microsoft.VisualBasic.Core</LogicalName>
           <Link>Resources\net70\Microsoft.VisualBasic.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net70.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net70\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>net70.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\net70\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.Win32.Registry.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\Microsoft.Win32.Registry.dll" WithCulture="false">
           <LogicalName>net70.Microsoft.Win32.Registry</LogicalName>
           <Link>Resources\net70\Microsoft.Win32.Registry.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\mscorlib.dll" WithCulture="false">
           <LogicalName>net70.mscorlib</LogicalName>
           <Link>Resources\net70\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\netstandard.dll" WithCulture="false">
           <LogicalName>net70.netstandard</LogicalName>
           <Link>Resources\net70\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.AppContext.dll" WithCulture="false">
           <LogicalName>net70.System.AppContext</LogicalName>
           <Link>Resources\net70\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Buffers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Buffers.dll" WithCulture="false">
           <LogicalName>net70.System.Buffers</LogicalName>
           <Link>Resources\net70\System.Buffers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net70.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net70\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.dll" WithCulture="false">
           <LogicalName>net70.System.Collections</LogicalName>
           <Link>Resources\net70\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.Immutable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.Immutable.dll" WithCulture="false">
           <LogicalName>net70.System.Collections.Immutable</LogicalName>
           <Link>Resources\net70\System.Collections.Immutable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>net70.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\net70\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>net70.System.Collections.Specialized</LogicalName>
           <Link>Resources\net70\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net70.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net70\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net70.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net70\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net70.System.ComponentModel</LogicalName>
           <Link>Resources\net70\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net70.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net70\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>net70.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\net70\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>net70.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\net70\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Configuration.dll" WithCulture="false">
           <LogicalName>net70.System.Configuration</LogicalName>
           <Link>Resources\net70\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Console.dll" WithCulture="false">
           <LogicalName>net70.System.Console</LogicalName>
           <Link>Resources\net70\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Core.dll" WithCulture="false">
           <LogicalName>net70.System.Core</LogicalName>
           <Link>Resources\net70\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Data.Common.dll" WithCulture="false">
           <LogicalName>net70.System.Data.Common</LogicalName>
           <Link>Resources\net70\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net70.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net70\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Data.dll" WithCulture="false">
           <LogicalName>net70.System.Data</LogicalName>
           <Link>Resources\net70\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net70\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net70\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.DiagnosticSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.DiagnosticSource</LogicalName>
           <Link>Resources\net70\System.Diagnostics.DiagnosticSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\net70\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.Process</LogicalName>
           <Link>Resources\net70\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\net70\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\net70\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net70\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\net70\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net70.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net70\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.dll" WithCulture="false">
           <LogicalName>net70.System</LogicalName>
           <Link>Resources\net70\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Drawing.dll" WithCulture="false">
           <LogicalName>net70.System.Drawing</LogicalName>
           <Link>Resources\net70\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>net70.System.Drawing.Primitives</LogicalName>
           <Link>Resources\net70\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net70.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net70\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Formats.Asn1.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Formats.Asn1.dll" WithCulture="false">
           <LogicalName>net70.System.Formats.Asn1</LogicalName>
           <Link>Resources\net70\System.Formats.Asn1.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Formats.Tar.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Formats.Tar.dll" WithCulture="false">
           <LogicalName>net70.System.Formats.Tar</LogicalName>
           <Link>Resources\net70\System.Formats.Tar.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>net70.System.Globalization.Calendars</LogicalName>
           <Link>Resources\net70\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Globalization.dll" WithCulture="false">
           <LogicalName>net70.System.Globalization</LogicalName>
           <Link>Resources\net70\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>net70.System.Globalization.Extensions</LogicalName>
           <Link>Resources\net70\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.Brotli.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.Brotli.dll" WithCulture="false">
           <LogicalName>net70.System.IO.Compression.Brotli</LogicalName>
           <Link>Resources\net70\System.IO.Compression.Brotli.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net70.System.IO.Compression</LogicalName>
           <Link>Resources\net70\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net70.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net70\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>net70.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\net70\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.dll" WithCulture="false">
           <LogicalName>net70.System.IO</LogicalName>
           <Link>Resources\net70\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.AccessControl.dll" WithCulture="false">
           <LogicalName>net70.System.IO.FileSystem.AccessControl</LogicalName>
           <Link>Resources\net70\System.IO.FileSystem.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>net70.System.IO.FileSystem</LogicalName>
           <Link>Resources\net70\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>net70.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\net70\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>net70.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\net70\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>net70.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\net70\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>net70.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\net70\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>net70.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\net70\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Pipes.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Pipes.AccessControl.dll" WithCulture="false">
           <LogicalName>net70.System.IO.Pipes.AccessControl</LogicalName>
           <Link>Resources\net70\System.IO.Pipes.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>net70.System.IO.Pipes</LogicalName>
           <Link>Resources\net70\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>net70.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\net70\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.dll" WithCulture="false">
           <LogicalName>net70.System.Linq</LogicalName>
           <Link>Resources\net70\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net70.System.Linq.Expressions</LogicalName>
           <Link>Resources\net70\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net70.System.Linq.Parallel</LogicalName>
           <Link>Resources\net70\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net70.System.Linq.Queryable</LogicalName>
           <Link>Resources\net70\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Memory.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Memory.dll" WithCulture="false">
           <LogicalName>net70.System.Memory</LogicalName>
           <Link>Resources\net70\System.Memory.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.dll" WithCulture="false">
           <LogicalName>net70.System.Net</LogicalName>
           <Link>Resources\net70\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Http</LogicalName>
           <Link>Resources\net70\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Http.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Http.Json.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Http.Json</LogicalName>
           <Link>Resources\net70\System.Net.Http.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.HttpListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.HttpListener.dll" WithCulture="false">
           <LogicalName>net70.System.Net.HttpListener</LogicalName>
           <Link>Resources\net70\System.Net.HttpListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Mail.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Mail.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Mail</LogicalName>
           <Link>Resources\net70\System.Net.Mail.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>net70.System.Net.NameResolution</LogicalName>
           <Link>Resources\net70\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net70.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net70\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Ping</LogicalName>
           <Link>Resources\net70\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Primitives</LogicalName>
           <Link>Resources\net70\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Quic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Quic.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Quic</LogicalName>
           <Link>Resources\net70\System.Net.Quic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Requests</LogicalName>
           <Link>Resources\net70\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Security.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Security</LogicalName>
           <Link>Resources\net70\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.ServicePoint.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.ServicePoint.dll" WithCulture="false">
           <LogicalName>net70.System.Net.ServicePoint</LogicalName>
           <Link>Resources\net70\System.Net.ServicePoint.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>net70.System.Net.Sockets</LogicalName>
           <Link>Resources\net70\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebClient.dll" WithCulture="false">
           <LogicalName>net70.System.Net.WebClient</LogicalName>
           <Link>Resources\net70\System.Net.WebClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net70.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net70\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebProxy.dll" WithCulture="false">
           <LogicalName>net70.System.Net.WebProxy</LogicalName>
           <Link>Resources\net70\System.Net.WebProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>net70.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\net70\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>net70.System.Net.WebSockets</LogicalName>
           <Link>Resources\net70\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Numerics.dll" WithCulture="false">
           <LogicalName>net70.System.Numerics</LogicalName>
           <Link>Resources\net70\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Numerics.Vectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Numerics.Vectors.dll" WithCulture="false">
           <LogicalName>net70.System.Numerics.Vectors</LogicalName>
           <Link>Resources\net70\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net70.System.ObjectModel</LogicalName>
           <Link>Resources\net70\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.DispatchProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.DispatchProxy.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.DispatchProxy</LogicalName>
           <Link>Resources\net70\System.Reflection.DispatchProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection</LogicalName>
           <Link>Resources\net70\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.Emit</LogicalName>
           <Link>Resources\net70\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net70\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net70\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net70\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Metadata.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Metadata.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.Metadata</LogicalName>
           <Link>Resources\net70\System.Reflection.Metadata.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net70\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.TypeExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Reflection.TypeExtensions.dll" WithCulture="false">
           <LogicalName>net70.System.Reflection.TypeExtensions</LogicalName>
           <Link>Resources\net70\System.Reflection.TypeExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>net70.System.Resources.Reader</LogicalName>
           <Link>Resources\net70\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net70.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net70\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>net70.System.Resources.Writer</LogicalName>
           <Link>Resources\net70\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.CompilerServices.Unsafe.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.CompilerServices.Unsafe</LogicalName>
           <Link>Resources\net70\System.Runtime.CompilerServices.Unsafe.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\net70\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime</LogicalName>
           <Link>Resources\net70\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net70\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Handles</LogicalName>
           <Link>Resources\net70\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net70\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.InteropServices.JavaScript.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.InteropServices.JavaScript.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.InteropServices.JavaScript</LogicalName>
           <Link>Resources\net70\System.Runtime.InteropServices.JavaScript.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\net70\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Intrinsics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Intrinsics.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Intrinsics</LogicalName>
           <Link>Resources\net70\System.Runtime.Intrinsics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Loader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Loader.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Loader</LogicalName>
           <Link>Resources\net70\System.Runtime.Loader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net70\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net70\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\net70\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net70\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net70\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net70.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net70\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.AccessControl.dll" WithCulture="false">
           <LogicalName>net70.System.Security.AccessControl</LogicalName>
           <Link>Resources\net70\System.Security.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Claims</LogicalName>
           <Link>Resources\net70\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Cng.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Cng.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography.Cng</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.Cng.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.OpenSsl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.OpenSsl.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography.OpenSsl</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.OpenSsl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\net70\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.dll" WithCulture="false">
           <LogicalName>net70.System.Security</LogicalName>
           <Link>Resources\net70\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Principal</LogicalName>
           <Link>Resources\net70\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Principal.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.Principal.Windows.dll" WithCulture="false">
           <LogicalName>net70.System.Security.Principal.Windows</LogicalName>
           <Link>Resources\net70\System.Security.Principal.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>net70.System.Security.SecureString</LogicalName>
           <Link>Resources\net70\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net70.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net70\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net70.System.ServiceProcess</LogicalName>
           <Link>Resources\net70\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encoding.CodePages.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encoding.CodePages.dll" WithCulture="false">
           <LogicalName>net70.System.Text.Encoding.CodePages</LogicalName>
           <Link>Resources\net70\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net70.System.Text.Encoding</LogicalName>
           <Link>Resources\net70\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net70.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net70\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encodings.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Encodings.Web.dll" WithCulture="false">
           <LogicalName>net70.System.Text.Encodings.Web</LogicalName>
           <Link>Resources\net70\System.Text.Encodings.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.Json.dll" WithCulture="false">
           <LogicalName>net70.System.Text.Json</LogicalName>
           <Link>Resources\net70\System.Text.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net70.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net70\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Channels.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Channels</LogicalName>
           <Link>Resources\net70\System.Threading.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.dll" WithCulture="false">
           <LogicalName>net70.System.Threading</LogicalName>
           <Link>Resources\net70\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Overlapped</LogicalName>
           <Link>Resources\net70\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.Dataflow.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Tasks.Dataflow</LogicalName>
           <Link>Resources\net70\System.Threading.Tasks.Dataflow.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Tasks</LogicalName>
           <Link>Resources\net70\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Tasks.Extensions</LogicalName>
           <Link>Resources\net70\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net70\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Thread</LogicalName>
           <Link>Resources\net70\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\net70\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net70.System.Threading.Timer</LogicalName>
           <Link>Resources\net70\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Transactions.dll" WithCulture="false">
           <LogicalName>net70.System.Transactions</LogicalName>
           <Link>Resources\net70\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Transactions.Local.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Transactions.Local.dll" WithCulture="false">
           <LogicalName>net70.System.Transactions.Local</LogicalName>
           <Link>Resources\net70\System.Transactions.Local.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>net70.System.ValueTuple</LogicalName>
           <Link>Resources\net70\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Web.dll" WithCulture="false">
           <LogicalName>net70.System.Web</LogicalName>
           <Link>Resources\net70\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Web.HttpUtility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Web.HttpUtility.dll" WithCulture="false">
           <LogicalName>net70.System.Web.HttpUtility</LogicalName>
           <Link>Resources\net70\System.Web.HttpUtility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Windows.dll" WithCulture="false">
           <LogicalName>net70.System.Windows</LogicalName>
           <Link>Resources\net70\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.dll" WithCulture="false">
           <LogicalName>net70.System.Xml</LogicalName>
           <Link>Resources\net70\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.Linq</LogicalName>
           <Link>Resources\net70\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net70\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.Serialization</LogicalName>
           <Link>Resources\net70\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.XDocument</LogicalName>
           <Link>Resources\net70\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\net70\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net70\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.XPath</LogicalName>
           <Link>Resources\net70\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>net70.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\net70\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\7.0.0-rc.1.22426.10\ref\net7.0\WindowsBase.dll" WithCulture="false">
           <LogicalName>net70.WindowsBase</LogicalName>
           <Link>Resources\net70\WindowsBase.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.Net80/Basic.Reference.Assemblies.Net80.csproj
+++ b/Basic.Reference.Assemblies.Net80/Basic.Reference.Assemblies.Net80.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.7.23375.6" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.NETCore.App.Ref" Version="8.0.0-preview.7.23375.6" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" ExcludeAssets="analyzers" />
   </ItemGroup>
 
   <Import Project="Generated.targets" />

--- a/Basic.Reference.Assemblies.Net80/Generated.targets
+++ b/Basic.Reference.Assemblies.Net80/Generated.targets
@@ -1,654 +1,654 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net80.Microsoft.CSharp</LogicalName>
           <Link>Resources\net80\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.VisualBasic.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.VisualBasic.Core.dll" WithCulture="false">
           <LogicalName>net80.Microsoft.VisualBasic.Core</LogicalName>
           <Link>Resources\net80\Microsoft.VisualBasic.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net80.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net80\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>net80.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\net80\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.Win32.Registry.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\Microsoft.Win32.Registry.dll" WithCulture="false">
           <LogicalName>net80.Microsoft.Win32.Registry</LogicalName>
           <Link>Resources\net80\Microsoft.Win32.Registry.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\mscorlib.dll" WithCulture="false">
           <LogicalName>net80.mscorlib</LogicalName>
           <Link>Resources\net80\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\netstandard.dll" WithCulture="false">
           <LogicalName>net80.netstandard</LogicalName>
           <Link>Resources\net80\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.AppContext.dll" WithCulture="false">
           <LogicalName>net80.System.AppContext</LogicalName>
           <Link>Resources\net80\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Buffers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Buffers.dll" WithCulture="false">
           <LogicalName>net80.System.Buffers</LogicalName>
           <Link>Resources\net80\System.Buffers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net80.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net80\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.dll" WithCulture="false">
           <LogicalName>net80.System.Collections</LogicalName>
           <Link>Resources\net80\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.Immutable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.Immutable.dll" WithCulture="false">
           <LogicalName>net80.System.Collections.Immutable</LogicalName>
           <Link>Resources\net80\System.Collections.Immutable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>net80.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\net80\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>net80.System.Collections.Specialized</LogicalName>
           <Link>Resources\net80\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net80.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net80\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net80.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net80\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net80.System.ComponentModel</LogicalName>
           <Link>Resources\net80\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net80.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net80\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>net80.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\net80\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>net80.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\net80\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Configuration.dll" WithCulture="false">
           <LogicalName>net80.System.Configuration</LogicalName>
           <Link>Resources\net80\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Console.dll" WithCulture="false">
           <LogicalName>net80.System.Console</LogicalName>
           <Link>Resources\net80\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Core.dll" WithCulture="false">
           <LogicalName>net80.System.Core</LogicalName>
           <Link>Resources\net80\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Data.Common.dll" WithCulture="false">
           <LogicalName>net80.System.Data.Common</LogicalName>
           <Link>Resources\net80\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net80.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net80\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Data.dll" WithCulture="false">
           <LogicalName>net80.System.Data</LogicalName>
           <Link>Resources\net80\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net80\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net80\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.DiagnosticSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.DiagnosticSource</LogicalName>
           <Link>Resources\net80\System.Diagnostics.DiagnosticSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\net80\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.Process</LogicalName>
           <Link>Resources\net80\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\net80\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\net80\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net80\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\net80\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net80.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net80\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.dll" WithCulture="false">
           <LogicalName>net80.System</LogicalName>
           <Link>Resources\net80\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Drawing.dll" WithCulture="false">
           <LogicalName>net80.System.Drawing</LogicalName>
           <Link>Resources\net80\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>net80.System.Drawing.Primitives</LogicalName>
           <Link>Resources\net80\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net80.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net80\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Formats.Asn1.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Formats.Asn1.dll" WithCulture="false">
           <LogicalName>net80.System.Formats.Asn1</LogicalName>
           <Link>Resources\net80\System.Formats.Asn1.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Formats.Tar.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Formats.Tar.dll" WithCulture="false">
           <LogicalName>net80.System.Formats.Tar</LogicalName>
           <Link>Resources\net80\System.Formats.Tar.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>net80.System.Globalization.Calendars</LogicalName>
           <Link>Resources\net80\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Globalization.dll" WithCulture="false">
           <LogicalName>net80.System.Globalization</LogicalName>
           <Link>Resources\net80\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>net80.System.Globalization.Extensions</LogicalName>
           <Link>Resources\net80\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.Brotli.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.Brotli.dll" WithCulture="false">
           <LogicalName>net80.System.IO.Compression.Brotli</LogicalName>
           <Link>Resources\net80\System.IO.Compression.Brotli.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net80.System.IO.Compression</LogicalName>
           <Link>Resources\net80\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net80.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net80\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>net80.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\net80\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.dll" WithCulture="false">
           <LogicalName>net80.System.IO</LogicalName>
           <Link>Resources\net80\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.AccessControl.dll" WithCulture="false">
           <LogicalName>net80.System.IO.FileSystem.AccessControl</LogicalName>
           <Link>Resources\net80\System.IO.FileSystem.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>net80.System.IO.FileSystem</LogicalName>
           <Link>Resources\net80\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>net80.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\net80\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>net80.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\net80\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>net80.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\net80\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>net80.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\net80\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>net80.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\net80\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Pipes.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Pipes.AccessControl.dll" WithCulture="false">
           <LogicalName>net80.System.IO.Pipes.AccessControl</LogicalName>
           <Link>Resources\net80\System.IO.Pipes.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>net80.System.IO.Pipes</LogicalName>
           <Link>Resources\net80\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>net80.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\net80\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.dll" WithCulture="false">
           <LogicalName>net80.System.Linq</LogicalName>
           <Link>Resources\net80\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net80.System.Linq.Expressions</LogicalName>
           <Link>Resources\net80\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net80.System.Linq.Parallel</LogicalName>
           <Link>Resources\net80\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net80.System.Linq.Queryable</LogicalName>
           <Link>Resources\net80\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Memory.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Memory.dll" WithCulture="false">
           <LogicalName>net80.System.Memory</LogicalName>
           <Link>Resources\net80\System.Memory.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.dll" WithCulture="false">
           <LogicalName>net80.System.Net</LogicalName>
           <Link>Resources\net80\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Http</LogicalName>
           <Link>Resources\net80\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Http.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Http.Json.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Http.Json</LogicalName>
           <Link>Resources\net80\System.Net.Http.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.HttpListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.HttpListener.dll" WithCulture="false">
           <LogicalName>net80.System.Net.HttpListener</LogicalName>
           <Link>Resources\net80\System.Net.HttpListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Mail.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Mail.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Mail</LogicalName>
           <Link>Resources\net80\System.Net.Mail.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>net80.System.Net.NameResolution</LogicalName>
           <Link>Resources\net80\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net80.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net80\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Ping</LogicalName>
           <Link>Resources\net80\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Primitives</LogicalName>
           <Link>Resources\net80\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Quic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Quic.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Quic</LogicalName>
           <Link>Resources\net80\System.Net.Quic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Requests</LogicalName>
           <Link>Resources\net80\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Security.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Security</LogicalName>
           <Link>Resources\net80\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.ServicePoint.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.ServicePoint.dll" WithCulture="false">
           <LogicalName>net80.System.Net.ServicePoint</LogicalName>
           <Link>Resources\net80\System.Net.ServicePoint.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>net80.System.Net.Sockets</LogicalName>
           <Link>Resources\net80\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebClient.dll" WithCulture="false">
           <LogicalName>net80.System.Net.WebClient</LogicalName>
           <Link>Resources\net80\System.Net.WebClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net80.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net80\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebProxy.dll" WithCulture="false">
           <LogicalName>net80.System.Net.WebProxy</LogicalName>
           <Link>Resources\net80\System.Net.WebProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>net80.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\net80\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>net80.System.Net.WebSockets</LogicalName>
           <Link>Resources\net80\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Numerics.dll" WithCulture="false">
           <LogicalName>net80.System.Numerics</LogicalName>
           <Link>Resources\net80\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Numerics.Vectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Numerics.Vectors.dll" WithCulture="false">
           <LogicalName>net80.System.Numerics.Vectors</LogicalName>
           <Link>Resources\net80\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net80.System.ObjectModel</LogicalName>
           <Link>Resources\net80\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.DispatchProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.DispatchProxy.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.DispatchProxy</LogicalName>
           <Link>Resources\net80\System.Reflection.DispatchProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection</LogicalName>
           <Link>Resources\net80\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.Emit</LogicalName>
           <Link>Resources\net80\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net80\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net80\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net80\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Metadata.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Metadata.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.Metadata</LogicalName>
           <Link>Resources\net80\System.Reflection.Metadata.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net80\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.TypeExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Reflection.TypeExtensions.dll" WithCulture="false">
           <LogicalName>net80.System.Reflection.TypeExtensions</LogicalName>
           <Link>Resources\net80\System.Reflection.TypeExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>net80.System.Resources.Reader</LogicalName>
           <Link>Resources\net80\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net80.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net80\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>net80.System.Resources.Writer</LogicalName>
           <Link>Resources\net80\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.CompilerServices.Unsafe.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.CompilerServices.Unsafe</LogicalName>
           <Link>Resources\net80\System.Runtime.CompilerServices.Unsafe.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\net80\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime</LogicalName>
           <Link>Resources\net80\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net80\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Handles</LogicalName>
           <Link>Resources\net80\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net80\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.InteropServices.JavaScript.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.InteropServices.JavaScript.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.InteropServices.JavaScript</LogicalName>
           <Link>Resources\net80\System.Runtime.InteropServices.JavaScript.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\net80\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Intrinsics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Intrinsics.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Intrinsics</LogicalName>
           <Link>Resources\net80\System.Runtime.Intrinsics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Loader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Loader.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Loader</LogicalName>
           <Link>Resources\net80\System.Runtime.Loader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net80\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net80\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\net80\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net80\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net80\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net80.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net80\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.AccessControl.dll" WithCulture="false">
           <LogicalName>net80.System.Security.AccessControl</LogicalName>
           <Link>Resources\net80\System.Security.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Claims</LogicalName>
           <Link>Resources\net80\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Cng.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Cng.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography.Cng</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.Cng.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.OpenSsl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.OpenSsl.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography.OpenSsl</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.OpenSsl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\net80\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.dll" WithCulture="false">
           <LogicalName>net80.System.Security</LogicalName>
           <Link>Resources\net80\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Principal</LogicalName>
           <Link>Resources\net80\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Principal.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.Principal.Windows.dll" WithCulture="false">
           <LogicalName>net80.System.Security.Principal.Windows</LogicalName>
           <Link>Resources\net80\System.Security.Principal.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>net80.System.Security.SecureString</LogicalName>
           <Link>Resources\net80\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net80.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net80\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net80.System.ServiceProcess</LogicalName>
           <Link>Resources\net80\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encoding.CodePages.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encoding.CodePages.dll" WithCulture="false">
           <LogicalName>net80.System.Text.Encoding.CodePages</LogicalName>
           <Link>Resources\net80\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net80.System.Text.Encoding</LogicalName>
           <Link>Resources\net80\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net80.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net80\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encodings.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Encodings.Web.dll" WithCulture="false">
           <LogicalName>net80.System.Text.Encodings.Web</LogicalName>
           <Link>Resources\net80\System.Text.Encodings.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.Json.dll" WithCulture="false">
           <LogicalName>net80.System.Text.Json</LogicalName>
           <Link>Resources\net80\System.Text.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net80.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net80\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Channels.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Channels</LogicalName>
           <Link>Resources\net80\System.Threading.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.dll" WithCulture="false">
           <LogicalName>net80.System.Threading</LogicalName>
           <Link>Resources\net80\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Overlapped</LogicalName>
           <Link>Resources\net80\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.Dataflow.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Tasks.Dataflow</LogicalName>
           <Link>Resources\net80\System.Threading.Tasks.Dataflow.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Tasks</LogicalName>
           <Link>Resources\net80\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Tasks.Extensions</LogicalName>
           <Link>Resources\net80\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net80\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Thread</LogicalName>
           <Link>Resources\net80\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\net80\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net80.System.Threading.Timer</LogicalName>
           <Link>Resources\net80\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Transactions.dll" WithCulture="false">
           <LogicalName>net80.System.Transactions</LogicalName>
           <Link>Resources\net80\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Transactions.Local.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Transactions.Local.dll" WithCulture="false">
           <LogicalName>net80.System.Transactions.Local</LogicalName>
           <Link>Resources\net80\System.Transactions.Local.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>net80.System.ValueTuple</LogicalName>
           <Link>Resources\net80\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Web.dll" WithCulture="false">
           <LogicalName>net80.System.Web</LogicalName>
           <Link>Resources\net80\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Web.HttpUtility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Web.HttpUtility.dll" WithCulture="false">
           <LogicalName>net80.System.Web.HttpUtility</LogicalName>
           <Link>Resources\net80\System.Web.HttpUtility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Windows.dll" WithCulture="false">
           <LogicalName>net80.System.Windows</LogicalName>
           <Link>Resources\net80\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.dll" WithCulture="false">
           <LogicalName>net80.System.Xml</LogicalName>
           <Link>Resources\net80\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.Linq</LogicalName>
           <Link>Resources\net80\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net80\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.Serialization</LogicalName>
           <Link>Resources\net80\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.XDocument</LogicalName>
           <Link>Resources\net80\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\net80\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net80\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.XPath</LogicalName>
           <Link>Resources\net80\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>net80.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\net80\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\8.0.0-preview.7.23375.6\ref\net8.0\WindowsBase.dll" WithCulture="false">
           <LogicalName>net80.WindowsBase</LogicalName>
           <Link>Resources\net80\WindowsBase.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.NetCoreApp31/Generated.targets
+++ b/Basic.Reference.Assemblies.NetCoreApp31/Generated.targets
@@ -1,606 +1,606 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>netcoreapp31.Microsoft.CSharp</LogicalName>
           <Link>Resources\netcoreapp31\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.VisualBasic.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.VisualBasic.Core.dll" WithCulture="false">
           <LogicalName>netcoreapp31.Microsoft.VisualBasic.Core</LogicalName>
           <Link>Resources\netcoreapp31\Microsoft.VisualBasic.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>netcoreapp31.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\netcoreapp31\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\mscorlib.dll" WithCulture="false">
           <LogicalName>netcoreapp31.mscorlib</LogicalName>
           <Link>Resources\netcoreapp31\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\netstandard.dll" WithCulture="false">
           <LogicalName>netcoreapp31.netstandard</LogicalName>
           <Link>Resources\netcoreapp31\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.AppContext.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.AppContext</LogicalName>
           <Link>Resources\netcoreapp31\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Buffers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Buffers.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Buffers</LogicalName>
           <Link>Resources\netcoreapp31\System.Buffers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Collections.Concurrent</LogicalName>
           <Link>Resources\netcoreapp31\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Collections</LogicalName>
           <Link>Resources\netcoreapp31\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.Immutable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.Immutable.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Collections.Immutable</LogicalName>
           <Link>Resources\netcoreapp31\System.Collections.Immutable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\netcoreapp31\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Collections.Specialized</LogicalName>
           <Link>Resources\netcoreapp31\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\netcoreapp31\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\netcoreapp31\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ComponentModel</LogicalName>
           <Link>Resources\netcoreapp31\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\netcoreapp31\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\netcoreapp31\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Configuration.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Configuration</LogicalName>
           <Link>Resources\netcoreapp31\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Console.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Console</LogicalName>
           <Link>Resources\netcoreapp31\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Core.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Core</LogicalName>
           <Link>Resources\netcoreapp31\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Data.Common.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Data.Common</LogicalName>
           <Link>Resources\netcoreapp31\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\netcoreapp31\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Data.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Data</LogicalName>
           <Link>Resources\netcoreapp31\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.DiagnosticSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.DiagnosticSource</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.DiagnosticSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.Process</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\netcoreapp31\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System</LogicalName>
           <Link>Resources\netcoreapp31\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Drawing.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Drawing</LogicalName>
           <Link>Resources\netcoreapp31\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Drawing.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\netcoreapp31\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Globalization.Calendars</LogicalName>
           <Link>Resources\netcoreapp31\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Globalization.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Globalization</LogicalName>
           <Link>Resources\netcoreapp31\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Globalization.Extensions</LogicalName>
           <Link>Resources\netcoreapp31\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.Brotli.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.Brotli.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.Compression.Brotli</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.Compression.Brotli.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.Compression</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.FileSystem</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.Pipes</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\netcoreapp31\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Linq</LogicalName>
           <Link>Resources\netcoreapp31\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Linq.Expressions</LogicalName>
           <Link>Resources\netcoreapp31\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Linq.Parallel</LogicalName>
           <Link>Resources\netcoreapp31\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Linq.Queryable</LogicalName>
           <Link>Resources\netcoreapp31\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Memory.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Memory.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Memory</LogicalName>
           <Link>Resources\netcoreapp31\System.Memory.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Http.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.Http</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.HttpListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.HttpListener.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.HttpListener</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.HttpListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Mail.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Mail.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.Mail</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.Mail.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.NameResolution</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.Ping</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.Requests</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Security.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.Security</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.ServicePoint.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.ServicePoint.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.ServicePoint</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.ServicePoint.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.Sockets</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebClient.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.WebClient</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.WebClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebProxy.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.WebProxy</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.WebProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Net.WebSockets</LogicalName>
           <Link>Resources\netcoreapp31\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Numerics.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Numerics</LogicalName>
           <Link>Resources\netcoreapp31\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Numerics.Vectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Numerics.Vectors.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Numerics.Vectors</LogicalName>
           <Link>Resources\netcoreapp31\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ObjectModel</LogicalName>
           <Link>Resources\netcoreapp31\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.DispatchProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.DispatchProxy.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.DispatchProxy</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.DispatchProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.Emit</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.Extensions</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Metadata.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Metadata.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.Metadata</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.Metadata.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.TypeExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Reflection.TypeExtensions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Reflection.TypeExtensions</LogicalName>
           <Link>Resources\netcoreapp31\System.Reflection.TypeExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Resources.Reader</LogicalName>
           <Link>Resources\netcoreapp31\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\netcoreapp31\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Resources.Writer</LogicalName>
           <Link>Resources\netcoreapp31\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.CompilerServices.Unsafe.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.CompilerServices.Unsafe</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.CompilerServices.Unsafe.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Extensions</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Handles</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.InteropServices.WindowsRuntime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.InteropServices.WindowsRuntime.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.InteropServices.WindowsRuntime</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.InteropServices.WindowsRuntime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Intrinsics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Intrinsics.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Intrinsics</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Intrinsics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Loader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Loader.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Loader</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Loader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Numerics</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Serialization</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\netcoreapp31\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.Claims</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.Principal</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Security.SecureString</LogicalName>
           <Link>Resources\netcoreapp31\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ServiceModel.Web</LogicalName>
           <Link>Resources\netcoreapp31\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ServiceProcess</LogicalName>
           <Link>Resources\netcoreapp31\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encoding.CodePages.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encoding.CodePages.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Text.Encoding.CodePages</LogicalName>
           <Link>Resources\netcoreapp31\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Text.Encoding</LogicalName>
           <Link>Resources\netcoreapp31\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\netcoreapp31\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encodings.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Encodings.Web.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Text.Encodings.Web</LogicalName>
           <Link>Resources\netcoreapp31\System.Text.Encodings.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.Json.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Text.Json</LogicalName>
           <Link>Resources\netcoreapp31\System.Text.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\netcoreapp31\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Channels.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Channels</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Overlapped</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.Dataflow.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Tasks.Dataflow</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Tasks.Dataflow.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Tasks</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.Extensions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Tasks.Extensions</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Thread</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Threading.Timer</LogicalName>
           <Link>Resources\netcoreapp31\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Transactions.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Transactions</LogicalName>
           <Link>Resources\netcoreapp31\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Transactions.Local.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Transactions.Local.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Transactions.Local</LogicalName>
           <Link>Resources\netcoreapp31\System.Transactions.Local.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.ValueTuple</LogicalName>
           <Link>Resources\netcoreapp31\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Web.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Web</LogicalName>
           <Link>Resources\netcoreapp31\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Web.HttpUtility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Web.HttpUtility.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Web.HttpUtility</LogicalName>
           <Link>Resources\netcoreapp31\System.Web.HttpUtility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Windows.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Windows</LogicalName>
           <Link>Resources\netcoreapp31\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.Linq</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.Serialization</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.XDocument</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.XPath</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>netcoreapp31.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\netcoreapp31\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\3.1.0\ref\netcoreapp3.1\WindowsBase.dll" WithCulture="false">
           <LogicalName>netcoreapp31.WindowsBase</LogicalName>
           <Link>Resources\netcoreapp31\WindowsBase.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.NetStandard13/Generated.targets
+++ b/Basic.Reference.Assemblies.NetStandard13/Generated.targets
@@ -1,234 +1,234 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard13.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\netstandard13\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.AppContext.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.AppContext.dll" WithCulture="false">
           <LogicalName>netstandard13.System.AppContext</LogicalName>
           <Link>Resources\netstandard13\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Collections.Concurrent</LogicalName>
           <Link>Resources\netstandard13\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Collections.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Collections.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Collections</LogicalName>
           <Link>Resources\netstandard13\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Console.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Console.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Console</LogicalName>
           <Link>Resources\netstandard13\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\netstandard13\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\netstandard13\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Diagnostics.Process</LogicalName>
           <Link>Resources\netstandard13\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\netstandard13\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\netstandard13\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Globalization.Calendars</LogicalName>
           <Link>Resources\netstandard13\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Globalization.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Globalization.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Globalization</LogicalName>
           <Link>Resources\netstandard13\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>netstandard13.System.IO.Compression</LogicalName>
           <Link>Resources\netstandard13\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>netstandard13.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\netstandard13\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.dll" WithCulture="false">
           <LogicalName>netstandard13.System.IO</LogicalName>
           <Link>Resources\netstandard13\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>netstandard13.System.IO.FileSystem</LogicalName>
           <Link>Resources\netstandard13\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard13.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\netstandard13\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Linq.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Linq.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Linq</LogicalName>
           <Link>Resources\netstandard13\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Linq.Expressions</LogicalName>
           <Link>Resources\netstandard13\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Http.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Http.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Net.Http</LogicalName>
           <Link>Resources\netstandard13\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Net.Primitives</LogicalName>
           <Link>Resources\netstandard13\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Security.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Security.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Net.Security</LogicalName>
           <Link>Resources\netstandard13\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Net.Sockets</LogicalName>
           <Link>Resources\netstandard13\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>netstandard13.System.ObjectModel</LogicalName>
           <Link>Resources\netstandard13\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Reflection</LogicalName>
           <Link>Resources\netstandard13\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Reflection.Extensions</LogicalName>
           <Link>Resources\netstandard13\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Reflection.Primitives</LogicalName>
           <Link>Resources\netstandard13\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\netstandard13\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Runtime</LogicalName>
           <Link>Resources\netstandard13\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Runtime.Extensions</LogicalName>
           <Link>Resources\netstandard13\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Runtime.Handles</LogicalName>
           <Link>Resources\netstandard13\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\netstandard13\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\netstandard13\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Runtime.Numerics</LogicalName>
           <Link>Resources\netstandard13\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\netstandard13\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.AccessControl.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.AccessControl.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.AccessControl</LogicalName>
           <Link>Resources\netstandard13\System.Security.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Claims</LogicalName>
           <Link>Resources\netstandard13\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\netstandard13\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\netstandard13\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\netstandard13\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\netstandard13\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\netstandard13\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Principal</LogicalName>
           <Link>Resources\netstandard13\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Principal.Windows.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Principal.Windows.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Security.Principal.Windows</LogicalName>
           <Link>Resources\netstandard13\System.Security.Principal.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.CodePages.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.CodePages.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Text.Encoding.CodePages</LogicalName>
           <Link>Resources\netstandard13\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Text.Encoding</LogicalName>
           <Link>Resources\netstandard13\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\netstandard13\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\netstandard13\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Threading</LogicalName>
           <Link>Resources\netstandard13\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Threading.Tasks</LogicalName>
           <Link>Resources\netstandard13\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Tasks.Extensions.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Tasks.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Threading.Tasks.Extensions</LogicalName>
           <Link>Resources\netstandard13\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Threading.Timer</LogicalName>
           <Link>Resources\netstandard13\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>netstandard13.System.ValueTuple</LogicalName>
           <Link>Resources\netstandard13\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\netstandard13\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Xml.XDocument</LogicalName>
           <Link>Resources\netstandard13\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\netstandard13\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Xml.XPath</LogicalName>
           <Link>Resources\netstandard13\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>netstandard13.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\netstandard13\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.NetStandard20/Generated.targets
+++ b/Basic.Reference.Assemblies.NetStandard20/Generated.targets
@@ -1,454 +1,454 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\netstandard20\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll" WithCulture="false">
           <LogicalName>netstandard20.mscorlib</LogicalName>
           <Link>Resources\netstandard20\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll" WithCulture="false">
           <LogicalName>netstandard20.netstandard</LogicalName>
           <Link>Resources\netstandard20\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.AppContext.dll" WithCulture="false">
           <LogicalName>netstandard20.System.AppContext</LogicalName>
           <Link>Resources\netstandard20\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections.Concurrent</LogicalName>
           <Link>Resources\netstandard20\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections</LogicalName>
           <Link>Resources\netstandard20\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\netstandard20\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections.Specialized</LogicalName>
           <Link>Resources\netstandard20\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Composition.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Composition.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.Composition</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.Composition.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Console.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Console</LogicalName>
           <Link>Resources\netstandard20\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Core.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Core</LogicalName>
           <Link>Resources\netstandard20\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.Common.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Data.Common</LogicalName>
           <Link>Resources\netstandard20\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Data</LogicalName>
           <Link>Resources\netstandard20\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Process</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.dll" WithCulture="false">
           <LogicalName>netstandard20.System</LogicalName>
           <Link>Resources\netstandard20\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Drawing</LogicalName>
           <Link>Resources\netstandard20\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Drawing.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\netstandard20\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Globalization.Calendars</LogicalName>
           <Link>Resources\netstandard20\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Globalization</LogicalName>
           <Link>Resources\netstandard20\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Globalization.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Compression</LogicalName>
           <Link>Resources\netstandard20\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\netstandard20\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\netstandard20\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO</LogicalName>
           <Link>Resources\netstandard20\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\netstandard20\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\netstandard20\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Pipes</LogicalName>
           <Link>Resources\netstandard20\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\netstandard20\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq</LogicalName>
           <Link>Resources\netstandard20\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq.Expressions</LogicalName>
           <Link>Resources\netstandard20\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq.Parallel</LogicalName>
           <Link>Resources\netstandard20\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq.Queryable</LogicalName>
           <Link>Resources\netstandard20\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net</LogicalName>
           <Link>Resources\netstandard20\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Http.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Http</LogicalName>
           <Link>Resources\netstandard20\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.NameResolution</LogicalName>
           <Link>Resources\netstandard20\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\netstandard20\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Ping</LogicalName>
           <Link>Resources\netstandard20\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Requests</LogicalName>
           <Link>Resources\netstandard20\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Security.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Security</LogicalName>
           <Link>Resources\netstandard20\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Sockets</LogicalName>
           <Link>Resources\netstandard20\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\netstandard20\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\netstandard20\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.WebSockets</LogicalName>
           <Link>Resources\netstandard20\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Numerics.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Numerics</LogicalName>
           <Link>Resources\netstandard20\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ObjectModel</LogicalName>
           <Link>Resources\netstandard20\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Reflection</LogicalName>
           <Link>Resources\netstandard20\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Reflection.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Reflection.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Resources.Reader</LogicalName>
           <Link>Resources\netstandard20\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\netstandard20\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Resources.Writer</LogicalName>
           <Link>Resources\netstandard20\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Handles</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Numerics</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Claims</LogicalName>
           <Link>Resources\netstandard20\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Principal</LogicalName>
           <Link>Resources\netstandard20\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.SecureString</LogicalName>
           <Link>Resources\netstandard20\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ServiceModel.Web</LogicalName>
           <Link>Resources\netstandard20\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Text.Encoding</LogicalName>
           <Link>Resources\netstandard20\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\netstandard20\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading</LogicalName>
           <Link>Resources\netstandard20\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Overlapped</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Tasks</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Thread</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\netstandard20\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Timer</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Transactions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Transactions</LogicalName>
           <Link>Resources\netstandard20\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ValueTuple</LogicalName>
           <Link>Resources\netstandard20\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Web.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Web</LogicalName>
           <Link>Resources\netstandard20\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Windows.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Windows</LogicalName>
           <Link>Resources\netstandard20\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml</LogicalName>
           <Link>Resources\netstandard20\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.Linq</LogicalName>
           <Link>Resources\netstandard20\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\netstandard20\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.Serialization</LogicalName>
           <Link>Resources\netstandard20\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XDocument</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XPath</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.UnitTests/Basic.Reference.Assemblies.UnitTests.csproj
+++ b/Basic.Reference.Assemblies.UnitTests/Basic.Reference.Assemblies.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Basic.Reference.Assemblies.UnitTests/CoreUnitTests.cs
+++ b/Basic.Reference.Assemblies.UnitTests/CoreUnitTests.cs
@@ -1,0 +1,22 @@
+
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Basic.Reference.Assemblies.UnitTests;
+
+public sealed class CoreUnitTests
+{
+
+    [Fact]
+    public void Issue43()
+    {
+        var references = new List<MetadataReference>(Basic.Reference.Assemblies.Net70.References.All)
+        {
+            MetadataReference.CreateFromFile(Assembly.GetExecutingAssembly().Location)
+        };
+
+        Assert.NotEmpty(references);
+    }
+}

--- a/Basic.Reference.Assemblies/Generated.Net472.targets
+++ b/Basic.Reference.Assemblies/Generated.Net472.targets
@@ -1,938 +1,938 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Accessibility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Accessibility.dll" WithCulture="false">
           <LogicalName>net472.Accessibility</LogicalName>
           <Link>Resources\net472\Accessibility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\CustomMarshalers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\CustomMarshalers.dll" WithCulture="false">
           <LogicalName>net472.CustomMarshalers</LogicalName>
           <Link>Resources\net472\CustomMarshalers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ISymWrapper.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ISymWrapper.dll" WithCulture="false">
           <LogicalName>net472.ISymWrapper</LogicalName>
           <Link>Resources\net472\ISymWrapper.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Activities.Build.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Activities.Build.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Activities.Build</LogicalName>
           <Link>Resources\net472\Microsoft.Activities.Build.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Conversion.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Conversion.v4.0.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Conversion.v4.0</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Conversion.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build</LogicalName>
           <Link>Resources\net472\Microsoft.Build.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Engine.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Engine.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Engine</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Engine.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Framework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Framework.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Framework</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Framework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Tasks.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Tasks.v4.0.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Tasks.v4.0</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Tasks.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Utilities.v4.0.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.Build.Utilities.v4.0.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Build.Utilities.v4.0</LogicalName>
           <Link>Resources\net472\Microsoft.Build.Utilities.v4.0.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.CSharp</LogicalName>
           <Link>Resources\net472\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.JScript.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.JScript.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.JScript</LogicalName>
           <Link>Resources\net472\Microsoft.JScript.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.Data.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualBasic.Compatibility.Data</LogicalName>
           <Link>Resources\net472\Microsoft.VisualBasic.Compatibility.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.Compatibility.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualBasic.Compatibility</LogicalName>
           <Link>Resources\net472\Microsoft.VisualBasic.Compatibility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net472\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualC</LogicalName>
           <Link>Resources\net472\Microsoft.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.STLCLR.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Microsoft.VisualC.STLCLR.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.VisualC.STLCLR</LogicalName>
           <Link>Resources\net472\Microsoft.VisualC.STLCLR.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\mscorlib.dll" WithCulture="false">
           <LogicalName>net472.mscorlib</LogicalName>
           <Link>Resources\net472\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationBuildTasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationBuildTasks.dll" WithCulture="false">
           <LogicalName>net472.PresentationBuildTasks</LogicalName>
           <Link>Resources\net472\PresentationBuildTasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationCore.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationCore.dll" WithCulture="false">
           <LogicalName>net472.PresentationCore</LogicalName>
           <Link>Resources\net472\PresentationCore.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Aero</LogicalName>
           <Link>Resources\net472\PresentationFramework.Aero.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero2.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Aero2.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Aero2</LogicalName>
           <Link>Resources\net472\PresentationFramework.Aero2.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.AeroLite.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.AeroLite.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.AeroLite</LogicalName>
           <Link>Resources\net472\PresentationFramework.AeroLite.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Classic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Classic.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Classic</LogicalName>
           <Link>Resources\net472\PresentationFramework.Classic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework</LogicalName>
           <Link>Resources\net472\PresentationFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Luna.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Luna.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Luna</LogicalName>
           <Link>Resources\net472\PresentationFramework.Luna.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Royale.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\PresentationFramework.Royale.dll" WithCulture="false">
           <LogicalName>net472.PresentationFramework.Royale</LogicalName>
           <Link>Resources\net472\PresentationFramework.Royale.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ReachFramework.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\ReachFramework.dll" WithCulture="false">
           <LogicalName>net472.ReachFramework</LogicalName>
           <Link>Resources\net472\ReachFramework.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\sysglobl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\sysglobl.dll" WithCulture="false">
           <LogicalName>net472.sysglobl</LogicalName>
           <Link>Resources\net472\sysglobl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Core.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Core.Presentation.dll" WithCulture="false">
           <LogicalName>net472.System.Activities.Core.Presentation</LogicalName>
           <Link>Resources\net472\System.Activities.Core.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.dll" WithCulture="false">
           <LogicalName>net472.System.Activities</LogicalName>
           <Link>Resources\net472\System.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.DurableInstancing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.DurableInstancing.dll" WithCulture="false">
           <LogicalName>net472.System.Activities.DurableInstancing</LogicalName>
           <Link>Resources\net472\System.Activities.DurableInstancing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Activities.Presentation.dll" WithCulture="false">
           <LogicalName>net472.System.Activities.Presentation</LogicalName>
           <Link>Resources\net472\System.Activities.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.Contract.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.Contract.dll" WithCulture="false">
           <LogicalName>net472.System.AddIn.Contract</LogicalName>
           <Link>Resources\net472\System.AddIn.Contract.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.AddIn.dll" WithCulture="false">
           <LogicalName>net472.System.AddIn</LogicalName>
           <Link>Resources\net472\System.AddIn.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Composition</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Composition.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.Registration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.Composition.Registration.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Composition.Registration</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Composition.Registration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net472\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.dll" WithCulture="false">
           <LogicalName>net472.System.Configuration</LogicalName>
           <Link>Resources\net472\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.Install.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Configuration.Install.dll" WithCulture="false">
           <LogicalName>net472.System.Configuration.Install</LogicalName>
           <Link>Resources\net472\System.Configuration.Install.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Core.dll" WithCulture="false">
           <LogicalName>net472.System.Core</LogicalName>
           <Link>Resources\net472\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net472.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net472\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.dll" WithCulture="false">
           <LogicalName>net472.System.Data</LogicalName>
           <Link>Resources\net472\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Entity.Design</LogicalName>
           <Link>Resources\net472\System.Data.Entity.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Entity.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Entity</LogicalName>
           <Link>Resources\net472\System.Data.Entity.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Linq.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Linq</LogicalName>
           <Link>Resources\net472\System.Data.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.OracleClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.OracleClient.dll" WithCulture="false">
           <LogicalName>net472.System.Data.OracleClient</LogicalName>
           <Link>Resources\net472\System.Data.OracleClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Client.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Services.Client</LogicalName>
           <Link>Resources\net472\System.Data.Services.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Services.Design</LogicalName>
           <Link>Resources\net472\System.Data.Services.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.Services.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Services</LogicalName>
           <Link>Resources\net472\System.Data.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.SqlXml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Data.SqlXml.dll" WithCulture="false">
           <LogicalName>net472.System.Data.SqlXml</LogicalName>
           <Link>Resources\net472\System.Data.SqlXml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Deployment.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Deployment.dll" WithCulture="false">
           <LogicalName>net472.System.Deployment</LogicalName>
           <Link>Resources\net472\System.Deployment.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Design</LogicalName>
           <Link>Resources\net472\System.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Device.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Device.dll" WithCulture="false">
           <LogicalName>net472.System.Device</LogicalName>
           <Link>Resources\net472\System.Device.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.AccountManagement.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.AccountManagement.dll" WithCulture="false">
           <LogicalName>net472.System.DirectoryServices.AccountManagement</LogicalName>
           <Link>Resources\net472\System.DirectoryServices.AccountManagement.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.dll" WithCulture="false">
           <LogicalName>net472.System.DirectoryServices</LogicalName>
           <Link>Resources\net472\System.DirectoryServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.Protocols.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.DirectoryServices.Protocols.dll" WithCulture="false">
           <LogicalName>net472.System.DirectoryServices.Protocols</LogicalName>
           <Link>Resources\net472\System.DirectoryServices.Protocols.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.dll" WithCulture="false">
           <LogicalName>net472.System</LogicalName>
           <Link>Resources\net472\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Drawing.Design</LogicalName>
           <Link>Resources\net472\System.Drawing.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Drawing.dll" WithCulture="false">
           <LogicalName>net472.System.Drawing</LogicalName>
           <Link>Resources\net472\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Dynamic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Dynamic.dll" WithCulture="false">
           <LogicalName>net472.System.Dynamic</LogicalName>
           <Link>Resources\net472\System.Dynamic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.dll" WithCulture="false">
           <LogicalName>net472.System.IdentityModel</LogicalName>
           <Link>Resources\net472\System.IdentityModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Selectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Selectors.dll" WithCulture="false">
           <LogicalName>net472.System.IdentityModel.Selectors</LogicalName>
           <Link>Resources\net472\System.IdentityModel.Selectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IdentityModel.Services.dll" WithCulture="false">
           <LogicalName>net472.System.IdentityModel.Services</LogicalName>
           <Link>Resources\net472\System.IdentityModel.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Compression</LogicalName>
           <Link>Resources\net472\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net472\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Log.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.IO.Log.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Log</LogicalName>
           <Link>Resources\net472\System.IO.Log.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.dll" WithCulture="false">
           <LogicalName>net472.System.Management</LogicalName>
           <Link>Resources\net472\System.Management.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.Instrumentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Management.Instrumentation.dll" WithCulture="false">
           <LogicalName>net472.System.Management.Instrumentation</LogicalName>
           <Link>Resources\net472\System.Management.Instrumentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Messaging.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Messaging.dll" WithCulture="false">
           <LogicalName>net472.System.Messaging</LogicalName>
           <Link>Resources\net472\System.Messaging.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.dll" WithCulture="false">
           <LogicalName>net472.System.Net</LogicalName>
           <Link>Resources\net472\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Http</LogicalName>
           <Link>Resources\net472\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.WebRequest.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Net.Http.WebRequest.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Http.WebRequest</LogicalName>
           <Link>Resources\net472\System.Net.Http.WebRequest.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Numerics.dll" WithCulture="false">
           <LogicalName>net472.System.Numerics</LogicalName>
           <Link>Resources\net472\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Printing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Printing.dll" WithCulture="false">
           <LogicalName>net472.System.Printing</LogicalName>
           <Link>Resources\net472\System.Printing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Reflection.Context.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Reflection.Context.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Context</LogicalName>
           <Link>Resources\net472\System.Reflection.Context.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Caching.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Caching.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Caching</LogicalName>
           <Link>Resources\net472\System.Runtime.Caching.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.DurableInstancing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.DurableInstancing.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.DurableInstancing</LogicalName>
           <Link>Resources\net472\System.Runtime.DurableInstancing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Remoting.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Remoting.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Remoting</LogicalName>
           <Link>Resources\net472\System.Runtime.Remoting.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.Formatters.Soap.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Runtime.Serialization.Formatters.Soap.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Formatters.Soap</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Formatters.Soap.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Security.dll" WithCulture="false">
           <LogicalName>net472.System.Security</LogicalName>
           <Link>Resources\net472\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activation.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Activation</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Activation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Activities.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Activities</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Channels.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Channels</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Discovery.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Discovery.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Discovery</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Discovery.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel</LogicalName>
           <Link>Resources\net472\System.ServiceModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Routing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Routing.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Routing</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Routing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceProcess</LogicalName>
           <Link>Resources\net472\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Speech.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Speech.dll" WithCulture="false">
           <LogicalName>net472.System.Speech</LogicalName>
           <Link>Resources\net472\System.Speech.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Transactions.dll" WithCulture="false">
           <LogicalName>net472.System.Transactions</LogicalName>
           <Link>Resources\net472\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Abstractions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Abstractions.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Abstractions</LogicalName>
           <Link>Resources\net472\System.Web.Abstractions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.ApplicationServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.ApplicationServices.dll" WithCulture="false">
           <LogicalName>net472.System.Web.ApplicationServices</LogicalName>
           <Link>Resources\net472\System.Web.ApplicationServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DataVisualization.Design</LogicalName>
           <Link>Resources\net472\System.Web.DataVisualization.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DataVisualization.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DataVisualization</LogicalName>
           <Link>Resources\net472\System.Web.DataVisualization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.dll" WithCulture="false">
           <LogicalName>net472.System.Web</LogicalName>
           <Link>Resources\net472\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DynamicData.Design</LogicalName>
           <Link>Resources\net472\System.Web.DynamicData.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.DynamicData.dll" WithCulture="false">
           <LogicalName>net472.System.Web.DynamicData</LogicalName>
           <Link>Resources\net472\System.Web.DynamicData.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Entity.Design</LogicalName>
           <Link>Resources\net472\System.Web.Entity.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Entity.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Entity</LogicalName>
           <Link>Resources\net472\System.Web.Entity.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Extensions.Design</LogicalName>
           <Link>Resources\net472\System.Web.Extensions.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Extensions</LogicalName>
           <Link>Resources\net472\System.Web.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Mobile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Mobile.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Mobile</LogicalName>
           <Link>Resources\net472\System.Web.Mobile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net472.System.Web.RegularExpressions</LogicalName>
           <Link>Resources\net472\System.Web.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Routing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Routing.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Routing</LogicalName>
           <Link>Resources\net472\System.Web.Routing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Services.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Web.Services.dll" WithCulture="false">
           <LogicalName>net472.System.Web.Services</LogicalName>
           <Link>Resources\net472\System.Web.Services.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Controls.Ribbon.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Controls.Ribbon.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Controls.Ribbon</LogicalName>
           <Link>Resources\net472\System.Windows.Controls.Ribbon.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.dll" WithCulture="false">
           <LogicalName>net472.System.Windows</LogicalName>
           <Link>Resources\net472\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.Design.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.Design.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Forms.DataVisualization.Design</LogicalName>
           <Link>Resources\net472\System.Windows.Forms.DataVisualization.Design.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.DataVisualization.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Forms.DataVisualization</LogicalName>
           <Link>Resources\net472\System.Windows.Forms.DataVisualization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Forms.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Forms</LogicalName>
           <Link>Resources\net472\System.Windows.Forms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Input.Manipulations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Input.Manipulations.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Input.Manipulations</LogicalName>
           <Link>Resources\net472\System.Windows.Input.Manipulations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Presentation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Windows.Presentation.dll" WithCulture="false">
           <LogicalName>net472.System.Windows.Presentation</LogicalName>
           <Link>Resources\net472\System.Windows.Presentation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Activities.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Activities.dll" WithCulture="false">
           <LogicalName>net472.System.Workflow.Activities</LogicalName>
           <Link>Resources\net472\System.Workflow.Activities.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.ComponentModel.dll" WithCulture="false">
           <LogicalName>net472.System.Workflow.ComponentModel</LogicalName>
           <Link>Resources\net472\System.Workflow.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Workflow.Runtime.dll" WithCulture="false">
           <LogicalName>net472.System.Workflow.Runtime</LogicalName>
           <Link>Resources\net472\System.Workflow.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.WorkflowServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.WorkflowServices.dll" WithCulture="false">
           <LogicalName>net472.System.WorkflowServices</LogicalName>
           <Link>Resources\net472\System.WorkflowServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xaml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xaml.dll" WithCulture="false">
           <LogicalName>net472.System.Xaml</LogicalName>
           <Link>Resources\net472\System.Xaml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.dll" WithCulture="false">
           <LogicalName>net472.System.Xml</LogicalName>
           <Link>Resources\net472\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.Linq</LogicalName>
           <Link>Resources\net472\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.Serialization</LogicalName>
           <Link>Resources\net472\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClient.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationClient</LogicalName>
           <Link>Resources\net472\UIAutomationClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClientsideProviders.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationClientsideProviders.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationClientsideProviders</LogicalName>
           <Link>Resources\net472\UIAutomationClientsideProviders.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationProvider.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationProvider.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationProvider</LogicalName>
           <Link>Resources\net472\UIAutomationProvider.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationTypes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\UIAutomationTypes.dll" WithCulture="false">
           <LogicalName>net472.UIAutomationTypes</LogicalName>
           <Link>Resources\net472\UIAutomationTypes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsBase.dll" WithCulture="false">
           <LogicalName>net472.WindowsBase</LogicalName>
           <Link>Resources\net472\WindowsBase.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsFormsIntegration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\WindowsFormsIntegration.dll" WithCulture="false">
           <LogicalName>net472.WindowsFormsIntegration</LogicalName>
           <Link>Resources\net472\WindowsFormsIntegration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\XamlBuildTask.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\XamlBuildTask.dll" WithCulture="false">
           <LogicalName>net472.XamlBuildTask</LogicalName>
           <Link>Resources\net472\XamlBuildTask.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>net472.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\net472\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\netstandard.dll" WithCulture="false">
           <LogicalName>net472.netstandard</LogicalName>
           <Link>Resources\net472\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.AppContext.dll" WithCulture="false">
           <LogicalName>net472.System.AppContext</LogicalName>
           <Link>Resources\net472\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net472.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net472\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.dll" WithCulture="false">
           <LogicalName>net472.System.Collections</LogicalName>
           <Link>Resources\net472\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>net472.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\net472\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>net472.System.Collections.Specialized</LogicalName>
           <Link>Resources\net472\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel</LogicalName>
           <Link>Resources\net472\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net472\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\net472\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>net472.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\net472\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Console.dll" WithCulture="false">
           <LogicalName>net472.System.Console</LogicalName>
           <Link>Resources\net472\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Data.Common.dll" WithCulture="false">
           <LogicalName>net472.System.Data.Common</LogicalName>
           <Link>Resources\net472\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\net472\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Process</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\net472\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\net472\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net472\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>net472.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\net472\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Drawing.Primitives</LogicalName>
           <Link>Resources\net472\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net472.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net472\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>net472.System.Globalization.Calendars</LogicalName>
           <Link>Resources\net472\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.dll" WithCulture="false">
           <LogicalName>net472.System.Globalization</LogicalName>
           <Link>Resources\net472\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Globalization.Extensions</LogicalName>
           <Link>Resources\net472\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\net472\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.dll" WithCulture="false">
           <LogicalName>net472.System.IO</LogicalName>
           <Link>Resources\net472\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>net472.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\net472\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>net472.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\net472\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>net472.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\net472\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>net472.System.IO.Pipes</LogicalName>
           <Link>Resources\net472\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>net472.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\net472\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.dll" WithCulture="false">
           <LogicalName>net472.System.Linq</LogicalName>
           <Link>Resources\net472\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net472.System.Linq.Expressions</LogicalName>
           <Link>Resources\net472\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net472.System.Linq.Parallel</LogicalName>
           <Link>Resources\net472\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net472.System.Linq.Queryable</LogicalName>
           <Link>Resources\net472\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Http.Rtc.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Http.Rtc.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Http.Rtc</LogicalName>
           <Link>Resources\net472\System.Net.Http.Rtc.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>net472.System.Net.NameResolution</LogicalName>
           <Link>Resources\net472\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net472.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net472\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Ping</LogicalName>
           <Link>Resources\net472\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Primitives</LogicalName>
           <Link>Resources\net472\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Requests</LogicalName>
           <Link>Resources\net472\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Security.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Security</LogicalName>
           <Link>Resources\net472\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>net472.System.Net.Sockets</LogicalName>
           <Link>Resources\net472\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net472.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net472\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>net472.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\net472\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>net472.System.Net.WebSockets</LogicalName>
           <Link>Resources\net472\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net472.System.ObjectModel</LogicalName>
           <Link>Resources\net472\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection</LogicalName>
           <Link>Resources\net472\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Emit</LogicalName>
           <Link>Resources\net472\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net472\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net472\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net472\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net472\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>net472.System.Resources.Reader</LogicalName>
           <Link>Resources\net472\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net472.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net472\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>net472.System.Resources.Writer</LogicalName>
           <Link>Resources\net472\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\net472\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime</LogicalName>
           <Link>Resources\net472\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net472\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Handles</LogicalName>
           <Link>Resources\net472\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net472\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\net472\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.WindowsRuntime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.InteropServices.WindowsRuntime.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.InteropServices.WindowsRuntime</LogicalName>
           <Link>Resources\net472\System.Runtime.InteropServices.WindowsRuntime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net472\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net472.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net472\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Claims</LogicalName>
           <Link>Resources\net472\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\net472\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net472.System.Security.Principal</LogicalName>
           <Link>Resources\net472\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>net472.System.Security.SecureString</LogicalName>
           <Link>Resources\net472\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Duplex.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Duplex.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Duplex</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Duplex.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Http.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Http</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.NetTcp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.NetTcp.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.NetTcp</LogicalName>
           <Link>Resources\net472\System.ServiceModel.NetTcp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Primitives.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Primitives</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ServiceModel.Security.dll" WithCulture="false">
           <LogicalName>net472.System.ServiceModel.Security</LogicalName>
           <Link>Resources\net472\System.ServiceModel.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net472.System.Text.Encoding</LogicalName>
           <Link>Resources\net472\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net472.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net472\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net472.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net472\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.dll" WithCulture="false">
           <LogicalName>net472.System.Threading</LogicalName>
           <Link>Resources\net472\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Overlapped</LogicalName>
           <Link>Resources\net472\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Tasks</LogicalName>
           <Link>Resources\net472\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net472\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Thread</LogicalName>
           <Link>Resources\net472\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\net472\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net472.System.Threading.Timer</LogicalName>
           <Link>Resources\net472\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>net472.System.ValueTuple</LogicalName>
           <Link>Resources\net472\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net472\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XDocument</LogicalName>
           <Link>Resources\net472\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\net472\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net472\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XPath</LogicalName>
           <Link>Resources\net472\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netframework.referenceassemblies.net472\1.0.0\build\.NETFramework\v4.7.2\Facades\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>net472.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\net472\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies/Generated.Net60.targets
+++ b/Basic.Reference.Assemblies/Generated.Net60.targets
@@ -1,638 +1,638 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.CSharp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.CSharp.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.CSharp</LogicalName>
           <Link>Resources\net60\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.Core.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.VisualBasic.Core</LogicalName>
           <Link>Resources\net60\Microsoft.VisualBasic.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.VisualBasic.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.VisualBasic</LogicalName>
           <Link>Resources\net60\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\net60\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Registry.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\Microsoft.Win32.Registry.dll" WithCulture="false">
           <LogicalName>net60.Microsoft.Win32.Registry</LogicalName>
           <Link>Resources\net60\Microsoft.Win32.Registry.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\mscorlib.dll" WithCulture="false">
           <LogicalName>net60.mscorlib</LogicalName>
           <Link>Resources\net60\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\netstandard.dll" WithCulture="false">
           <LogicalName>net60.netstandard</LogicalName>
           <Link>Resources\net60\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.AppContext.dll" WithCulture="false">
           <LogicalName>net60.System.AppContext</LogicalName>
           <Link>Resources\net60\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Buffers.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Buffers.dll" WithCulture="false">
           <LogicalName>net60.System.Buffers</LogicalName>
           <Link>Resources\net60\System.Buffers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.Concurrent</LogicalName>
           <Link>Resources\net60\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.dll" WithCulture="false">
           <LogicalName>net60.System.Collections</LogicalName>
           <Link>Resources\net60\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Immutable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Immutable.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.Immutable</LogicalName>
           <Link>Resources\net60\System.Collections.Immutable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\net60\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>net60.System.Collections.Specialized</LogicalName>
           <Link>Resources\net60\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Annotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Annotations.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.Annotations</LogicalName>
           <Link>Resources\net60\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.DataAnnotations.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.DataAnnotations</LogicalName>
           <Link>Resources\net60\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel</LogicalName>
           <Link>Resources\net60\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\net60\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\net60\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>net60.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\net60\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Configuration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Configuration.dll" WithCulture="false">
           <LogicalName>net60.System.Configuration</LogicalName>
           <Link>Resources\net60\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Console.dll" WithCulture="false">
           <LogicalName>net60.System.Console</LogicalName>
           <Link>Resources\net60\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Core.dll" WithCulture="false">
           <LogicalName>net60.System.Core</LogicalName>
           <Link>Resources\net60\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.Common.dll" WithCulture="false">
           <LogicalName>net60.System.Data.Common</LogicalName>
           <Link>Resources\net60\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.DataSetExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.DataSetExtensions.dll" WithCulture="false">
           <LogicalName>net60.System.Data.DataSetExtensions</LogicalName>
           <Link>Resources\net60\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Data.dll" WithCulture="false">
           <LogicalName>net60.System.Data</LogicalName>
           <Link>Resources\net60\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.DiagnosticSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.DiagnosticSource</LogicalName>
           <Link>Resources\net60\System.Diagnostics.DiagnosticSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\net60\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Process</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\net60\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\net60\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\net60\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>net60.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\net60\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.dll" WithCulture="false">
           <LogicalName>net60.System</LogicalName>
           <Link>Resources\net60\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.dll" WithCulture="false">
           <LogicalName>net60.System.Drawing</LogicalName>
           <Link>Resources\net60\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Drawing.Primitives</LogicalName>
           <Link>Resources\net60\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>net60.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\net60\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Formats.Asn1.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Formats.Asn1.dll" WithCulture="false">
           <LogicalName>net60.System.Formats.Asn1</LogicalName>
           <Link>Resources\net60\System.Formats.Asn1.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>net60.System.Globalization.Calendars</LogicalName>
           <Link>Resources\net60\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.dll" WithCulture="false">
           <LogicalName>net60.System.Globalization</LogicalName>
           <Link>Resources\net60\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Globalization.Extensions</LogicalName>
           <Link>Resources\net60\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.Brotli.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.Brotli.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression.Brotli</LogicalName>
           <Link>Resources\net60\System.IO.Compression.Brotli.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression</LogicalName>
           <Link>Resources\net60\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\net60\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\net60\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.dll" WithCulture="false">
           <LogicalName>net60.System.IO</LogicalName>
           <Link>Resources\net60\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.AccessControl.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.AccessControl</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>net60.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\net60\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>net60.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\net60\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>net60.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\net60\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.AccessControl.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Pipes.AccessControl</LogicalName>
           <Link>Resources\net60\System.IO.Pipes.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>net60.System.IO.Pipes</LogicalName>
           <Link>Resources\net60\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>net60.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\net60\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.dll" WithCulture="false">
           <LogicalName>net60.System.Linq</LogicalName>
           <Link>Resources\net60\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>net60.System.Linq.Expressions</LogicalName>
           <Link>Resources\net60\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>net60.System.Linq.Parallel</LogicalName>
           <Link>Resources\net60\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>net60.System.Linq.Queryable</LogicalName>
           <Link>Resources\net60\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Memory.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Memory.dll" WithCulture="false">
           <LogicalName>net60.System.Memory</LogicalName>
           <Link>Resources\net60\System.Memory.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.dll" WithCulture="false">
           <LogicalName>net60.System.Net</LogicalName>
           <Link>Resources\net60\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Http</LogicalName>
           <Link>Resources\net60\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Http.Json.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Http.Json</LogicalName>
           <Link>Resources\net60\System.Net.Http.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.HttpListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.HttpListener.dll" WithCulture="false">
           <LogicalName>net60.System.Net.HttpListener</LogicalName>
           <Link>Resources\net60\System.Net.HttpListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Mail.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Mail.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Mail</LogicalName>
           <Link>Resources\net60\System.Net.Mail.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>net60.System.Net.NameResolution</LogicalName>
           <Link>Resources\net60\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>net60.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\net60\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Ping</LogicalName>
           <Link>Resources\net60\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Primitives</LogicalName>
           <Link>Resources\net60\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Requests</LogicalName>
           <Link>Resources\net60\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Security.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Security</LogicalName>
           <Link>Resources\net60\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.ServicePoint.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.ServicePoint.dll" WithCulture="false">
           <LogicalName>net60.System.Net.ServicePoint</LogicalName>
           <Link>Resources\net60\System.Net.ServicePoint.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>net60.System.Net.Sockets</LogicalName>
           <Link>Resources\net60\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebClient.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebClient.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebClient</LogicalName>
           <Link>Resources\net60\System.Net.WebClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\net60\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebProxy.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebProxy</LogicalName>
           <Link>Resources\net60\System.Net.WebProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\net60\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>net60.System.Net.WebSockets</LogicalName>
           <Link>Resources\net60\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.dll" WithCulture="false">
           <LogicalName>net60.System.Numerics</LogicalName>
           <Link>Resources\net60\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.Vectors.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Numerics.Vectors.dll" WithCulture="false">
           <LogicalName>net60.System.Numerics.Vectors</LogicalName>
           <Link>Resources\net60\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>net60.System.ObjectModel</LogicalName>
           <Link>Resources\net60\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.DispatchProxy.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.DispatchProxy.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.DispatchProxy</LogicalName>
           <Link>Resources\net60\System.Reflection.DispatchProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection</LogicalName>
           <Link>Resources\net60\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Emit</LogicalName>
           <Link>Resources\net60\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.ILGeneration.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Emit.ILGeneration</LogicalName>
           <Link>Resources\net60\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.Lightweight.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Emit.Lightweight</LogicalName>
           <Link>Resources\net60\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Extensions</LogicalName>
           <Link>Resources\net60\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Metadata.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Metadata.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Metadata</LogicalName>
           <Link>Resources\net60\System.Reflection.Metadata.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.Primitives</LogicalName>
           <Link>Resources\net60\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.TypeExtensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Reflection.TypeExtensions.dll" WithCulture="false">
           <LogicalName>net60.System.Reflection.TypeExtensions</LogicalName>
           <Link>Resources\net60\System.Reflection.TypeExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>net60.System.Resources.Reader</LogicalName>
           <Link>Resources\net60\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>net60.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\net60\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>net60.System.Resources.Writer</LogicalName>
           <Link>Resources\net60\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.Unsafe.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.CompilerServices.Unsafe</LogicalName>
           <Link>Resources\net60\System.Runtime.CompilerServices.Unsafe.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\net60\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime</LogicalName>
           <Link>Resources\net60\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Extensions</LogicalName>
           <Link>Resources\net60\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Handles</LogicalName>
           <Link>Resources\net60\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\net60\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\net60\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Intrinsics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Intrinsics.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Intrinsics</LogicalName>
           <Link>Resources\net60\System.Runtime.Intrinsics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Loader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Loader.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Loader</LogicalName>
           <Link>Resources\net60\System.Runtime.Loader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Numerics</LogicalName>
           <Link>Resources\net60\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>net60.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\net60\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.AccessControl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.AccessControl.dll" WithCulture="false">
           <LogicalName>net60.System.Security.AccessControl</LogicalName>
           <Link>Resources\net60\System.Security.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Claims</LogicalName>
           <Link>Resources\net60\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Cng.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Cng.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Cng</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Cng.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.OpenSsl.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.OpenSsl.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.OpenSsl</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.OpenSsl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\net60\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.dll" WithCulture="false">
           <LogicalName>net60.System.Security</LogicalName>
           <Link>Resources\net60\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Principal</LogicalName>
           <Link>Resources\net60\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.Principal.Windows.dll" WithCulture="false">
           <LogicalName>net60.System.Security.Principal.Windows</LogicalName>
           <Link>Resources\net60\System.Security.Principal.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>net60.System.Security.SecureString</LogicalName>
           <Link>Resources\net60\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>net60.System.ServiceModel.Web</LogicalName>
           <Link>Resources\net60\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceProcess.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ServiceProcess.dll" WithCulture="false">
           <LogicalName>net60.System.ServiceProcess</LogicalName>
           <Link>Resources\net60\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.CodePages.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.CodePages.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encoding.CodePages</LogicalName>
           <Link>Resources\net60\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encoding</LogicalName>
           <Link>Resources\net60\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\net60\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encodings.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Encodings.Web.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Encodings.Web</LogicalName>
           <Link>Resources\net60\System.Text.Encodings.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.Json.dll" WithCulture="false">
           <LogicalName>net60.System.Text.Json</LogicalName>
           <Link>Resources\net60\System.Text.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>net60.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\net60\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Channels.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Channels.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Channels</LogicalName>
           <Link>Resources\net60\System.Threading.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.dll" WithCulture="false">
           <LogicalName>net60.System.Threading</LogicalName>
           <Link>Resources\net60\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Overlapped</LogicalName>
           <Link>Resources\net60\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Dataflow.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks.Dataflow</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.Dataflow.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks.Extensions</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\net60\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Thread</LogicalName>
           <Link>Resources\net60\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\net60\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>net60.System.Threading.Timer</LogicalName>
           <Link>Resources\net60\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.dll" WithCulture="false">
           <LogicalName>net60.System.Transactions</LogicalName>
           <Link>Resources\net60\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.Local.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Transactions.Local.dll" WithCulture="false">
           <LogicalName>net60.System.Transactions.Local</LogicalName>
           <Link>Resources\net60\System.Transactions.Local.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>net60.System.ValueTuple</LogicalName>
           <Link>Resources\net60\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.dll" WithCulture="false">
           <LogicalName>net60.System.Web</LogicalName>
           <Link>Resources\net60\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.HttpUtility.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Web.HttpUtility.dll" WithCulture="false">
           <LogicalName>net60.System.Web.HttpUtility</LogicalName>
           <Link>Resources\net60\System.Web.HttpUtility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Windows.dll" WithCulture="false">
           <LogicalName>net60.System.Windows</LogicalName>
           <Link>Resources\net60\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.dll" WithCulture="false">
           <LogicalName>net60.System.Xml</LogicalName>
           <Link>Resources\net60\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.Linq</LogicalName>
           <Link>Resources\net60\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\net60\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.Serialization</LogicalName>
           <Link>Resources\net60\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XDocument</LogicalName>
           <Link>Resources\net60\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\net60\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\net60\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XPath</LogicalName>
           <Link>Resources\net60\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>net60.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\net60\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\WindowsBase.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\6.0.9\ref\net6.0\WindowsBase.dll" WithCulture="false">
           <LogicalName>net60.WindowsBase</LogicalName>
           <Link>Resources\net60\WindowsBase.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies/Generated.NetStandard20.targets
+++ b/Basic.Reference.Assemblies/Generated.NetStandard20.targets
@@ -1,454 +1,454 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\Microsoft.Win32.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\Microsoft.Win32.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.Microsoft.Win32.Primitives</LogicalName>
           <Link>Resources\netstandard20\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\mscorlib.dll" WithCulture="false">
           <LogicalName>netstandard20.mscorlib</LogicalName>
           <Link>Resources\netstandard20\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\netstandard.dll" WithCulture="false">
           <LogicalName>netstandard20.netstandard</LogicalName>
           <Link>Resources\netstandard20\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.AppContext.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.AppContext.dll" WithCulture="false">
           <LogicalName>netstandard20.System.AppContext</LogicalName>
           <Link>Resources\netstandard20\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Concurrent.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Concurrent.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections.Concurrent</LogicalName>
           <Link>Resources\netstandard20\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections</LogicalName>
           <Link>Resources\netstandard20\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.NonGeneric.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.NonGeneric.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections.NonGeneric</LogicalName>
           <Link>Resources\netstandard20\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Specialized.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Collections.Specialized.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Collections.Specialized</LogicalName>
           <Link>Resources\netstandard20\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Composition.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Composition.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.Composition</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.Composition.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.EventBasedAsync.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.EventBasedAsync</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.TypeConverter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ComponentModel.TypeConverter.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ComponentModel.TypeConverter</LogicalName>
           <Link>Resources\netstandard20\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Console.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Console.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Console</LogicalName>
           <Link>Resources\netstandard20\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Core.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Core.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Core</LogicalName>
           <Link>Resources\netstandard20\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.Common.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.Common.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Data.Common</LogicalName>
           <Link>Resources\netstandard20\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Data.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Data</LogicalName>
           <Link>Resources\netstandard20\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Contracts.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Contracts.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Contracts</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Debug.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Debug.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Debug</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.FileVersionInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.FileVersionInfo</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Process.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Process.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Process</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.StackTrace.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.StackTrace.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.StackTrace</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TextWriterTraceListener.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.TextWriterTraceListener</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tools.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tools.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Tools</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TraceSource.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.TraceSource.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.TraceSource</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tracing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Diagnostics.Tracing.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Diagnostics.Tracing</LogicalName>
           <Link>Resources\netstandard20\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.dll" WithCulture="false">
           <LogicalName>netstandard20.System</LogicalName>
           <Link>Resources\netstandard20\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Drawing</LogicalName>
           <Link>Resources\netstandard20\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Drawing.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Drawing.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Dynamic.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Dynamic.Runtime.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Dynamic.Runtime</LogicalName>
           <Link>Resources\netstandard20\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Calendars.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Calendars.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Globalization.Calendars</LogicalName>
           <Link>Resources\netstandard20\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Globalization</LogicalName>
           <Link>Resources\netstandard20\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Globalization.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Globalization.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Compression</LogicalName>
           <Link>Resources\netstandard20\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.FileSystem.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Compression.FileSystem</LogicalName>
           <Link>Resources\netstandard20\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.ZipFile.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Compression.ZipFile.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Compression.ZipFile</LogicalName>
           <Link>Resources\netstandard20\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO</LogicalName>
           <Link>Resources\netstandard20\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.DriveInfo.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem.DriveInfo</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Watcher.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.FileSystem.Watcher.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.FileSystem.Watcher</LogicalName>
           <Link>Resources\netstandard20\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.IsolatedStorage.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.IsolatedStorage.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.IsolatedStorage</LogicalName>
           <Link>Resources\netstandard20\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.MemoryMappedFiles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.MemoryMappedFiles.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.MemoryMappedFiles</LogicalName>
           <Link>Resources\netstandard20\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Pipes.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.Pipes.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.Pipes</LogicalName>
           <Link>Resources\netstandard20\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.UnmanagedMemoryStream.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
           <LogicalName>netstandard20.System.IO.UnmanagedMemoryStream</LogicalName>
           <Link>Resources\netstandard20\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq</LogicalName>
           <Link>Resources\netstandard20\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Expressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Expressions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq.Expressions</LogicalName>
           <Link>Resources\netstandard20\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Parallel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq.Parallel</LogicalName>
           <Link>Resources\netstandard20\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Queryable.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Linq.Queryable.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Linq.Queryable</LogicalName>
           <Link>Resources\netstandard20\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net</LogicalName>
           <Link>Resources\netstandard20\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Http.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Http.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Http</LogicalName>
           <Link>Resources\netstandard20\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NameResolution.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NameResolution.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.NameResolution</LogicalName>
           <Link>Resources\netstandard20\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NetworkInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.NetworkInformation.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.NetworkInformation</LogicalName>
           <Link>Resources\netstandard20\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Ping.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Ping.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Ping</LogicalName>
           <Link>Resources\netstandard20\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Requests.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Requests.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Requests</LogicalName>
           <Link>Resources\netstandard20\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Security.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Security.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Security</LogicalName>
           <Link>Resources\netstandard20\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Sockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.Sockets.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.Sockets</LogicalName>
           <Link>Resources\netstandard20\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebHeaderCollection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebHeaderCollection.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.WebHeaderCollection</LogicalName>
           <Link>Resources\netstandard20\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.Client.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.Client.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.WebSockets.Client</LogicalName>
           <Link>Resources\netstandard20\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Net.WebSockets.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Net.WebSockets</LogicalName>
           <Link>Resources\netstandard20\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Numerics.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Numerics</LogicalName>
           <Link>Resources\netstandard20\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ObjectModel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ObjectModel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ObjectModel</LogicalName>
           <Link>Resources\netstandard20\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Reflection</LogicalName>
           <Link>Resources\netstandard20\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Reflection.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Reflection.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Reflection.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Reader.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Reader.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Resources.Reader</LogicalName>
           <Link>Resources\netstandard20\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.ResourceManager.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.ResourceManager.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Resources.ResourceManager</LogicalName>
           <Link>Resources\netstandard20\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Writer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Resources.Writer.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Resources.Writer</LogicalName>
           <Link>Resources\netstandard20\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.CompilerServices.VisualC.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.CompilerServices.VisualC</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Handles.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Handles.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Handles</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.InteropServices</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.RuntimeInformation.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Numerics.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Numerics.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Numerics</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Formatters.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Formatters</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Json.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Json.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Json</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Runtime.Serialization.Xml.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Runtime.Serialization.Xml</LogicalName>
           <Link>Resources\netstandard20\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Claims.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Claims.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Claims</LogicalName>
           <Link>Resources\netstandard20\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Algorithms.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Algorithms</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Csp.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Csp.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Csp</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Encoding.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Encoding</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Primitives.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.Primitives.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.Primitives</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.X509Certificates.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Cryptography.X509Certificates</LogicalName>
           <Link>Resources\netstandard20\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Principal.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.Principal.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.Principal</LogicalName>
           <Link>Resources\netstandard20\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.SecureString.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Security.SecureString.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Security.SecureString</LogicalName>
           <Link>Resources\netstandard20\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ServiceModel.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ServiceModel.Web.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ServiceModel.Web</LogicalName>
           <Link>Resources\netstandard20\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Text.Encoding</LogicalName>
           <Link>Resources\netstandard20\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.Extensions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.Encoding.Extensions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Text.Encoding.Extensions</LogicalName>
           <Link>Resources\netstandard20\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.RegularExpressions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Text.RegularExpressions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Text.RegularExpressions</LogicalName>
           <Link>Resources\netstandard20\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading</LogicalName>
           <Link>Resources\netstandard20\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Overlapped.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Overlapped.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Overlapped</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Tasks</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.Parallel.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Tasks.Parallel.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Tasks.Parallel</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Thread.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Thread.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Thread</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.ThreadPool.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.ThreadPool.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.ThreadPool</LogicalName>
           <Link>Resources\netstandard20\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Timer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Threading.Timer.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Threading.Timer</LogicalName>
           <Link>Resources\netstandard20\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Transactions.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Transactions.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Transactions</LogicalName>
           <Link>Resources\netstandard20\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ValueTuple.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.ValueTuple.dll" WithCulture="false">
           <LogicalName>netstandard20.System.ValueTuple</LogicalName>
           <Link>Resources\netstandard20\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Web.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Web.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Web</LogicalName>
           <Link>Resources\netstandard20\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Windows.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Windows.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Windows</LogicalName>
           <Link>Resources\netstandard20\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml</LogicalName>
           <Link>Resources\netstandard20\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Linq.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Linq.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.Linq</LogicalName>
           <Link>Resources\netstandard20\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.ReaderWriter.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.ReaderWriter.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.ReaderWriter</LogicalName>
           <Link>Resources\netstandard20\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Serialization.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.Serialization.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.Serialization</LogicalName>
           <Link>Resources\netstandard20\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XDocument.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XDocument</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlDocument.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XmlDocument</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlSerializer.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XmlSerializer.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XmlSerializer</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XPath</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.XDocument.dll">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\netstandard.library\2.0.3\build\netstandard2.0\ref\System.Xml.XPath.XDocument.dll" WithCulture="false">
           <LogicalName>netstandard20.System.Xml.XPath.XDocument</LogicalName>
           <Link>Resources\netstandard20\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>

--- a/Scripts/Generate.ps1
+++ b/Scripts/Generate.ps1
@@ -66,7 +66,7 @@ namespace Basic.Reference.Assemblies
     $dllPath = $targetsPrefix + $dllPath
 
     $targetsContent += @"
-        <EmbeddedResource Include="$dllPath">
+        <EmbeddedResource Include="$dllPath" WithCulture="false">
           <LogicalName>$logicalName</LogicalName>
           <Link>Resources\$lowerName\$dllName</Link>
         </EmbeddedResource>


### PR DESCRIPTION
The core issue here is that "metadata" is a valid culture on Linux. Once I moved the build machines to Linux this caused the _System.Reflection.Metadata.dll_ entry to be silently removed from the DLL. Needed to put `WithCulture="false"` to prevent that from happening. 

https://github.com/dotnet/msbuild/issues/9152