### PR TITLE
update net9.0, fix path construction

### DIFF
--- a/Basic.Reference.Assemblies.Net90/Basic.Reference.Assemblies.Net90.csproj
+++ b/Basic.Reference.Assemblies.Net90/Basic.Reference.Assemblies.Net90.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.3.24172.9" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" ExcludeAssets="analyzers" />
+    <PackageReference Include="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.6.24327.7" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" ExcludeAssets="analyzers" />
   </ItemGroup>
 
   <Import Project="Generated.targets" />

--- a/Basic.Reference.Assemblies.Net90/Generated.cs
+++ b/Basic.Reference.Assemblies.Net90/Generated.cs
@@ -354,6 +354,12 @@ public static partial class Net90
         private static byte[]? _SystemIOMemoryMappedFiles;
 
         /// <summary>
+        /// The image bytes for System.IO.Pipelines.dll
+        /// </summary>
+        public static byte[] SystemIOPipelines => ResourceLoader.GetOrCreateResource(ref _SystemIOPipelines, "net90.System.IO.Pipelines");
+        private static byte[]? _SystemIOPipelines;
+
+        /// <summary>
         /// The image bytes for System.IO.Pipes.AccessControl.dll
         /// </summary>
         public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net90.System.IO.Pipes.AccessControl");
@@ -1000,817 +1006,822 @@ public static partial class Net90
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, Net90.References.MicrosoftCSharp, global::System.Guid.Parse("64f1e8f4-0b94-4379-9625-2885e0f3a5bd"));
+        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, Net90.References.MicrosoftCSharp, global::System.Guid.Parse("5e5d761e-44dc-43c0-a8f6-2204e0c2e0bc"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.Core.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftVisualBasicCore => new ReferenceInfo("Microsoft.VisualBasic.Core.dll", Resources.MicrosoftVisualBasicCore, Net90.References.MicrosoftVisualBasicCore, global::System.Guid.Parse("e93dc53b-93fa-41d2-8e46-4fa40c2d445e"));
+        public static ReferenceInfo MicrosoftVisualBasicCore => new ReferenceInfo("Microsoft.VisualBasic.Core.dll", Resources.MicrosoftVisualBasicCore, Net90.References.MicrosoftVisualBasicCore, global::System.Guid.Parse("21b84e31-5fc3-4638-b96f-867e19aa286b"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, Net90.References.MicrosoftVisualBasic, global::System.Guid.Parse("16f675b4-07d3-4574-993a-8863d44523c1"));
+        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, Net90.References.MicrosoftVisualBasic, global::System.Guid.Parse("a1bcb046-e4f8-4f42-a6e3-5993c52953f9"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.Win32.Primitives.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftWin32Primitives => new ReferenceInfo("Microsoft.Win32.Primitives.dll", Resources.MicrosoftWin32Primitives, Net90.References.MicrosoftWin32Primitives, global::System.Guid.Parse("1b663b10-1d81-47ec-91f7-795a178568a5"));
+        public static ReferenceInfo MicrosoftWin32Primitives => new ReferenceInfo("Microsoft.Win32.Primitives.dll", Resources.MicrosoftWin32Primitives, Net90.References.MicrosoftWin32Primitives, global::System.Guid.Parse("c2c0d40d-5d32-45a6-81a3-db4a6a2af146"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.Win32.Registry.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftWin32Registry => new ReferenceInfo("Microsoft.Win32.Registry.dll", Resources.MicrosoftWin32Registry, Net90.References.MicrosoftWin32Registry, global::System.Guid.Parse("25f949ca-dfca-4e11-a64f-7672cef83211"));
+        public static ReferenceInfo MicrosoftWin32Registry => new ReferenceInfo("Microsoft.Win32.Registry.dll", Resources.MicrosoftWin32Registry, Net90.References.MicrosoftWin32Registry, global::System.Guid.Parse("33cf8f36-abf9-48d4-b54f-29c529322926"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for mscorlib.dll
         /// </summary>
-        public static ReferenceInfo mscorlib => new ReferenceInfo("mscorlib.dll", Resources.mscorlib, Net90.References.mscorlib, global::System.Guid.Parse("681f7cf7-fcef-4030-8d94-8334797f24f5"));
+        public static ReferenceInfo mscorlib => new ReferenceInfo("mscorlib.dll", Resources.mscorlib, Net90.References.mscorlib, global::System.Guid.Parse("a4a42340-a405-4235-9f4d-65bdeb26bcf4"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for netstandard.dll
         /// </summary>
-        public static ReferenceInfo netstandard => new ReferenceInfo("netstandard.dll", Resources.netstandard, Net90.References.netstandard, global::System.Guid.Parse("d9a4daed-ffaf-476a-b0ea-ab41c25fa5a1"));
+        public static ReferenceInfo netstandard => new ReferenceInfo("netstandard.dll", Resources.netstandard, Net90.References.netstandard, global::System.Guid.Parse("1befba54-1bbc-4bcd-950f-13012b5e590e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.AppContext.dll
         /// </summary>
-        public static ReferenceInfo SystemAppContext => new ReferenceInfo("System.AppContext.dll", Resources.SystemAppContext, Net90.References.SystemAppContext, global::System.Guid.Parse("b3ec8263-113d-40aa-883e-37853a296bdf"));
+        public static ReferenceInfo SystemAppContext => new ReferenceInfo("System.AppContext.dll", Resources.SystemAppContext, Net90.References.SystemAppContext, global::System.Guid.Parse("c44345c3-dd50-40af-b737-c7edfc291fd2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Buffers.dll
         /// </summary>
-        public static ReferenceInfo SystemBuffers => new ReferenceInfo("System.Buffers.dll", Resources.SystemBuffers, Net90.References.SystemBuffers, global::System.Guid.Parse("64be861d-d169-4172-8f4a-3acd5395e19b"));
+        public static ReferenceInfo SystemBuffers => new ReferenceInfo("System.Buffers.dll", Resources.SystemBuffers, Net90.References.SystemBuffers, global::System.Guid.Parse("90d5d925-25cc-436c-aaef-aec6ecc34531"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Collections.Concurrent.dll
         /// </summary>
-        public static ReferenceInfo SystemCollectionsConcurrent => new ReferenceInfo("System.Collections.Concurrent.dll", Resources.SystemCollectionsConcurrent, Net90.References.SystemCollectionsConcurrent, global::System.Guid.Parse("a15ee733-6cda-439d-af6a-59245ce0806b"));
+        public static ReferenceInfo SystemCollectionsConcurrent => new ReferenceInfo("System.Collections.Concurrent.dll", Resources.SystemCollectionsConcurrent, Net90.References.SystemCollectionsConcurrent, global::System.Guid.Parse("c78ccdf4-6abf-4859-9c3f-32375e16b51c"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Collections.dll
         /// </summary>
-        public static ReferenceInfo SystemCollections => new ReferenceInfo("System.Collections.dll", Resources.SystemCollections, Net90.References.SystemCollections, global::System.Guid.Parse("54bc55a5-81b5-4ac4-a66d-be8d8177ffa2"));
+        public static ReferenceInfo SystemCollections => new ReferenceInfo("System.Collections.dll", Resources.SystemCollections, Net90.References.SystemCollections, global::System.Guid.Parse("babcb9eb-7b26-4c7a-bec9-2a8b6eb5ee19"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Collections.Immutable.dll
         /// </summary>
-        public static ReferenceInfo SystemCollectionsImmutable => new ReferenceInfo("System.Collections.Immutable.dll", Resources.SystemCollectionsImmutable, Net90.References.SystemCollectionsImmutable, global::System.Guid.Parse("dbd97958-7803-4d96-b06f-64264bfce0ee"));
+        public static ReferenceInfo SystemCollectionsImmutable => new ReferenceInfo("System.Collections.Immutable.dll", Resources.SystemCollectionsImmutable, Net90.References.SystemCollectionsImmutable, global::System.Guid.Parse("a0a99396-09d1-49ab-867a-ee5fa8c84b4f"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Collections.NonGeneric.dll
         /// </summary>
-        public static ReferenceInfo SystemCollectionsNonGeneric => new ReferenceInfo("System.Collections.NonGeneric.dll", Resources.SystemCollectionsNonGeneric, Net90.References.SystemCollectionsNonGeneric, global::System.Guid.Parse("fc34be72-f3dd-4312-a1e4-647bb08a9df2"));
+        public static ReferenceInfo SystemCollectionsNonGeneric => new ReferenceInfo("System.Collections.NonGeneric.dll", Resources.SystemCollectionsNonGeneric, Net90.References.SystemCollectionsNonGeneric, global::System.Guid.Parse("cc7d5299-2f87-4580-bcba-0c898ab67588"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Collections.Specialized.dll
         /// </summary>
-        public static ReferenceInfo SystemCollectionsSpecialized => new ReferenceInfo("System.Collections.Specialized.dll", Resources.SystemCollectionsSpecialized, Net90.References.SystemCollectionsSpecialized, global::System.Guid.Parse("b5ba44f4-6b7c-4513-9b11-b32266b88fcd"));
+        public static ReferenceInfo SystemCollectionsSpecialized => new ReferenceInfo("System.Collections.Specialized.dll", Resources.SystemCollectionsSpecialized, Net90.References.SystemCollectionsSpecialized, global::System.Guid.Parse("0da94147-5517-41d6-b9e6-9bee7a3d3847"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ComponentModel.Annotations.dll
         /// </summary>
-        public static ReferenceInfo SystemComponentModelAnnotations => new ReferenceInfo("System.ComponentModel.Annotations.dll", Resources.SystemComponentModelAnnotations, Net90.References.SystemComponentModelAnnotations, global::System.Guid.Parse("33105e93-edd5-43a8-882e-9661f1aaabf6"));
+        public static ReferenceInfo SystemComponentModelAnnotations => new ReferenceInfo("System.ComponentModel.Annotations.dll", Resources.SystemComponentModelAnnotations, Net90.References.SystemComponentModelAnnotations, global::System.Guid.Parse("beaa78e3-18ad-4680-8e0c-becc78a642fb"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ComponentModel.DataAnnotations.dll
         /// </summary>
-        public static ReferenceInfo SystemComponentModelDataAnnotations => new ReferenceInfo("System.ComponentModel.DataAnnotations.dll", Resources.SystemComponentModelDataAnnotations, Net90.References.SystemComponentModelDataAnnotations, global::System.Guid.Parse("678f5cd2-7067-4493-b9f9-32f8bb48290f"));
+        public static ReferenceInfo SystemComponentModelDataAnnotations => new ReferenceInfo("System.ComponentModel.DataAnnotations.dll", Resources.SystemComponentModelDataAnnotations, Net90.References.SystemComponentModelDataAnnotations, global::System.Guid.Parse("2e245778-2ba3-420a-a887-e9578421586b"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ComponentModel.dll
         /// </summary>
-        public static ReferenceInfo SystemComponentModel => new ReferenceInfo("System.ComponentModel.dll", Resources.SystemComponentModel, Net90.References.SystemComponentModel, global::System.Guid.Parse("fd7c2eca-b360-48fb-898f-2db55aab9ecd"));
+        public static ReferenceInfo SystemComponentModel => new ReferenceInfo("System.ComponentModel.dll", Resources.SystemComponentModel, Net90.References.SystemComponentModel, global::System.Guid.Parse("24f1330c-5896-44e4-9abb-eac54976fff5"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ComponentModel.EventBasedAsync.dll
         /// </summary>
-        public static ReferenceInfo SystemComponentModelEventBasedAsync => new ReferenceInfo("System.ComponentModel.EventBasedAsync.dll", Resources.SystemComponentModelEventBasedAsync, Net90.References.SystemComponentModelEventBasedAsync, global::System.Guid.Parse("ef153d7d-96bc-43c1-a6a9-2f77be69eef8"));
+        public static ReferenceInfo SystemComponentModelEventBasedAsync => new ReferenceInfo("System.ComponentModel.EventBasedAsync.dll", Resources.SystemComponentModelEventBasedAsync, Net90.References.SystemComponentModelEventBasedAsync, global::System.Guid.Parse("1672a842-f7a4-4d64-8a40-3a55d25ad6b3"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ComponentModel.Primitives.dll
         /// </summary>
-        public static ReferenceInfo SystemComponentModelPrimitives => new ReferenceInfo("System.ComponentModel.Primitives.dll", Resources.SystemComponentModelPrimitives, Net90.References.SystemComponentModelPrimitives, global::System.Guid.Parse("711fd2f5-60cc-4e71-950f-119ba68f7582"));
+        public static ReferenceInfo SystemComponentModelPrimitives => new ReferenceInfo("System.ComponentModel.Primitives.dll", Resources.SystemComponentModelPrimitives, Net90.References.SystemComponentModelPrimitives, global::System.Guid.Parse("0ff31d83-a32b-43f5-aa5e-ff72e93d085a"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ComponentModel.TypeConverter.dll
         /// </summary>
-        public static ReferenceInfo SystemComponentModelTypeConverter => new ReferenceInfo("System.ComponentModel.TypeConverter.dll", Resources.SystemComponentModelTypeConverter, Net90.References.SystemComponentModelTypeConverter, global::System.Guid.Parse("35190eef-9462-49cb-ac67-cc558c2b92b5"));
+        public static ReferenceInfo SystemComponentModelTypeConverter => new ReferenceInfo("System.ComponentModel.TypeConverter.dll", Resources.SystemComponentModelTypeConverter, Net90.References.SystemComponentModelTypeConverter, global::System.Guid.Parse("0cd2a362-f0ab-4be2-b414-794def1de349"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Configuration.dll
         /// </summary>
-        public static ReferenceInfo SystemConfiguration => new ReferenceInfo("System.Configuration.dll", Resources.SystemConfiguration, Net90.References.SystemConfiguration, global::System.Guid.Parse("bae12525-381f-48d6-99ba-7cb9ae47977c"));
+        public static ReferenceInfo SystemConfiguration => new ReferenceInfo("System.Configuration.dll", Resources.SystemConfiguration, Net90.References.SystemConfiguration, global::System.Guid.Parse("54717bf5-0832-4da7-be5f-7753b918abef"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Console.dll
         /// </summary>
-        public static ReferenceInfo SystemConsole => new ReferenceInfo("System.Console.dll", Resources.SystemConsole, Net90.References.SystemConsole, global::System.Guid.Parse("c87ca8af-d7b8-4e16-aedd-d67f8ff3d513"));
+        public static ReferenceInfo SystemConsole => new ReferenceInfo("System.Console.dll", Resources.SystemConsole, Net90.References.SystemConsole, global::System.Guid.Parse("87e32124-a8df-4878-b715-7613d2228a11"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Core.dll
         /// </summary>
-        public static ReferenceInfo SystemCore => new ReferenceInfo("System.Core.dll", Resources.SystemCore, Net90.References.SystemCore, global::System.Guid.Parse("f75c5d38-8b46-4dc5-9423-c51cdb214ad9"));
+        public static ReferenceInfo SystemCore => new ReferenceInfo("System.Core.dll", Resources.SystemCore, Net90.References.SystemCore, global::System.Guid.Parse("53e14993-9d8f-4305-8ee2-45ce7a7e7ebe"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Data.Common.dll
         /// </summary>
-        public static ReferenceInfo SystemDataCommon => new ReferenceInfo("System.Data.Common.dll", Resources.SystemDataCommon, Net90.References.SystemDataCommon, global::System.Guid.Parse("f86965fd-3383-4674-b8c1-2881aaf9c8f6"));
+        public static ReferenceInfo SystemDataCommon => new ReferenceInfo("System.Data.Common.dll", Resources.SystemDataCommon, Net90.References.SystemDataCommon, global::System.Guid.Parse("b86a19be-a16c-4e90-9225-481ae0dcfb9e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Data.DataSetExtensions.dll
         /// </summary>
-        public static ReferenceInfo SystemDataDataSetExtensions => new ReferenceInfo("System.Data.DataSetExtensions.dll", Resources.SystemDataDataSetExtensions, Net90.References.SystemDataDataSetExtensions, global::System.Guid.Parse("a2acfe63-720c-456c-b450-4033b500498f"));
+        public static ReferenceInfo SystemDataDataSetExtensions => new ReferenceInfo("System.Data.DataSetExtensions.dll", Resources.SystemDataDataSetExtensions, Net90.References.SystemDataDataSetExtensions, global::System.Guid.Parse("f08933bd-aed5-4392-b7d5-408dba3a10ff"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Data.dll
         /// </summary>
-        public static ReferenceInfo SystemData => new ReferenceInfo("System.Data.dll", Resources.SystemData, Net90.References.SystemData, global::System.Guid.Parse("f5d7b3d9-0e51-4e97-9bb6-3f34f8803dc5"));
+        public static ReferenceInfo SystemData => new ReferenceInfo("System.Data.dll", Resources.SystemData, Net90.References.SystemData, global::System.Guid.Parse("912ec259-179b-4fee-81bd-2c370de13539"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.Contracts.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsContracts => new ReferenceInfo("System.Diagnostics.Contracts.dll", Resources.SystemDiagnosticsContracts, Net90.References.SystemDiagnosticsContracts, global::System.Guid.Parse("bed1df30-ac56-4627-91ad-124a4c80202d"));
+        public static ReferenceInfo SystemDiagnosticsContracts => new ReferenceInfo("System.Diagnostics.Contracts.dll", Resources.SystemDiagnosticsContracts, Net90.References.SystemDiagnosticsContracts, global::System.Guid.Parse("3b899e01-8035-48e8-ab8c-6ba3830c46d2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.Debug.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsDebug => new ReferenceInfo("System.Diagnostics.Debug.dll", Resources.SystemDiagnosticsDebug, Net90.References.SystemDiagnosticsDebug, global::System.Guid.Parse("6b880bd3-729c-4630-b4f0-24ee6e71a4ae"));
+        public static ReferenceInfo SystemDiagnosticsDebug => new ReferenceInfo("System.Diagnostics.Debug.dll", Resources.SystemDiagnosticsDebug, Net90.References.SystemDiagnosticsDebug, global::System.Guid.Parse("2d3bbd7d-d307-4465-ba74-5f82f02e78d2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.DiagnosticSource.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsDiagnosticSource => new ReferenceInfo("System.Diagnostics.DiagnosticSource.dll", Resources.SystemDiagnosticsDiagnosticSource, Net90.References.SystemDiagnosticsDiagnosticSource, global::System.Guid.Parse("7e99c2e2-b3b7-4ccb-af79-9e4eba3830c8"));
+        public static ReferenceInfo SystemDiagnosticsDiagnosticSource => new ReferenceInfo("System.Diagnostics.DiagnosticSource.dll", Resources.SystemDiagnosticsDiagnosticSource, Net90.References.SystemDiagnosticsDiagnosticSource, global::System.Guid.Parse("24dc8bbc-d054-4bf1-b04b-f70d71d952b7"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.FileVersionInfo.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsFileVersionInfo => new ReferenceInfo("System.Diagnostics.FileVersionInfo.dll", Resources.SystemDiagnosticsFileVersionInfo, Net90.References.SystemDiagnosticsFileVersionInfo, global::System.Guid.Parse("a359ee03-bc2b-4a21-9561-1bc851debf01"));
+        public static ReferenceInfo SystemDiagnosticsFileVersionInfo => new ReferenceInfo("System.Diagnostics.FileVersionInfo.dll", Resources.SystemDiagnosticsFileVersionInfo, Net90.References.SystemDiagnosticsFileVersionInfo, global::System.Guid.Parse("c781cc84-fd39-4efa-981e-7a4a65dc5f3b"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.Process.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsProcess => new ReferenceInfo("System.Diagnostics.Process.dll", Resources.SystemDiagnosticsProcess, Net90.References.SystemDiagnosticsProcess, global::System.Guid.Parse("6c366f72-6580-4e6b-b3c2-05a996410782"));
+        public static ReferenceInfo SystemDiagnosticsProcess => new ReferenceInfo("System.Diagnostics.Process.dll", Resources.SystemDiagnosticsProcess, Net90.References.SystemDiagnosticsProcess, global::System.Guid.Parse("6d879e92-cd94-425f-b458-af0ef566e034"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.StackTrace.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsStackTrace => new ReferenceInfo("System.Diagnostics.StackTrace.dll", Resources.SystemDiagnosticsStackTrace, Net90.References.SystemDiagnosticsStackTrace, global::System.Guid.Parse("d9103001-7b71-4e0d-ad11-e5145be4b092"));
+        public static ReferenceInfo SystemDiagnosticsStackTrace => new ReferenceInfo("System.Diagnostics.StackTrace.dll", Resources.SystemDiagnosticsStackTrace, Net90.References.SystemDiagnosticsStackTrace, global::System.Guid.Parse("749f4854-08d5-40de-b6ae-dd1ae49e6600"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.TextWriterTraceListener.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsTextWriterTraceListener => new ReferenceInfo("System.Diagnostics.TextWriterTraceListener.dll", Resources.SystemDiagnosticsTextWriterTraceListener, Net90.References.SystemDiagnosticsTextWriterTraceListener, global::System.Guid.Parse("0d5df73c-5d02-40a1-876b-5ccebad662d8"));
+        public static ReferenceInfo SystemDiagnosticsTextWriterTraceListener => new ReferenceInfo("System.Diagnostics.TextWriterTraceListener.dll", Resources.SystemDiagnosticsTextWriterTraceListener, Net90.References.SystemDiagnosticsTextWriterTraceListener, global::System.Guid.Parse("6f48e650-4bf6-470c-851d-02367ae7a3e2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.Tools.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsTools => new ReferenceInfo("System.Diagnostics.Tools.dll", Resources.SystemDiagnosticsTools, Net90.References.SystemDiagnosticsTools, global::System.Guid.Parse("14010c89-7aef-4ee1-acb7-443d320667e7"));
+        public static ReferenceInfo SystemDiagnosticsTools => new ReferenceInfo("System.Diagnostics.Tools.dll", Resources.SystemDiagnosticsTools, Net90.References.SystemDiagnosticsTools, global::System.Guid.Parse("c487f4f6-7f4a-4f86-b43e-9007da34445e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.TraceSource.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsTraceSource => new ReferenceInfo("System.Diagnostics.TraceSource.dll", Resources.SystemDiagnosticsTraceSource, Net90.References.SystemDiagnosticsTraceSource, global::System.Guid.Parse("84a0a5b2-7088-4432-a80a-d4d416fb9d05"));
+        public static ReferenceInfo SystemDiagnosticsTraceSource => new ReferenceInfo("System.Diagnostics.TraceSource.dll", Resources.SystemDiagnosticsTraceSource, Net90.References.SystemDiagnosticsTraceSource, global::System.Guid.Parse("f309ca1d-8e48-4dda-9c4e-3cf01eed4f7a"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Diagnostics.Tracing.dll
         /// </summary>
-        public static ReferenceInfo SystemDiagnosticsTracing => new ReferenceInfo("System.Diagnostics.Tracing.dll", Resources.SystemDiagnosticsTracing, Net90.References.SystemDiagnosticsTracing, global::System.Guid.Parse("ff297d98-c4c6-498e-a647-4b1dc1ca7b45"));
+        public static ReferenceInfo SystemDiagnosticsTracing => new ReferenceInfo("System.Diagnostics.Tracing.dll", Resources.SystemDiagnosticsTracing, Net90.References.SystemDiagnosticsTracing, global::System.Guid.Parse("e416fa28-0b56-4218-9914-50fe0cac5250"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.dll
         /// </summary>
-        public static ReferenceInfo System => new ReferenceInfo("System.dll", Resources.System, Net90.References.System, global::System.Guid.Parse("e34921b7-df2b-42b1-9360-692c990e4fb8"));
+        public static ReferenceInfo System => new ReferenceInfo("System.dll", Resources.System, Net90.References.System, global::System.Guid.Parse("645bb429-e822-43ab-ba54-574538190710"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Drawing.dll
         /// </summary>
-        public static ReferenceInfo SystemDrawing => new ReferenceInfo("System.Drawing.dll", Resources.SystemDrawing, Net90.References.SystemDrawing, global::System.Guid.Parse("f632e32c-cd18-407e-a1c1-a4bd228ab22c"));
+        public static ReferenceInfo SystemDrawing => new ReferenceInfo("System.Drawing.dll", Resources.SystemDrawing, Net90.References.SystemDrawing, global::System.Guid.Parse("7f934cc1-4461-4313-8044-d64d5bc365ee"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Drawing.Primitives.dll
         /// </summary>
-        public static ReferenceInfo SystemDrawingPrimitives => new ReferenceInfo("System.Drawing.Primitives.dll", Resources.SystemDrawingPrimitives, Net90.References.SystemDrawingPrimitives, global::System.Guid.Parse("af04aa3e-4590-44f1-8876-a874f54ec156"));
+        public static ReferenceInfo SystemDrawingPrimitives => new ReferenceInfo("System.Drawing.Primitives.dll", Resources.SystemDrawingPrimitives, Net90.References.SystemDrawingPrimitives, global::System.Guid.Parse("a630ecd0-f891-4a3a-9a8e-39407f308c71"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Dynamic.Runtime.dll
         /// </summary>
-        public static ReferenceInfo SystemDynamicRuntime => new ReferenceInfo("System.Dynamic.Runtime.dll", Resources.SystemDynamicRuntime, Net90.References.SystemDynamicRuntime, global::System.Guid.Parse("1b4d1074-81ad-4c28-a55a-d9b3eff22510"));
+        public static ReferenceInfo SystemDynamicRuntime => new ReferenceInfo("System.Dynamic.Runtime.dll", Resources.SystemDynamicRuntime, Net90.References.SystemDynamicRuntime, global::System.Guid.Parse("eba5e025-aafb-4012-81c0-40501f7f8cca"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Formats.Asn1.dll
         /// </summary>
-        public static ReferenceInfo SystemFormatsAsn1 => new ReferenceInfo("System.Formats.Asn1.dll", Resources.SystemFormatsAsn1, Net90.References.SystemFormatsAsn1, global::System.Guid.Parse("ac158784-3583-4bfc-91bf-d958b0aaff37"));
+        public static ReferenceInfo SystemFormatsAsn1 => new ReferenceInfo("System.Formats.Asn1.dll", Resources.SystemFormatsAsn1, Net90.References.SystemFormatsAsn1, global::System.Guid.Parse("a20b5ace-975a-4986-86a7-ae45a0cc5b94"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Formats.Tar.dll
         /// </summary>
-        public static ReferenceInfo SystemFormatsTar => new ReferenceInfo("System.Formats.Tar.dll", Resources.SystemFormatsTar, Net90.References.SystemFormatsTar, global::System.Guid.Parse("7f24b913-e0b6-44a3-a753-82d269046172"));
+        public static ReferenceInfo SystemFormatsTar => new ReferenceInfo("System.Formats.Tar.dll", Resources.SystemFormatsTar, Net90.References.SystemFormatsTar, global::System.Guid.Parse("c8c89f1f-6e92-4790-8308-cae04c779429"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Globalization.Calendars.dll
         /// </summary>
-        public static ReferenceInfo SystemGlobalizationCalendars => new ReferenceInfo("System.Globalization.Calendars.dll", Resources.SystemGlobalizationCalendars, Net90.References.SystemGlobalizationCalendars, global::System.Guid.Parse("ebe52c0c-a622-4ba0-b97f-df27b991bbaa"));
+        public static ReferenceInfo SystemGlobalizationCalendars => new ReferenceInfo("System.Globalization.Calendars.dll", Resources.SystemGlobalizationCalendars, Net90.References.SystemGlobalizationCalendars, global::System.Guid.Parse("25d894c5-20e5-431f-8d08-d1bc3886616e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Globalization.dll
         /// </summary>
-        public static ReferenceInfo SystemGlobalization => new ReferenceInfo("System.Globalization.dll", Resources.SystemGlobalization, Net90.References.SystemGlobalization, global::System.Guid.Parse("e0073c3f-72b1-4cad-b7b0-e2111d2bd80d"));
+        public static ReferenceInfo SystemGlobalization => new ReferenceInfo("System.Globalization.dll", Resources.SystemGlobalization, Net90.References.SystemGlobalization, global::System.Guid.Parse("ad082de7-a6e4-490b-810c-105c33b5ee10"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Globalization.Extensions.dll
         /// </summary>
-        public static ReferenceInfo SystemGlobalizationExtensions => new ReferenceInfo("System.Globalization.Extensions.dll", Resources.SystemGlobalizationExtensions, Net90.References.SystemGlobalizationExtensions, global::System.Guid.Parse("af7e75e5-f0ed-4670-a3b5-ba35ec197b25"));
+        public static ReferenceInfo SystemGlobalizationExtensions => new ReferenceInfo("System.Globalization.Extensions.dll", Resources.SystemGlobalizationExtensions, Net90.References.SystemGlobalizationExtensions, global::System.Guid.Parse("4c1bdeb4-9343-4c8a-833e-08d25895d0b1"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.Compression.Brotli.dll
         /// </summary>
-        public static ReferenceInfo SystemIOCompressionBrotli => new ReferenceInfo("System.IO.Compression.Brotli.dll", Resources.SystemIOCompressionBrotli, Net90.References.SystemIOCompressionBrotli, global::System.Guid.Parse("01c6591a-44b8-4ae8-bb12-d16cd6f87fd3"));
+        public static ReferenceInfo SystemIOCompressionBrotli => new ReferenceInfo("System.IO.Compression.Brotli.dll", Resources.SystemIOCompressionBrotli, Net90.References.SystemIOCompressionBrotli, global::System.Guid.Parse("901ee5bc-8d43-4d18-8604-dd2594ee81eb"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.Compression.dll
         /// </summary>
-        public static ReferenceInfo SystemIOCompression => new ReferenceInfo("System.IO.Compression.dll", Resources.SystemIOCompression, Net90.References.SystemIOCompression, global::System.Guid.Parse("eddcee02-d732-4ec4-aa0b-426ae5e64fa8"));
+        public static ReferenceInfo SystemIOCompression => new ReferenceInfo("System.IO.Compression.dll", Resources.SystemIOCompression, Net90.References.SystemIOCompression, global::System.Guid.Parse("cfdcdfce-f947-4870-b882-d0949dfb3601"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.Compression.FileSystem.dll
         /// </summary>
-        public static ReferenceInfo SystemIOCompressionFileSystem => new ReferenceInfo("System.IO.Compression.FileSystem.dll", Resources.SystemIOCompressionFileSystem, Net90.References.SystemIOCompressionFileSystem, global::System.Guid.Parse("67172869-2c17-445a-b379-ac507d4ba254"));
+        public static ReferenceInfo SystemIOCompressionFileSystem => new ReferenceInfo("System.IO.Compression.FileSystem.dll", Resources.SystemIOCompressionFileSystem, Net90.References.SystemIOCompressionFileSystem, global::System.Guid.Parse("25405392-0cd8-44af-87c7-757cb2f11d98"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.Compression.ZipFile.dll
         /// </summary>
-        public static ReferenceInfo SystemIOCompressionZipFile => new ReferenceInfo("System.IO.Compression.ZipFile.dll", Resources.SystemIOCompressionZipFile, Net90.References.SystemIOCompressionZipFile, global::System.Guid.Parse("e5ccb76b-b576-4ec1-a39c-6ac178fc1b08"));
+        public static ReferenceInfo SystemIOCompressionZipFile => new ReferenceInfo("System.IO.Compression.ZipFile.dll", Resources.SystemIOCompressionZipFile, Net90.References.SystemIOCompressionZipFile, global::System.Guid.Parse("7c3b42ef-a51e-4e35-8a9d-02ec24ac396e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.dll
         /// </summary>
-        public static ReferenceInfo SystemIO => new ReferenceInfo("System.IO.dll", Resources.SystemIO, Net90.References.SystemIO, global::System.Guid.Parse("da065782-4de7-49b1-bfba-2045c96187a3"));
+        public static ReferenceInfo SystemIO => new ReferenceInfo("System.IO.dll", Resources.SystemIO, Net90.References.SystemIO, global::System.Guid.Parse("2667e952-94ce-4882-a1bf-a10b587048ec"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.FileSystem.AccessControl.dll
         /// </summary>
-        public static ReferenceInfo SystemIOFileSystemAccessControl => new ReferenceInfo("System.IO.FileSystem.AccessControl.dll", Resources.SystemIOFileSystemAccessControl, Net90.References.SystemIOFileSystemAccessControl, global::System.Guid.Parse("0488e787-f710-4780-a150-4a292b2d52ab"));
+        public static ReferenceInfo SystemIOFileSystemAccessControl => new ReferenceInfo("System.IO.FileSystem.AccessControl.dll", Resources.SystemIOFileSystemAccessControl, Net90.References.SystemIOFileSystemAccessControl, global::System.Guid.Parse("29b78546-dd61-4ee8-a6fe-6fb45d7bd37e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.FileSystem.dll
         /// </summary>
-        public static ReferenceInfo SystemIOFileSystem => new ReferenceInfo("System.IO.FileSystem.dll", Resources.SystemIOFileSystem, Net90.References.SystemIOFileSystem, global::System.Guid.Parse("f5685739-c594-4e1f-9471-81c86ebc8c32"));
+        public static ReferenceInfo SystemIOFileSystem => new ReferenceInfo("System.IO.FileSystem.dll", Resources.SystemIOFileSystem, Net90.References.SystemIOFileSystem, global::System.Guid.Parse("cd45eac2-ceef-4ec8-9e03-6fb70d953e0a"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.FileSystem.DriveInfo.dll
         /// </summary>
-        public static ReferenceInfo SystemIOFileSystemDriveInfo => new ReferenceInfo("System.IO.FileSystem.DriveInfo.dll", Resources.SystemIOFileSystemDriveInfo, Net90.References.SystemIOFileSystemDriveInfo, global::System.Guid.Parse("2da41a28-be2e-41ae-ae3e-3ebe88f1e964"));
+        public static ReferenceInfo SystemIOFileSystemDriveInfo => new ReferenceInfo("System.IO.FileSystem.DriveInfo.dll", Resources.SystemIOFileSystemDriveInfo, Net90.References.SystemIOFileSystemDriveInfo, global::System.Guid.Parse("c3763927-a3c6-4ad6-84c4-30bbbd9ae339"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.FileSystem.Primitives.dll
         /// </summary>
-        public static ReferenceInfo SystemIOFileSystemPrimitives => new ReferenceInfo("System.IO.FileSystem.Primitives.dll", Resources.SystemIOFileSystemPrimitives, Net90.References.SystemIOFileSystemPrimitives, global::System.Guid.Parse("61aaadfe-1f57-48eb-bd4b-31adab20c9ca"));
+        public static ReferenceInfo SystemIOFileSystemPrimitives => new ReferenceInfo("System.IO.FileSystem.Primitives.dll", Resources.SystemIOFileSystemPrimitives, Net90.References.SystemIOFileSystemPrimitives, global::System.Guid.Parse("05f8561d-3a94-4e0e-90d6-e1ca9e1b52eb"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.FileSystem.Watcher.dll
         /// </summary>
-        public static ReferenceInfo SystemIOFileSystemWatcher => new ReferenceInfo("System.IO.FileSystem.Watcher.dll", Resources.SystemIOFileSystemWatcher, Net90.References.SystemIOFileSystemWatcher, global::System.Guid.Parse("1dd55f96-2c9a-40ef-bab3-ccbc241f2930"));
+        public static ReferenceInfo SystemIOFileSystemWatcher => new ReferenceInfo("System.IO.FileSystem.Watcher.dll", Resources.SystemIOFileSystemWatcher, Net90.References.SystemIOFileSystemWatcher, global::System.Guid.Parse("07612a7c-f3fb-4fc4-8f83-7609682f5b27"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.IsolatedStorage.dll
         /// </summary>
-        public static ReferenceInfo SystemIOIsolatedStorage => new ReferenceInfo("System.IO.IsolatedStorage.dll", Resources.SystemIOIsolatedStorage, Net90.References.SystemIOIsolatedStorage, global::System.Guid.Parse("5860b1a3-adb8-435a-9935-72452ee6c9a0"));
+        public static ReferenceInfo SystemIOIsolatedStorage => new ReferenceInfo("System.IO.IsolatedStorage.dll", Resources.SystemIOIsolatedStorage, Net90.References.SystemIOIsolatedStorage, global::System.Guid.Parse("5a2eee8f-3418-4fe0-9874-b80d4c45f67d"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.MemoryMappedFiles.dll
         /// </summary>
-        public static ReferenceInfo SystemIOMemoryMappedFiles => new ReferenceInfo("System.IO.MemoryMappedFiles.dll", Resources.SystemIOMemoryMappedFiles, Net90.References.SystemIOMemoryMappedFiles, global::System.Guid.Parse("51c7ce38-5620-4688-811f-61d138226f84"));
+        public static ReferenceInfo SystemIOMemoryMappedFiles => new ReferenceInfo("System.IO.MemoryMappedFiles.dll", Resources.SystemIOMemoryMappedFiles, Net90.References.SystemIOMemoryMappedFiles, global::System.Guid.Parse("ee3effcb-580a-4a28-a59d-43ba265562e7"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for System.IO.Pipelines.dll
+        /// </summary>
+        public static ReferenceInfo SystemIOPipelines => new ReferenceInfo("System.IO.Pipelines.dll", Resources.SystemIOPipelines, Net90.References.SystemIOPipelines, global::System.Guid.Parse("0e8929fb-56d2-4f39-88c8-cd7af1efa792"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.Pipes.AccessControl.dll
         /// </summary>
-        public static ReferenceInfo SystemIOPipesAccessControl => new ReferenceInfo("System.IO.Pipes.AccessControl.dll", Resources.SystemIOPipesAccessControl, Net90.References.SystemIOPipesAccessControl, global::System.Guid.Parse("15621a24-476d-4c76-8b0e-1b0343d8a638"));
+        public static ReferenceInfo SystemIOPipesAccessControl => new ReferenceInfo("System.IO.Pipes.AccessControl.dll", Resources.SystemIOPipesAccessControl, Net90.References.SystemIOPipesAccessControl, global::System.Guid.Parse("89b7e094-77e3-46e4-b5a5-1f04bd2b1d2c"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.Pipes.dll
         /// </summary>
-        public static ReferenceInfo SystemIOPipes => new ReferenceInfo("System.IO.Pipes.dll", Resources.SystemIOPipes, Net90.References.SystemIOPipes, global::System.Guid.Parse("3a5f3df7-5f84-4f22-95ed-702630274094"));
+        public static ReferenceInfo SystemIOPipes => new ReferenceInfo("System.IO.Pipes.dll", Resources.SystemIOPipes, Net90.References.SystemIOPipes, global::System.Guid.Parse("d051784f-75c7-4e70-b766-12e4655f829b"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.IO.UnmanagedMemoryStream.dll
         /// </summary>
-        public static ReferenceInfo SystemIOUnmanagedMemoryStream => new ReferenceInfo("System.IO.UnmanagedMemoryStream.dll", Resources.SystemIOUnmanagedMemoryStream, Net90.References.SystemIOUnmanagedMemoryStream, global::System.Guid.Parse("78a28c46-3bd6-4d8e-981f-740ebf696917"));
+        public static ReferenceInfo SystemIOUnmanagedMemoryStream => new ReferenceInfo("System.IO.UnmanagedMemoryStream.dll", Resources.SystemIOUnmanagedMemoryStream, Net90.References.SystemIOUnmanagedMemoryStream, global::System.Guid.Parse("25cc519e-9a80-4cd4-bd58-85079a17b48d"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Linq.dll
         /// </summary>
-        public static ReferenceInfo SystemLinq => new ReferenceInfo("System.Linq.dll", Resources.SystemLinq, Net90.References.SystemLinq, global::System.Guid.Parse("5251dfcd-c88f-4aaf-9e54-e50cacd47110"));
+        public static ReferenceInfo SystemLinq => new ReferenceInfo("System.Linq.dll", Resources.SystemLinq, Net90.References.SystemLinq, global::System.Guid.Parse("a3564a06-7cd1-4e27-8744-6c5d0db4366f"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Linq.Expressions.dll
         /// </summary>
-        public static ReferenceInfo SystemLinqExpressions => new ReferenceInfo("System.Linq.Expressions.dll", Resources.SystemLinqExpressions, Net90.References.SystemLinqExpressions, global::System.Guid.Parse("51174548-3db9-4bc2-824d-56b4d2043ea2"));
+        public static ReferenceInfo SystemLinqExpressions => new ReferenceInfo("System.Linq.Expressions.dll", Resources.SystemLinqExpressions, Net90.References.SystemLinqExpressions, global::System.Guid.Parse("48993239-d04b-41bd-ad1d-105ecf2cd028"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Linq.Parallel.dll
         /// </summary>
-        public static ReferenceInfo SystemLinqParallel => new ReferenceInfo("System.Linq.Parallel.dll", Resources.SystemLinqParallel, Net90.References.SystemLinqParallel, global::System.Guid.Parse("cbc0b05c-cc89-4362-a67f-07b031100198"));
+        public static ReferenceInfo SystemLinqParallel => new ReferenceInfo("System.Linq.Parallel.dll", Resources.SystemLinqParallel, Net90.References.SystemLinqParallel, global::System.Guid.Parse("0bed1f24-bad7-4fb7-b448-cbf9878456ad"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Linq.Queryable.dll
         /// </summary>
-        public static ReferenceInfo SystemLinqQueryable => new ReferenceInfo("System.Linq.Queryable.dll", Resources.SystemLinqQueryable, Net90.References.SystemLinqQueryable, global::System.Guid.Parse("76d303ef-4be5-4cbe-8a68-206b74373f5b"));
+        public static ReferenceInfo SystemLinqQueryable => new ReferenceInfo("System.Linq.Queryable.dll", Resources.SystemLinqQueryable, Net90.References.SystemLinqQueryable, global::System.Guid.Parse("0ca9e5dc-8a68-4dd6-9407-9ca37d52c044"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Memory.dll
         /// </summary>
-        public static ReferenceInfo SystemMemory => new ReferenceInfo("System.Memory.dll", Resources.SystemMemory, Net90.References.SystemMemory, global::System.Guid.Parse("22eb61be-9e0b-4501-b7f2-0be745c7197d"));
+        public static ReferenceInfo SystemMemory => new ReferenceInfo("System.Memory.dll", Resources.SystemMemory, Net90.References.SystemMemory, global::System.Guid.Parse("a967698e-b6b3-4593-8e70-80b431a9a355"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.dll
         /// </summary>
-        public static ReferenceInfo SystemNet => new ReferenceInfo("System.Net.dll", Resources.SystemNet, Net90.References.SystemNet, global::System.Guid.Parse("0aeabd41-7ff9-45fe-b67e-47ba83d56cb0"));
+        public static ReferenceInfo SystemNet => new ReferenceInfo("System.Net.dll", Resources.SystemNet, Net90.References.SystemNet, global::System.Guid.Parse("48777b07-0218-4a44-b3d8-f2a9a8f8ab47"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Http.dll
         /// </summary>
-        public static ReferenceInfo SystemNetHttp => new ReferenceInfo("System.Net.Http.dll", Resources.SystemNetHttp, Net90.References.SystemNetHttp, global::System.Guid.Parse("28715bc8-ee0c-435f-a0d3-c54ba3da5fc2"));
+        public static ReferenceInfo SystemNetHttp => new ReferenceInfo("System.Net.Http.dll", Resources.SystemNetHttp, Net90.References.SystemNetHttp, global::System.Guid.Parse("f37d0d59-d540-4eb3-9687-17ea03cf43dd"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Http.Json.dll
         /// </summary>
-        public static ReferenceInfo SystemNetHttpJson => new ReferenceInfo("System.Net.Http.Json.dll", Resources.SystemNetHttpJson, Net90.References.SystemNetHttpJson, global::System.Guid.Parse("ecfce77f-ecc6-4e70-acbb-218a2959c2f6"));
+        public static ReferenceInfo SystemNetHttpJson => new ReferenceInfo("System.Net.Http.Json.dll", Resources.SystemNetHttpJson, Net90.References.SystemNetHttpJson, global::System.Guid.Parse("81f7bb92-e341-472c-b388-06c1feb0e8ca"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.HttpListener.dll
         /// </summary>
-        public static ReferenceInfo SystemNetHttpListener => new ReferenceInfo("System.Net.HttpListener.dll", Resources.SystemNetHttpListener, Net90.References.SystemNetHttpListener, global::System.Guid.Parse("43619b0a-7c82-46e2-8b01-33747aa8fed7"));
+        public static ReferenceInfo SystemNetHttpListener => new ReferenceInfo("System.Net.HttpListener.dll", Resources.SystemNetHttpListener, Net90.References.SystemNetHttpListener, global::System.Guid.Parse("f640665d-2e46-4c69-91d4-3115ad2c8cd7"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Mail.dll
         /// </summary>
-        public static ReferenceInfo SystemNetMail => new ReferenceInfo("System.Net.Mail.dll", Resources.SystemNetMail, Net90.References.SystemNetMail, global::System.Guid.Parse("cf56402f-8072-465a-9363-e84d1c6c31ce"));
+        public static ReferenceInfo SystemNetMail => new ReferenceInfo("System.Net.Mail.dll", Resources.SystemNetMail, Net90.References.SystemNetMail, global::System.Guid.Parse("cbf8b2db-b3ba-4891-bcf4-9ed30e8cacea"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.NameResolution.dll
         /// </summary>
-        public static ReferenceInfo SystemNetNameResolution => new ReferenceInfo("System.Net.NameResolution.dll", Resources.SystemNetNameResolution, Net90.References.SystemNetNameResolution, global::System.Guid.Parse("c85f8bba-7f53-4010-b1ae-da9aec405b93"));
+        public static ReferenceInfo SystemNetNameResolution => new ReferenceInfo("System.Net.NameResolution.dll", Resources.SystemNetNameResolution, Net90.References.SystemNetNameResolution, global::System.Guid.Parse("0fb618d7-b063-4972-a726-3bbf4575536a"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.NetworkInformation.dll
         /// </summary>
-        public static ReferenceInfo SystemNetNetworkInformation => new ReferenceInfo("System.Net.NetworkInformation.dll", Resources.SystemNetNetworkInformation, Net90.References.SystemNetNetworkInformation, global::System.Guid.Parse("0cf2664a-062a-46d7-844f-783fc8498bb4"));
+        public static ReferenceInfo SystemNetNetworkInformation => new ReferenceInfo("System.Net.NetworkInformation.dll", Resources.SystemNetNetworkInformation, Net90.References.SystemNetNetworkInformation, global::System.Guid.Parse("3cdc611c-416b-4550-b7a2-882dd873c7a5"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Ping.dll
         /// </summary>
-        public static ReferenceInfo SystemNetPing => new ReferenceInfo("System.Net.Ping.dll", Resources.SystemNetPing, Net90.References.SystemNetPing, global::System.Guid.Parse("2c783868-a74a-406e-90de-c168b2d95136"));
+        public static ReferenceInfo SystemNetPing => new ReferenceInfo("System.Net.Ping.dll", Resources.SystemNetPing, Net90.References.SystemNetPing, global::System.Guid.Parse("3d1cbe77-71dc-4ae2-88a0-a68ad8a62f8e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Primitives.dll
         /// </summary>
-        public static ReferenceInfo SystemNetPrimitives => new ReferenceInfo("System.Net.Primitives.dll", Resources.SystemNetPrimitives, Net90.References.SystemNetPrimitives, global::System.Guid.Parse("6e3204d1-e6ca-45aa-9325-09d82e468a87"));
+        public static ReferenceInfo SystemNetPrimitives => new ReferenceInfo("System.Net.Primitives.dll", Resources.SystemNetPrimitives, Net90.References.SystemNetPrimitives, global::System.Guid.Parse("fbc7d239-889b-4a6e-9700-a631385a2591"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Quic.dll
         /// </summary>
-        public static ReferenceInfo SystemNetQuic => new ReferenceInfo("System.Net.Quic.dll", Resources.SystemNetQuic, Net90.References.SystemNetQuic, global::System.Guid.Parse("0a3645c8-ddc9-49c5-aa02-73bbfae47bfd"));
+        public static ReferenceInfo SystemNetQuic => new ReferenceInfo("System.Net.Quic.dll", Resources.SystemNetQuic, Net90.References.SystemNetQuic, global::System.Guid.Parse("832be000-226b-46ac-81ab-4a9544528b6b"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Requests.dll
         /// </summary>
-        public static ReferenceInfo SystemNetRequests => new ReferenceInfo("System.Net.Requests.dll", Resources.SystemNetRequests, Net90.References.SystemNetRequests, global::System.Guid.Parse("8957755d-f380-47ac-9bdc-402298fe3153"));
+        public static ReferenceInfo SystemNetRequests => new ReferenceInfo("System.Net.Requests.dll", Resources.SystemNetRequests, Net90.References.SystemNetRequests, global::System.Guid.Parse("701d614c-54ff-4651-a4ce-b45dfbf991f5"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Security.dll
         /// </summary>
-        public static ReferenceInfo SystemNetSecurity => new ReferenceInfo("System.Net.Security.dll", Resources.SystemNetSecurity, Net90.References.SystemNetSecurity, global::System.Guid.Parse("c9001978-75f9-451b-ab11-e1d59df612a7"));
+        public static ReferenceInfo SystemNetSecurity => new ReferenceInfo("System.Net.Security.dll", Resources.SystemNetSecurity, Net90.References.SystemNetSecurity, global::System.Guid.Parse("2198db71-b38f-4c02-8112-90d7dc42136b"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.ServicePoint.dll
         /// </summary>
-        public static ReferenceInfo SystemNetServicePoint => new ReferenceInfo("System.Net.ServicePoint.dll", Resources.SystemNetServicePoint, Net90.References.SystemNetServicePoint, global::System.Guid.Parse("26982446-8358-458f-af96-868809609227"));
+        public static ReferenceInfo SystemNetServicePoint => new ReferenceInfo("System.Net.ServicePoint.dll", Resources.SystemNetServicePoint, Net90.References.SystemNetServicePoint, global::System.Guid.Parse("e9056301-fd80-4858-8a7a-a9102748ee69"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.Sockets.dll
         /// </summary>
-        public static ReferenceInfo SystemNetSockets => new ReferenceInfo("System.Net.Sockets.dll", Resources.SystemNetSockets, Net90.References.SystemNetSockets, global::System.Guid.Parse("453aa752-6ef6-4796-8516-4d450162e2d4"));
+        public static ReferenceInfo SystemNetSockets => new ReferenceInfo("System.Net.Sockets.dll", Resources.SystemNetSockets, Net90.References.SystemNetSockets, global::System.Guid.Parse("5fded80a-1fbe-4da7-acc1-8c13117bde73"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.WebClient.dll
         /// </summary>
-        public static ReferenceInfo SystemNetWebClient => new ReferenceInfo("System.Net.WebClient.dll", Resources.SystemNetWebClient, Net90.References.SystemNetWebClient, global::System.Guid.Parse("7c43d47a-4ab3-4d51-8ec1-bfd832abcb20"));
+        public static ReferenceInfo SystemNetWebClient => new ReferenceInfo("System.Net.WebClient.dll", Resources.SystemNetWebClient, Net90.References.SystemNetWebClient, global::System.Guid.Parse("d7b30867-5b97-4dc5-aaf7-76784a05b272"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.WebHeaderCollection.dll
         /// </summary>
-        public static ReferenceInfo SystemNetWebHeaderCollection => new ReferenceInfo("System.Net.WebHeaderCollection.dll", Resources.SystemNetWebHeaderCollection, Net90.References.SystemNetWebHeaderCollection, global::System.Guid.Parse("663caf0c-78b4-4b8f-a411-c1b824b230a1"));
+        public static ReferenceInfo SystemNetWebHeaderCollection => new ReferenceInfo("System.Net.WebHeaderCollection.dll", Resources.SystemNetWebHeaderCollection, Net90.References.SystemNetWebHeaderCollection, global::System.Guid.Parse("989570f6-4a8f-44a0-ad52-10f70a4ecaf0"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.WebProxy.dll
         /// </summary>
-        public static ReferenceInfo SystemNetWebProxy => new ReferenceInfo("System.Net.WebProxy.dll", Resources.SystemNetWebProxy, Net90.References.SystemNetWebProxy, global::System.Guid.Parse("d3a9d726-d835-4963-993d-6b73560e8473"));
+        public static ReferenceInfo SystemNetWebProxy => new ReferenceInfo("System.Net.WebProxy.dll", Resources.SystemNetWebProxy, Net90.References.SystemNetWebProxy, global::System.Guid.Parse("f3e8be98-0a59-4d9a-b43d-e4720d334917"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.WebSockets.Client.dll
         /// </summary>
-        public static ReferenceInfo SystemNetWebSocketsClient => new ReferenceInfo("System.Net.WebSockets.Client.dll", Resources.SystemNetWebSocketsClient, Net90.References.SystemNetWebSocketsClient, global::System.Guid.Parse("c8a49233-a390-4471-bdba-7b3b15e80f18"));
+        public static ReferenceInfo SystemNetWebSocketsClient => new ReferenceInfo("System.Net.WebSockets.Client.dll", Resources.SystemNetWebSocketsClient, Net90.References.SystemNetWebSocketsClient, global::System.Guid.Parse("7c1a3c5b-3b37-437c-b749-38949dd10df2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Net.WebSockets.dll
         /// </summary>
-        public static ReferenceInfo SystemNetWebSockets => new ReferenceInfo("System.Net.WebSockets.dll", Resources.SystemNetWebSockets, Net90.References.SystemNetWebSockets, global::System.Guid.Parse("67fb2814-1383-4492-a210-64945ce99788"));
+        public static ReferenceInfo SystemNetWebSockets => new ReferenceInfo("System.Net.WebSockets.dll", Resources.SystemNetWebSockets, Net90.References.SystemNetWebSockets, global::System.Guid.Parse("34745b18-5ba5-4ad7-9743-398c1f5d2bf1"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Numerics.dll
         /// </summary>
-        public static ReferenceInfo SystemNumerics => new ReferenceInfo("System.Numerics.dll", Resources.SystemNumerics, Net90.References.SystemNumerics, global::System.Guid.Parse("04ac73c5-2dd9-43e4-8e8e-0a72a6efc3cd"));
+        public static ReferenceInfo SystemNumerics => new ReferenceInfo("System.Numerics.dll", Resources.SystemNumerics, Net90.References.SystemNumerics, global::System.Guid.Parse("f63d8ab9-1b97-45a5-a5d6-2c09d36db8c4"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Numerics.Vectors.dll
         /// </summary>
-        public static ReferenceInfo SystemNumericsVectors => new ReferenceInfo("System.Numerics.Vectors.dll", Resources.SystemNumericsVectors, Net90.References.SystemNumericsVectors, global::System.Guid.Parse("16203810-1a3e-4998-a9af-c6ac21dda424"));
+        public static ReferenceInfo SystemNumericsVectors => new ReferenceInfo("System.Numerics.Vectors.dll", Resources.SystemNumericsVectors, Net90.References.SystemNumericsVectors, global::System.Guid.Parse("372b489b-10ab-47d8-8194-935c9f22b11e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ObjectModel.dll
         /// </summary>
-        public static ReferenceInfo SystemObjectModel => new ReferenceInfo("System.ObjectModel.dll", Resources.SystemObjectModel, Net90.References.SystemObjectModel, global::System.Guid.Parse("c37796f4-166c-4d05-8e6a-2477800281c4"));
+        public static ReferenceInfo SystemObjectModel => new ReferenceInfo("System.ObjectModel.dll", Resources.SystemObjectModel, Net90.References.SystemObjectModel, global::System.Guid.Parse("ab03bd6c-5625-4884-b021-7bd95434d6f5"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.DispatchProxy.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionDispatchProxy => new ReferenceInfo("System.Reflection.DispatchProxy.dll", Resources.SystemReflectionDispatchProxy, Net90.References.SystemReflectionDispatchProxy, global::System.Guid.Parse("739f1fcf-b2f4-4ab1-b635-e42d6b941236"));
+        public static ReferenceInfo SystemReflectionDispatchProxy => new ReferenceInfo("System.Reflection.DispatchProxy.dll", Resources.SystemReflectionDispatchProxy, Net90.References.SystemReflectionDispatchProxy, global::System.Guid.Parse("1343a5eb-5325-448b-ab4e-a61f7b1076e5"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.dll
         /// </summary>
-        public static ReferenceInfo SystemReflection => new ReferenceInfo("System.Reflection.dll", Resources.SystemReflection, Net90.References.SystemReflection, global::System.Guid.Parse("5abd3528-91df-4cb7-9c35-bf3331e68573"));
+        public static ReferenceInfo SystemReflection => new ReferenceInfo("System.Reflection.dll", Resources.SystemReflection, Net90.References.SystemReflection, global::System.Guid.Parse("f9490446-ebda-4263-9e35-9e04134c6ede"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.Emit.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionEmit => new ReferenceInfo("System.Reflection.Emit.dll", Resources.SystemReflectionEmit, Net90.References.SystemReflectionEmit, global::System.Guid.Parse("d66b8df1-0f5e-4224-aff2-409cda0676a7"));
+        public static ReferenceInfo SystemReflectionEmit => new ReferenceInfo("System.Reflection.Emit.dll", Resources.SystemReflectionEmit, Net90.References.SystemReflectionEmit, global::System.Guid.Parse("8e3cdf61-914f-4c30-a3b8-d15cef8eba15"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.Emit.ILGeneration.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionEmitILGeneration => new ReferenceInfo("System.Reflection.Emit.ILGeneration.dll", Resources.SystemReflectionEmitILGeneration, Net90.References.SystemReflectionEmitILGeneration, global::System.Guid.Parse("5ccf4521-d07a-47f9-b850-1797db41aff0"));
+        public static ReferenceInfo SystemReflectionEmitILGeneration => new ReferenceInfo("System.Reflection.Emit.ILGeneration.dll", Resources.SystemReflectionEmitILGeneration, Net90.References.SystemReflectionEmitILGeneration, global::System.Guid.Parse("37d77c42-3d8d-4944-a852-c9277f7abd93"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.Emit.Lightweight.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionEmitLightweight => new ReferenceInfo("System.Reflection.Emit.Lightweight.dll", Resources.SystemReflectionEmitLightweight, Net90.References.SystemReflectionEmitLightweight, global::System.Guid.Parse("3c0fbf83-6dde-446a-8050-03185776fc32"));
+        public static ReferenceInfo SystemReflectionEmitLightweight => new ReferenceInfo("System.Reflection.Emit.Lightweight.dll", Resources.SystemReflectionEmitLightweight, Net90.References.SystemReflectionEmitLightweight, global::System.Guid.Parse("b4165208-bdfe-4b48-ae24-7e01cfd24ecf"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.Extensions.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionExtensions => new ReferenceInfo("System.Reflection.Extensions.dll", Resources.SystemReflectionExtensions, Net90.References.SystemReflectionExtensions, global::System.Guid.Parse("444b671e-7f76-465c-8051-07bfb8fcdb7d"));
+        public static ReferenceInfo SystemReflectionExtensions => new ReferenceInfo("System.Reflection.Extensions.dll", Resources.SystemReflectionExtensions, Net90.References.SystemReflectionExtensions, global::System.Guid.Parse("3dd74a91-7ccd-4d4f-974d-2669d39e30d6"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.Metadata.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionMetadata => new ReferenceInfo("System.Reflection.Metadata.dll", Resources.SystemReflectionMetadata, Net90.References.SystemReflectionMetadata, global::System.Guid.Parse("f4a8867c-7266-4ceb-845d-532f58147fb8"));
+        public static ReferenceInfo SystemReflectionMetadata => new ReferenceInfo("System.Reflection.Metadata.dll", Resources.SystemReflectionMetadata, Net90.References.SystemReflectionMetadata, global::System.Guid.Parse("b5f23585-7586-4a06-a621-40ef5db76247"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.Primitives.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionPrimitives => new ReferenceInfo("System.Reflection.Primitives.dll", Resources.SystemReflectionPrimitives, Net90.References.SystemReflectionPrimitives, global::System.Guid.Parse("7ae84d90-ffb0-48d8-b909-d3f4c9e1cfbb"));
+        public static ReferenceInfo SystemReflectionPrimitives => new ReferenceInfo("System.Reflection.Primitives.dll", Resources.SystemReflectionPrimitives, Net90.References.SystemReflectionPrimitives, global::System.Guid.Parse("1ebff9f5-4bc4-4a6f-bc3d-16b198696fd2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Reflection.TypeExtensions.dll
         /// </summary>
-        public static ReferenceInfo SystemReflectionTypeExtensions => new ReferenceInfo("System.Reflection.TypeExtensions.dll", Resources.SystemReflectionTypeExtensions, Net90.References.SystemReflectionTypeExtensions, global::System.Guid.Parse("5841a700-a7f1-4d9e-95e7-d96832dc9c60"));
+        public static ReferenceInfo SystemReflectionTypeExtensions => new ReferenceInfo("System.Reflection.TypeExtensions.dll", Resources.SystemReflectionTypeExtensions, Net90.References.SystemReflectionTypeExtensions, global::System.Guid.Parse("83aeda08-cd4a-441e-bcb5-db4aba962e7e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Resources.Reader.dll
         /// </summary>
-        public static ReferenceInfo SystemResourcesReader => new ReferenceInfo("System.Resources.Reader.dll", Resources.SystemResourcesReader, Net90.References.SystemResourcesReader, global::System.Guid.Parse("995f9890-a3b3-4079-8565-c8a3444c7461"));
+        public static ReferenceInfo SystemResourcesReader => new ReferenceInfo("System.Resources.Reader.dll", Resources.SystemResourcesReader, Net90.References.SystemResourcesReader, global::System.Guid.Parse("62a27abd-88c9-4487-8cbd-af44477cebaa"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Resources.ResourceManager.dll
         /// </summary>
-        public static ReferenceInfo SystemResourcesResourceManager => new ReferenceInfo("System.Resources.ResourceManager.dll", Resources.SystemResourcesResourceManager, Net90.References.SystemResourcesResourceManager, global::System.Guid.Parse("6bbf0e09-6dca-4f55-90a7-8f95b085efd0"));
+        public static ReferenceInfo SystemResourcesResourceManager => new ReferenceInfo("System.Resources.ResourceManager.dll", Resources.SystemResourcesResourceManager, Net90.References.SystemResourcesResourceManager, global::System.Guid.Parse("62f2ed2c-0883-4aef-b0d7-66e28565b3f8"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Resources.Writer.dll
         /// </summary>
-        public static ReferenceInfo SystemResourcesWriter => new ReferenceInfo("System.Resources.Writer.dll", Resources.SystemResourcesWriter, Net90.References.SystemResourcesWriter, global::System.Guid.Parse("35187a40-176e-49a8-a34a-0331ce1beb6c"));
+        public static ReferenceInfo SystemResourcesWriter => new ReferenceInfo("System.Resources.Writer.dll", Resources.SystemResourcesWriter, Net90.References.SystemResourcesWriter, global::System.Guid.Parse("094511e2-5a90-4b43-b497-fbcced0a5ea0"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.CompilerServices.Unsafe.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeCompilerServicesUnsafe => new ReferenceInfo("System.Runtime.CompilerServices.Unsafe.dll", Resources.SystemRuntimeCompilerServicesUnsafe, Net90.References.SystemRuntimeCompilerServicesUnsafe, global::System.Guid.Parse("611a3f92-f521-46b6-aa6c-e45f4f00b1df"));
+        public static ReferenceInfo SystemRuntimeCompilerServicesUnsafe => new ReferenceInfo("System.Runtime.CompilerServices.Unsafe.dll", Resources.SystemRuntimeCompilerServicesUnsafe, Net90.References.SystemRuntimeCompilerServicesUnsafe, global::System.Guid.Parse("5df98470-6587-4fa6-90bb-bd3e9197dc7d"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.CompilerServices.VisualC.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeCompilerServicesVisualC => new ReferenceInfo("System.Runtime.CompilerServices.VisualC.dll", Resources.SystemRuntimeCompilerServicesVisualC, Net90.References.SystemRuntimeCompilerServicesVisualC, global::System.Guid.Parse("6ec14de9-36c3-48e6-b1a0-647b8c15a619"));
+        public static ReferenceInfo SystemRuntimeCompilerServicesVisualC => new ReferenceInfo("System.Runtime.CompilerServices.VisualC.dll", Resources.SystemRuntimeCompilerServicesVisualC, Net90.References.SystemRuntimeCompilerServicesVisualC, global::System.Guid.Parse("559f929b-f0f3-4e17-b29f-7c3b39d37893"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntime => new ReferenceInfo("System.Runtime.dll", Resources.SystemRuntime, Net90.References.SystemRuntime, global::System.Guid.Parse("1fe2259e-279b-429b-9c13-734c12f5bf76"));
+        public static ReferenceInfo SystemRuntime => new ReferenceInfo("System.Runtime.dll", Resources.SystemRuntime, Net90.References.SystemRuntime, global::System.Guid.Parse("1457e562-1391-4dd0-b7c9-f8c35b242c2f"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Extensions.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeExtensions => new ReferenceInfo("System.Runtime.Extensions.dll", Resources.SystemRuntimeExtensions, Net90.References.SystemRuntimeExtensions, global::System.Guid.Parse("d6c390bb-9b48-441e-b402-60294e03b70a"));
+        public static ReferenceInfo SystemRuntimeExtensions => new ReferenceInfo("System.Runtime.Extensions.dll", Resources.SystemRuntimeExtensions, Net90.References.SystemRuntimeExtensions, global::System.Guid.Parse("9872edd9-f43c-47f7-aa2b-64103d942bb1"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Handles.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeHandles => new ReferenceInfo("System.Runtime.Handles.dll", Resources.SystemRuntimeHandles, Net90.References.SystemRuntimeHandles, global::System.Guid.Parse("aca44e0d-e5b8-48ed-930e-c8e7067a8cea"));
+        public static ReferenceInfo SystemRuntimeHandles => new ReferenceInfo("System.Runtime.Handles.dll", Resources.SystemRuntimeHandles, Net90.References.SystemRuntimeHandles, global::System.Guid.Parse("bb42925c-04ef-4116-bd71-eee1a6808cce"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.InteropServices.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeInteropServices => new ReferenceInfo("System.Runtime.InteropServices.dll", Resources.SystemRuntimeInteropServices, Net90.References.SystemRuntimeInteropServices, global::System.Guid.Parse("fa9244c4-d126-4dc4-ab5a-864fdff78dc6"));
+        public static ReferenceInfo SystemRuntimeInteropServices => new ReferenceInfo("System.Runtime.InteropServices.dll", Resources.SystemRuntimeInteropServices, Net90.References.SystemRuntimeInteropServices, global::System.Guid.Parse("17ec4526-e7ba-4c5e-9d49-4fd2842401c1"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.InteropServices.JavaScript.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeInteropServicesJavaScript => new ReferenceInfo("System.Runtime.InteropServices.JavaScript.dll", Resources.SystemRuntimeInteropServicesJavaScript, Net90.References.SystemRuntimeInteropServicesJavaScript, global::System.Guid.Parse("e9899df0-edaa-422d-903f-428c3b7a54a2"));
+        public static ReferenceInfo SystemRuntimeInteropServicesJavaScript => new ReferenceInfo("System.Runtime.InteropServices.JavaScript.dll", Resources.SystemRuntimeInteropServicesJavaScript, Net90.References.SystemRuntimeInteropServicesJavaScript, global::System.Guid.Parse("8f645015-39c3-42a6-bcb4-fde692739a30"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.InteropServices.RuntimeInformation.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeInteropServicesRuntimeInformation => new ReferenceInfo("System.Runtime.InteropServices.RuntimeInformation.dll", Resources.SystemRuntimeInteropServicesRuntimeInformation, Net90.References.SystemRuntimeInteropServicesRuntimeInformation, global::System.Guid.Parse("1b79c72c-40cd-490d-bb1c-3ba36a865f57"));
+        public static ReferenceInfo SystemRuntimeInteropServicesRuntimeInformation => new ReferenceInfo("System.Runtime.InteropServices.RuntimeInformation.dll", Resources.SystemRuntimeInteropServicesRuntimeInformation, Net90.References.SystemRuntimeInteropServicesRuntimeInformation, global::System.Guid.Parse("5f7c965c-0f4f-471c-a7fc-a9b53c664559"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Intrinsics.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeIntrinsics => new ReferenceInfo("System.Runtime.Intrinsics.dll", Resources.SystemRuntimeIntrinsics, Net90.References.SystemRuntimeIntrinsics, global::System.Guid.Parse("b02d1977-eeaa-4c43-b6c0-0b95b74c6078"));
+        public static ReferenceInfo SystemRuntimeIntrinsics => new ReferenceInfo("System.Runtime.Intrinsics.dll", Resources.SystemRuntimeIntrinsics, Net90.References.SystemRuntimeIntrinsics, global::System.Guid.Parse("aae5b6dc-bae1-4d52-a2e1-1ef16d69ea53"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Loader.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeLoader => new ReferenceInfo("System.Runtime.Loader.dll", Resources.SystemRuntimeLoader, Net90.References.SystemRuntimeLoader, global::System.Guid.Parse("ec134043-dccd-47bb-95fa-47588f3fd34d"));
+        public static ReferenceInfo SystemRuntimeLoader => new ReferenceInfo("System.Runtime.Loader.dll", Resources.SystemRuntimeLoader, Net90.References.SystemRuntimeLoader, global::System.Guid.Parse("ebcfcc71-f9d9-444f-b453-14b06e787365"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Numerics.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeNumerics => new ReferenceInfo("System.Runtime.Numerics.dll", Resources.SystemRuntimeNumerics, Net90.References.SystemRuntimeNumerics, global::System.Guid.Parse("1675c72b-3ad3-4b9b-bdeb-744335984960"));
+        public static ReferenceInfo SystemRuntimeNumerics => new ReferenceInfo("System.Runtime.Numerics.dll", Resources.SystemRuntimeNumerics, Net90.References.SystemRuntimeNumerics, global::System.Guid.Parse("d39dde32-466c-48a0-abf0-7a3275960600"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Serialization.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeSerialization => new ReferenceInfo("System.Runtime.Serialization.dll", Resources.SystemRuntimeSerialization, Net90.References.SystemRuntimeSerialization, global::System.Guid.Parse("f9a3255f-5575-45d1-8ea4-675c1f1f926b"));
+        public static ReferenceInfo SystemRuntimeSerialization => new ReferenceInfo("System.Runtime.Serialization.dll", Resources.SystemRuntimeSerialization, Net90.References.SystemRuntimeSerialization, global::System.Guid.Parse("7e7e8ffb-62a1-4bf0-b1ca-841b1d4eac67"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Serialization.Formatters.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeSerializationFormatters => new ReferenceInfo("System.Runtime.Serialization.Formatters.dll", Resources.SystemRuntimeSerializationFormatters, Net90.References.SystemRuntimeSerializationFormatters, global::System.Guid.Parse("7a2bc1a1-9613-4660-acf0-ef5e8cee9884"));
+        public static ReferenceInfo SystemRuntimeSerializationFormatters => new ReferenceInfo("System.Runtime.Serialization.Formatters.dll", Resources.SystemRuntimeSerializationFormatters, Net90.References.SystemRuntimeSerializationFormatters, global::System.Guid.Parse("8664ae2a-18b2-4adb-949b-02dbd6bfab23"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Serialization.Json.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeSerializationJson => new ReferenceInfo("System.Runtime.Serialization.Json.dll", Resources.SystemRuntimeSerializationJson, Net90.References.SystemRuntimeSerializationJson, global::System.Guid.Parse("8198e9e8-181b-4523-9024-9a23485dacfa"));
+        public static ReferenceInfo SystemRuntimeSerializationJson => new ReferenceInfo("System.Runtime.Serialization.Json.dll", Resources.SystemRuntimeSerializationJson, Net90.References.SystemRuntimeSerializationJson, global::System.Guid.Parse("53e29463-3131-4d92-9984-36fea94727e2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Serialization.Primitives.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeSerializationPrimitives => new ReferenceInfo("System.Runtime.Serialization.Primitives.dll", Resources.SystemRuntimeSerializationPrimitives, Net90.References.SystemRuntimeSerializationPrimitives, global::System.Guid.Parse("a3bff65b-2e0c-43e5-920b-2e976bec4a09"));
+        public static ReferenceInfo SystemRuntimeSerializationPrimitives => new ReferenceInfo("System.Runtime.Serialization.Primitives.dll", Resources.SystemRuntimeSerializationPrimitives, Net90.References.SystemRuntimeSerializationPrimitives, global::System.Guid.Parse("772d8e85-02a6-4bbb-bf24-926fdc2e3f75"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Runtime.Serialization.Xml.dll
         /// </summary>
-        public static ReferenceInfo SystemRuntimeSerializationXml => new ReferenceInfo("System.Runtime.Serialization.Xml.dll", Resources.SystemRuntimeSerializationXml, Net90.References.SystemRuntimeSerializationXml, global::System.Guid.Parse("60c8eb6a-2a6a-40f8-91fe-ac2e043be71b"));
+        public static ReferenceInfo SystemRuntimeSerializationXml => new ReferenceInfo("System.Runtime.Serialization.Xml.dll", Resources.SystemRuntimeSerializationXml, Net90.References.SystemRuntimeSerializationXml, global::System.Guid.Parse("639e7fd5-e5f5-41b8-82b4-e7242b7563ab"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.AccessControl.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityAccessControl => new ReferenceInfo("System.Security.AccessControl.dll", Resources.SystemSecurityAccessControl, Net90.References.SystemSecurityAccessControl, global::System.Guid.Parse("35fcdaaf-370c-40ae-82fb-3f838a15691f"));
+        public static ReferenceInfo SystemSecurityAccessControl => new ReferenceInfo("System.Security.AccessControl.dll", Resources.SystemSecurityAccessControl, Net90.References.SystemSecurityAccessControl, global::System.Guid.Parse("084c6743-dd2c-437b-a418-5453011062d5"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Claims.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityClaims => new ReferenceInfo("System.Security.Claims.dll", Resources.SystemSecurityClaims, Net90.References.SystemSecurityClaims, global::System.Guid.Parse("da578a15-b45e-4700-bc1a-045e07fba4b1"));
+        public static ReferenceInfo SystemSecurityClaims => new ReferenceInfo("System.Security.Claims.dll", Resources.SystemSecurityClaims, Net90.References.SystemSecurityClaims, global::System.Guid.Parse("0de258e5-2e26-4fef-ab77-f7b9fdf48905"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.Algorithms.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptographyAlgorithms => new ReferenceInfo("System.Security.Cryptography.Algorithms.dll", Resources.SystemSecurityCryptographyAlgorithms, Net90.References.SystemSecurityCryptographyAlgorithms, global::System.Guid.Parse("3cd4dc68-f33f-4b4f-843f-92af3643298b"));
+        public static ReferenceInfo SystemSecurityCryptographyAlgorithms => new ReferenceInfo("System.Security.Cryptography.Algorithms.dll", Resources.SystemSecurityCryptographyAlgorithms, Net90.References.SystemSecurityCryptographyAlgorithms, global::System.Guid.Parse("f5878bec-c200-4eea-b557-1f8cde0ae520"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.Cng.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptographyCng => new ReferenceInfo("System.Security.Cryptography.Cng.dll", Resources.SystemSecurityCryptographyCng, Net90.References.SystemSecurityCryptographyCng, global::System.Guid.Parse("8b3c5201-627b-4674-8435-92e614a4d1eb"));
+        public static ReferenceInfo SystemSecurityCryptographyCng => new ReferenceInfo("System.Security.Cryptography.Cng.dll", Resources.SystemSecurityCryptographyCng, Net90.References.SystemSecurityCryptographyCng, global::System.Guid.Parse("fdbfd7d6-4a9f-47ef-abe8-197f961cad99"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.Csp.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptographyCsp => new ReferenceInfo("System.Security.Cryptography.Csp.dll", Resources.SystemSecurityCryptographyCsp, Net90.References.SystemSecurityCryptographyCsp, global::System.Guid.Parse("cfa2de34-3939-44e8-a23e-b3df3ac63a06"));
+        public static ReferenceInfo SystemSecurityCryptographyCsp => new ReferenceInfo("System.Security.Cryptography.Csp.dll", Resources.SystemSecurityCryptographyCsp, Net90.References.SystemSecurityCryptographyCsp, global::System.Guid.Parse("f7a5103f-2ca4-415f-b3d5-52721b450dcc"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptography => new ReferenceInfo("System.Security.Cryptography.dll", Resources.SystemSecurityCryptography, Net90.References.SystemSecurityCryptography, global::System.Guid.Parse("bee88f96-2524-4436-9240-76c70dab97d4"));
+        public static ReferenceInfo SystemSecurityCryptography => new ReferenceInfo("System.Security.Cryptography.dll", Resources.SystemSecurityCryptography, Net90.References.SystemSecurityCryptography, global::System.Guid.Parse("67b97ff8-bd59-4e41-a47e-74240104fd3f"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.Encoding.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptographyEncoding => new ReferenceInfo("System.Security.Cryptography.Encoding.dll", Resources.SystemSecurityCryptographyEncoding, Net90.References.SystemSecurityCryptographyEncoding, global::System.Guid.Parse("2905ecd6-084f-4474-af77-ddb1d616c848"));
+        public static ReferenceInfo SystemSecurityCryptographyEncoding => new ReferenceInfo("System.Security.Cryptography.Encoding.dll", Resources.SystemSecurityCryptographyEncoding, Net90.References.SystemSecurityCryptographyEncoding, global::System.Guid.Parse("51e76de6-f882-4e76-8ae2-be4a68e51215"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.OpenSsl.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptographyOpenSsl => new ReferenceInfo("System.Security.Cryptography.OpenSsl.dll", Resources.SystemSecurityCryptographyOpenSsl, Net90.References.SystemSecurityCryptographyOpenSsl, global::System.Guid.Parse("47222aa0-4aa9-43fe-af8f-80f547d3bbe6"));
+        public static ReferenceInfo SystemSecurityCryptographyOpenSsl => new ReferenceInfo("System.Security.Cryptography.OpenSsl.dll", Resources.SystemSecurityCryptographyOpenSsl, Net90.References.SystemSecurityCryptographyOpenSsl, global::System.Guid.Parse("84cda978-4ae0-4691-a7c2-823fa62af866"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.Primitives.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptographyPrimitives => new ReferenceInfo("System.Security.Cryptography.Primitives.dll", Resources.SystemSecurityCryptographyPrimitives, Net90.References.SystemSecurityCryptographyPrimitives, global::System.Guid.Parse("af65ab63-a76f-4f27-a341-4cc3602c808f"));
+        public static ReferenceInfo SystemSecurityCryptographyPrimitives => new ReferenceInfo("System.Security.Cryptography.Primitives.dll", Resources.SystemSecurityCryptographyPrimitives, Net90.References.SystemSecurityCryptographyPrimitives, global::System.Guid.Parse("bd28c4b6-a044-42d6-815d-402076eb0b0e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Cryptography.X509Certificates.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityCryptographyX509Certificates => new ReferenceInfo("System.Security.Cryptography.X509Certificates.dll", Resources.SystemSecurityCryptographyX509Certificates, Net90.References.SystemSecurityCryptographyX509Certificates, global::System.Guid.Parse("645a70fd-6535-491c-aed2-1afc24bc4da3"));
+        public static ReferenceInfo SystemSecurityCryptographyX509Certificates => new ReferenceInfo("System.Security.Cryptography.X509Certificates.dll", Resources.SystemSecurityCryptographyX509Certificates, Net90.References.SystemSecurityCryptographyX509Certificates, global::System.Guid.Parse("2911adcc-7fc3-4551-9c85-9ca67b3e41c3"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurity => new ReferenceInfo("System.Security.dll", Resources.SystemSecurity, Net90.References.SystemSecurity, global::System.Guid.Parse("1b64b2ec-64d5-4d8a-9303-b1f8570d70e6"));
+        public static ReferenceInfo SystemSecurity => new ReferenceInfo("System.Security.dll", Resources.SystemSecurity, Net90.References.SystemSecurity, global::System.Guid.Parse("2a54bdd1-01d6-4332-94dc-e0fe20ff3498"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Principal.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityPrincipal => new ReferenceInfo("System.Security.Principal.dll", Resources.SystemSecurityPrincipal, Net90.References.SystemSecurityPrincipal, global::System.Guid.Parse("7483693c-9960-4396-afa9-cf58adc4259d"));
+        public static ReferenceInfo SystemSecurityPrincipal => new ReferenceInfo("System.Security.Principal.dll", Resources.SystemSecurityPrincipal, Net90.References.SystemSecurityPrincipal, global::System.Guid.Parse("8bb212d5-5a69-442c-b37a-3c512c589184"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.Principal.Windows.dll
         /// </summary>
-        public static ReferenceInfo SystemSecurityPrincipalWindows => new ReferenceInfo("System.Security.Principal.Windows.dll", Resources.SystemSecurityPrincipalWindows, Net90.References.SystemSecurityPrincipalWindows, global::System.Guid.Parse("6f758b1c-6d62-4133-ac8e-7045bd4c6dc6"));
+        public static ReferenceInfo SystemSecurityPrincipalWindows => new ReferenceInfo("System.Security.Principal.Windows.dll", Resources.SystemSecurityPrincipalWindows, Net90.References.SystemSecurityPrincipalWindows, global::System.Guid.Parse("a3696074-6e9f-40ad-b5d7-b2051d02ba4b"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Security.SecureString.dll
         /// </summary>
-        public static ReferenceInfo SystemSecuritySecureString => new ReferenceInfo("System.Security.SecureString.dll", Resources.SystemSecuritySecureString, Net90.References.SystemSecuritySecureString, global::System.Guid.Parse("9b598274-8751-438b-8b8d-4dad5b74a1eb"));
+        public static ReferenceInfo SystemSecuritySecureString => new ReferenceInfo("System.Security.SecureString.dll", Resources.SystemSecuritySecureString, Net90.References.SystemSecuritySecureString, global::System.Guid.Parse("3ce1ad7d-38b8-47a4-a397-0ceba462e900"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ServiceModel.Web.dll
         /// </summary>
-        public static ReferenceInfo SystemServiceModelWeb => new ReferenceInfo("System.ServiceModel.Web.dll", Resources.SystemServiceModelWeb, Net90.References.SystemServiceModelWeb, global::System.Guid.Parse("1d3f03bc-7cb6-4889-97b0-b125be9a6407"));
+        public static ReferenceInfo SystemServiceModelWeb => new ReferenceInfo("System.ServiceModel.Web.dll", Resources.SystemServiceModelWeb, Net90.References.SystemServiceModelWeb, global::System.Guid.Parse("6800967d-5fac-4f53-886b-d55c4f9e33a0"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ServiceProcess.dll
         /// </summary>
-        public static ReferenceInfo SystemServiceProcess => new ReferenceInfo("System.ServiceProcess.dll", Resources.SystemServiceProcess, Net90.References.SystemServiceProcess, global::System.Guid.Parse("cb24ca1e-5fb3-4eaa-8e38-2b4cff3d0d08"));
+        public static ReferenceInfo SystemServiceProcess => new ReferenceInfo("System.ServiceProcess.dll", Resources.SystemServiceProcess, Net90.References.SystemServiceProcess, global::System.Guid.Parse("e4359e86-d3b5-4f7a-915e-373cf768d37f"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Text.Encoding.CodePages.dll
         /// </summary>
-        public static ReferenceInfo SystemTextEncodingCodePages => new ReferenceInfo("System.Text.Encoding.CodePages.dll", Resources.SystemTextEncodingCodePages, Net90.References.SystemTextEncodingCodePages, global::System.Guid.Parse("0d28ebba-3e9f-45b2-bcc2-363f981f7cc1"));
+        public static ReferenceInfo SystemTextEncodingCodePages => new ReferenceInfo("System.Text.Encoding.CodePages.dll", Resources.SystemTextEncodingCodePages, Net90.References.SystemTextEncodingCodePages, global::System.Guid.Parse("700d925d-63ee-4717-a0f5-6875029305be"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Text.Encoding.dll
         /// </summary>
-        public static ReferenceInfo SystemTextEncoding => new ReferenceInfo("System.Text.Encoding.dll", Resources.SystemTextEncoding, Net90.References.SystemTextEncoding, global::System.Guid.Parse("bcd4e6f3-3b2d-483f-b950-5eeae2814d8c"));
+        public static ReferenceInfo SystemTextEncoding => new ReferenceInfo("System.Text.Encoding.dll", Resources.SystemTextEncoding, Net90.References.SystemTextEncoding, global::System.Guid.Parse("2b146ffc-eedb-47a0-82d2-8eab1189c27e"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Text.Encoding.Extensions.dll
         /// </summary>
-        public static ReferenceInfo SystemTextEncodingExtensions => new ReferenceInfo("System.Text.Encoding.Extensions.dll", Resources.SystemTextEncodingExtensions, Net90.References.SystemTextEncodingExtensions, global::System.Guid.Parse("5f24f9c2-62d3-4d82-a9c4-6901893727b8"));
+        public static ReferenceInfo SystemTextEncodingExtensions => new ReferenceInfo("System.Text.Encoding.Extensions.dll", Resources.SystemTextEncodingExtensions, Net90.References.SystemTextEncodingExtensions, global::System.Guid.Parse("c5cb7f43-90ec-4ae9-8fa8-e9693b6ce029"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Text.Encodings.Web.dll
         /// </summary>
-        public static ReferenceInfo SystemTextEncodingsWeb => new ReferenceInfo("System.Text.Encodings.Web.dll", Resources.SystemTextEncodingsWeb, Net90.References.SystemTextEncodingsWeb, global::System.Guid.Parse("17bdc9a4-8139-4111-829f-c508929558c3"));
+        public static ReferenceInfo SystemTextEncodingsWeb => new ReferenceInfo("System.Text.Encodings.Web.dll", Resources.SystemTextEncodingsWeb, Net90.References.SystemTextEncodingsWeb, global::System.Guid.Parse("8521df4d-5af7-4ff2-8cc9-cc44fb3b8f32"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Text.Json.dll
         /// </summary>
-        public static ReferenceInfo SystemTextJson => new ReferenceInfo("System.Text.Json.dll", Resources.SystemTextJson, Net90.References.SystemTextJson, global::System.Guid.Parse("eb49fe9a-8742-4c71-8497-dc53dd71377e"));
+        public static ReferenceInfo SystemTextJson => new ReferenceInfo("System.Text.Json.dll", Resources.SystemTextJson, Net90.References.SystemTextJson, global::System.Guid.Parse("9126df5e-fb30-4d92-a454-744ba525825c"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Text.RegularExpressions.dll
         /// </summary>
-        public static ReferenceInfo SystemTextRegularExpressions => new ReferenceInfo("System.Text.RegularExpressions.dll", Resources.SystemTextRegularExpressions, Net90.References.SystemTextRegularExpressions, global::System.Guid.Parse("fa6f9f6e-79b0-47d3-8310-c2a98bda8c87"));
+        public static ReferenceInfo SystemTextRegularExpressions => new ReferenceInfo("System.Text.RegularExpressions.dll", Resources.SystemTextRegularExpressions, Net90.References.SystemTextRegularExpressions, global::System.Guid.Parse("175af119-b999-4cc7-8c41-ced7c0defbea"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Channels.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingChannels => new ReferenceInfo("System.Threading.Channels.dll", Resources.SystemThreadingChannels, Net90.References.SystemThreadingChannels, global::System.Guid.Parse("052f5ba2-2af2-4fbe-9911-6cf71c2a3842"));
+        public static ReferenceInfo SystemThreadingChannels => new ReferenceInfo("System.Threading.Channels.dll", Resources.SystemThreadingChannels, Net90.References.SystemThreadingChannels, global::System.Guid.Parse("d9a73c5a-52f8-45c5-88f8-46f3bbfd6016"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.dll
         /// </summary>
-        public static ReferenceInfo SystemThreading => new ReferenceInfo("System.Threading.dll", Resources.SystemThreading, Net90.References.SystemThreading, global::System.Guid.Parse("62d8987e-c08d-46ab-86ae-aa63a328a79c"));
+        public static ReferenceInfo SystemThreading => new ReferenceInfo("System.Threading.dll", Resources.SystemThreading, Net90.References.SystemThreading, global::System.Guid.Parse("4e853ae4-446b-480e-9490-d1567debe518"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Overlapped.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingOverlapped => new ReferenceInfo("System.Threading.Overlapped.dll", Resources.SystemThreadingOverlapped, Net90.References.SystemThreadingOverlapped, global::System.Guid.Parse("a8427483-f8c2-464d-8002-e1f625af1578"));
+        public static ReferenceInfo SystemThreadingOverlapped => new ReferenceInfo("System.Threading.Overlapped.dll", Resources.SystemThreadingOverlapped, Net90.References.SystemThreadingOverlapped, global::System.Guid.Parse("51dc137e-6f3b-4ce5-92d4-de6cd703c62f"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Dataflow.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingTasksDataflow => new ReferenceInfo("System.Threading.Tasks.Dataflow.dll", Resources.SystemThreadingTasksDataflow, Net90.References.SystemThreadingTasksDataflow, global::System.Guid.Parse("2c451068-38fb-456c-9934-a423b9ea5e68"));
+        public static ReferenceInfo SystemThreadingTasksDataflow => new ReferenceInfo("System.Threading.Tasks.Dataflow.dll", Resources.SystemThreadingTasksDataflow, Net90.References.SystemThreadingTasksDataflow, global::System.Guid.Parse("beb49e4d-2ec5-4273-89c9-3f377fae6da0"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingTasks => new ReferenceInfo("System.Threading.Tasks.dll", Resources.SystemThreadingTasks, Net90.References.SystemThreadingTasks, global::System.Guid.Parse("5d277a32-fa38-496a-b048-bdb6c6490440"));
+        public static ReferenceInfo SystemThreadingTasks => new ReferenceInfo("System.Threading.Tasks.dll", Resources.SystemThreadingTasks, Net90.References.SystemThreadingTasks, global::System.Guid.Parse("6f058c46-a65e-4102-a031-e21dbc37755c"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, Net90.References.SystemThreadingTasksExtensions, global::System.Guid.Parse("f7307795-0d17-4060-b663-ceca6838ce42"));
+        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, Net90.References.SystemThreadingTasksExtensions, global::System.Guid.Parse("20dcee48-43d8-45ea-8164-1de62ee712f0"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Parallel.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingTasksParallel => new ReferenceInfo("System.Threading.Tasks.Parallel.dll", Resources.SystemThreadingTasksParallel, Net90.References.SystemThreadingTasksParallel, global::System.Guid.Parse("937c51fc-081f-42ba-8271-681d7479722e"));
+        public static ReferenceInfo SystemThreadingTasksParallel => new ReferenceInfo("System.Threading.Tasks.Parallel.dll", Resources.SystemThreadingTasksParallel, Net90.References.SystemThreadingTasksParallel, global::System.Guid.Parse("07756faa-680b-45df-a8b0-621e7047f9ec"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Thread.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingThread => new ReferenceInfo("System.Threading.Thread.dll", Resources.SystemThreadingThread, Net90.References.SystemThreadingThread, global::System.Guid.Parse("25d1caae-a87c-4e28-a244-8635dad3d370"));
+        public static ReferenceInfo SystemThreadingThread => new ReferenceInfo("System.Threading.Thread.dll", Resources.SystemThreadingThread, Net90.References.SystemThreadingThread, global::System.Guid.Parse("a54d72c9-7e92-4cf1-a907-b66404563963"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.ThreadPool.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingThreadPool => new ReferenceInfo("System.Threading.ThreadPool.dll", Resources.SystemThreadingThreadPool, Net90.References.SystemThreadingThreadPool, global::System.Guid.Parse("f4813c23-4e91-4fa0-b32f-1cce7600568a"));
+        public static ReferenceInfo SystemThreadingThreadPool => new ReferenceInfo("System.Threading.ThreadPool.dll", Resources.SystemThreadingThreadPool, Net90.References.SystemThreadingThreadPool, global::System.Guid.Parse("e7d00697-9478-4931-877b-85aef518585d"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Timer.dll
         /// </summary>
-        public static ReferenceInfo SystemThreadingTimer => new ReferenceInfo("System.Threading.Timer.dll", Resources.SystemThreadingTimer, Net90.References.SystemThreadingTimer, global::System.Guid.Parse("8ac52318-e3ce-4beb-96cf-cddb9cdb2c47"));
+        public static ReferenceInfo SystemThreadingTimer => new ReferenceInfo("System.Threading.Timer.dll", Resources.SystemThreadingTimer, Net90.References.SystemThreadingTimer, global::System.Guid.Parse("aff3f0ea-4f95-46ee-8ba8-ddb4c5078b32"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Transactions.dll
         /// </summary>
-        public static ReferenceInfo SystemTransactions => new ReferenceInfo("System.Transactions.dll", Resources.SystemTransactions, Net90.References.SystemTransactions, global::System.Guid.Parse("195b939c-dd58-4ccd-831d-4831fb6263ae"));
+        public static ReferenceInfo SystemTransactions => new ReferenceInfo("System.Transactions.dll", Resources.SystemTransactions, Net90.References.SystemTransactions, global::System.Guid.Parse("b036bc45-aa26-4fec-b076-3e0a240e9ed8"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Transactions.Local.dll
         /// </summary>
-        public static ReferenceInfo SystemTransactionsLocal => new ReferenceInfo("System.Transactions.Local.dll", Resources.SystemTransactionsLocal, Net90.References.SystemTransactionsLocal, global::System.Guid.Parse("551b1cff-2099-43c4-a588-54b0281702d5"));
+        public static ReferenceInfo SystemTransactionsLocal => new ReferenceInfo("System.Transactions.Local.dll", Resources.SystemTransactionsLocal, Net90.References.SystemTransactionsLocal, global::System.Guid.Parse("67fd49d5-c10d-4084-bc70-7983dd0a30b5"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.ValueTuple.dll
         /// </summary>
-        public static ReferenceInfo SystemValueTuple => new ReferenceInfo("System.ValueTuple.dll", Resources.SystemValueTuple, Net90.References.SystemValueTuple, global::System.Guid.Parse("eaf89c96-0ff9-494b-8bba-c8845c1e3ca6"));
+        public static ReferenceInfo SystemValueTuple => new ReferenceInfo("System.ValueTuple.dll", Resources.SystemValueTuple, Net90.References.SystemValueTuple, global::System.Guid.Parse("7976f384-9cd2-469e-a1b1-4b3ef69cfe1a"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Web.dll
         /// </summary>
-        public static ReferenceInfo SystemWeb => new ReferenceInfo("System.Web.dll", Resources.SystemWeb, Net90.References.SystemWeb, global::System.Guid.Parse("0d56b242-9f90-4c9e-925b-51c8ae27b4e6"));
+        public static ReferenceInfo SystemWeb => new ReferenceInfo("System.Web.dll", Resources.SystemWeb, Net90.References.SystemWeb, global::System.Guid.Parse("de56f046-673a-4d80-bf5b-5f7afda979ca"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Web.HttpUtility.dll
         /// </summary>
-        public static ReferenceInfo SystemWebHttpUtility => new ReferenceInfo("System.Web.HttpUtility.dll", Resources.SystemWebHttpUtility, Net90.References.SystemWebHttpUtility, global::System.Guid.Parse("f28aa66a-91c9-407b-abd6-463183003067"));
+        public static ReferenceInfo SystemWebHttpUtility => new ReferenceInfo("System.Web.HttpUtility.dll", Resources.SystemWebHttpUtility, Net90.References.SystemWebHttpUtility, global::System.Guid.Parse("4f135004-d2bb-4404-add2-4fb29e011470"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Windows.dll
         /// </summary>
-        public static ReferenceInfo SystemWindows => new ReferenceInfo("System.Windows.dll", Resources.SystemWindows, Net90.References.SystemWindows, global::System.Guid.Parse("72f3847b-c33c-48c7-bb5c-325e3ed17e91"));
+        public static ReferenceInfo SystemWindows => new ReferenceInfo("System.Windows.dll", Resources.SystemWindows, Net90.References.SystemWindows, global::System.Guid.Parse("8202316e-9523-46d4-a12c-8d4f195fddb9"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.dll
         /// </summary>
-        public static ReferenceInfo SystemXml => new ReferenceInfo("System.Xml.dll", Resources.SystemXml, Net90.References.SystemXml, global::System.Guid.Parse("55292126-5331-4a5b-b688-776cefaab7e5"));
+        public static ReferenceInfo SystemXml => new ReferenceInfo("System.Xml.dll", Resources.SystemXml, Net90.References.SystemXml, global::System.Guid.Parse("5e2fb4ca-1222-4361-b467-11dffd1e27d7"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.Linq.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlLinq => new ReferenceInfo("System.Xml.Linq.dll", Resources.SystemXmlLinq, Net90.References.SystemXmlLinq, global::System.Guid.Parse("83ed6c85-6b25-4a30-a73f-eb33ddbe3280"));
+        public static ReferenceInfo SystemXmlLinq => new ReferenceInfo("System.Xml.Linq.dll", Resources.SystemXmlLinq, Net90.References.SystemXmlLinq, global::System.Guid.Parse("511488f9-549d-4bd2-9ced-8d93b92827b2"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.ReaderWriter.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlReaderWriter => new ReferenceInfo("System.Xml.ReaderWriter.dll", Resources.SystemXmlReaderWriter, Net90.References.SystemXmlReaderWriter, global::System.Guid.Parse("ade21e99-ad83-4baa-bfeb-494aae75ebcb"));
+        public static ReferenceInfo SystemXmlReaderWriter => new ReferenceInfo("System.Xml.ReaderWriter.dll", Resources.SystemXmlReaderWriter, Net90.References.SystemXmlReaderWriter, global::System.Guid.Parse("fbf4e534-64ed-432b-955b-ae0c6fe814c0"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.Serialization.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlSerialization => new ReferenceInfo("System.Xml.Serialization.dll", Resources.SystemXmlSerialization, Net90.References.SystemXmlSerialization, global::System.Guid.Parse("38d7f976-bc70-4785-9cfa-511b77bf5e5b"));
+        public static ReferenceInfo SystemXmlSerialization => new ReferenceInfo("System.Xml.Serialization.dll", Resources.SystemXmlSerialization, Net90.References.SystemXmlSerialization, global::System.Guid.Parse("235c8aab-827d-4752-8fa3-ea0793d515bf"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.XDocument.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlXDocument => new ReferenceInfo("System.Xml.XDocument.dll", Resources.SystemXmlXDocument, Net90.References.SystemXmlXDocument, global::System.Guid.Parse("b9821e5f-e36d-4518-b607-f174f6085475"));
+        public static ReferenceInfo SystemXmlXDocument => new ReferenceInfo("System.Xml.XDocument.dll", Resources.SystemXmlXDocument, Net90.References.SystemXmlXDocument, global::System.Guid.Parse("b83be3ae-e9a1-4101-8be6-57610d8d56aa"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.XmlDocument.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlXmlDocument => new ReferenceInfo("System.Xml.XmlDocument.dll", Resources.SystemXmlXmlDocument, Net90.References.SystemXmlXmlDocument, global::System.Guid.Parse("efb919d1-d695-4ba3-87ba-fa2553d45fbd"));
+        public static ReferenceInfo SystemXmlXmlDocument => new ReferenceInfo("System.Xml.XmlDocument.dll", Resources.SystemXmlXmlDocument, Net90.References.SystemXmlXmlDocument, global::System.Guid.Parse("7ae651db-e12b-461c-b19f-b1abb01529a4"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.XmlSerializer.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlXmlSerializer => new ReferenceInfo("System.Xml.XmlSerializer.dll", Resources.SystemXmlXmlSerializer, Net90.References.SystemXmlXmlSerializer, global::System.Guid.Parse("58a8212b-b648-4500-8081-339f678f3ca6"));
+        public static ReferenceInfo SystemXmlXmlSerializer => new ReferenceInfo("System.Xml.XmlSerializer.dll", Resources.SystemXmlXmlSerializer, Net90.References.SystemXmlXmlSerializer, global::System.Guid.Parse("e199d8c6-7329-46c3-87fe-b9997efd0e5c"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.XPath.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlXPath => new ReferenceInfo("System.Xml.XPath.dll", Resources.SystemXmlXPath, Net90.References.SystemXmlXPath, global::System.Guid.Parse("bb4c6bbe-4779-4a51-9553-2f76dab5ed5b"));
+        public static ReferenceInfo SystemXmlXPath => new ReferenceInfo("System.Xml.XPath.dll", Resources.SystemXmlXPath, Net90.References.SystemXmlXPath, global::System.Guid.Parse("1a44c558-a71c-447e-b1c0-7c4305bef261"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Xml.XPath.XDocument.dll
         /// </summary>
-        public static ReferenceInfo SystemXmlXPathXDocument => new ReferenceInfo("System.Xml.XPath.XDocument.dll", Resources.SystemXmlXPathXDocument, Net90.References.SystemXmlXPathXDocument, global::System.Guid.Parse("ee9f724d-0c63-4da7-aa5d-806ba951d4c7"));
+        public static ReferenceInfo SystemXmlXPathXDocument => new ReferenceInfo("System.Xml.XPath.XDocument.dll", Resources.SystemXmlXPathXDocument, Net90.References.SystemXmlXPathXDocument, global::System.Guid.Parse("de643c4f-a8ca-4824-82db-bc6bd7ba3d95"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for WindowsBase.dll
         /// </summary>
-        public static ReferenceInfo WindowsBase => new ReferenceInfo("WindowsBase.dll", Resources.WindowsBase, Net90.References.WindowsBase, global::System.Guid.Parse("6d4ebda7-f15d-4751-b20d-ac42118240a6"));
+        public static ReferenceInfo WindowsBase => new ReferenceInfo("WindowsBase.dll", Resources.WindowsBase, Net90.References.WindowsBase, global::System.Guid.Parse("ecbf3d71-b7e4-48ce-9515-af9391668b2a"));
         private static ImmutableArray<ReferenceInfo> _all;
         public static ImmutableArray<ReferenceInfo> All
         {
@@ -1877,6 +1888,7 @@ public static partial class Net90
                         SystemIOFileSystemWatcher,
                         SystemIOIsolatedStorage,
                         SystemIOMemoryMappedFiles,
+                        SystemIOPipelines,
                         SystemIOPipesAccessControl,
                         SystemIOPipes,
                         SystemIOUnmanagedMemoryStream,
@@ -2963,6 +2975,23 @@ public static partial class Net90
                     _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net90)");
                 }
                 return _SystemIOMemoryMappedFiles;
+            }
+        }
+
+        private static PortableExecutableReference? _SystemIOPipelines;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for System.IO.Pipelines.dll
+        /// </summary>
+        public static PortableExecutableReference SystemIOPipelines
+        {
+            get
+            {
+                if (_SystemIOPipelines is null)
+                {
+                    _SystemIOPipelines = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipelines).GetReference(filePath: "System.IO.Pipelines.dll", display: "System.IO.Pipelines (net90)");
+                }
+                return _SystemIOPipelines;
             }
         }
 
@@ -4834,6 +4863,7 @@ public static partial class Net90
                         SystemIOFileSystemWatcher,
                         SystemIOIsolatedStorage,
                         SystemIOMemoryMappedFiles,
+                        SystemIOPipelines,
                         SystemIOPipesAccessControl,
                         SystemIOPipes,
                         SystemIOUnmanagedMemoryStream,

--- a/Basic.Reference.Assemblies.Net90/Generated.targets
+++ b/Basic.Reference.Assemblies.Net90/Generated.targets
@@ -1,654 +1,658 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\Microsoft.CSharp.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\Microsoft.CSharp.dll" WithCulture="false">
             <LogicalName>net90.Microsoft.CSharp</LogicalName>
             <Link>Resources\net90\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\Microsoft.VisualBasic.Core.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\Microsoft.VisualBasic.Core.dll" WithCulture="false">
             <LogicalName>net90.Microsoft.VisualBasic.Core</LogicalName>
             <Link>Resources\net90\Microsoft.VisualBasic.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\Microsoft.VisualBasic.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\Microsoft.VisualBasic.dll" WithCulture="false">
             <LogicalName>net90.Microsoft.VisualBasic</LogicalName>
             <Link>Resources\net90\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\Microsoft.Win32.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\Microsoft.Win32.Primitives.dll" WithCulture="false">
             <LogicalName>net90.Microsoft.Win32.Primitives</LogicalName>
             <Link>Resources\net90\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\Microsoft.Win32.Registry.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\Microsoft.Win32.Registry.dll" WithCulture="false">
             <LogicalName>net90.Microsoft.Win32.Registry</LogicalName>
             <Link>Resources\net90\Microsoft.Win32.Registry.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\mscorlib.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\mscorlib.dll" WithCulture="false">
             <LogicalName>net90.mscorlib</LogicalName>
             <Link>Resources\net90\mscorlib.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\netstandard.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\netstandard.dll" WithCulture="false">
             <LogicalName>net90.netstandard</LogicalName>
             <Link>Resources\net90\netstandard.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.AppContext.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.AppContext.dll" WithCulture="false">
             <LogicalName>net90.System.AppContext</LogicalName>
             <Link>Resources\net90\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Buffers.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Buffers.dll" WithCulture="false">
             <LogicalName>net90.System.Buffers</LogicalName>
             <Link>Resources\net90\System.Buffers.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Collections.Concurrent.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Collections.Concurrent.dll" WithCulture="false">
             <LogicalName>net90.System.Collections.Concurrent</LogicalName>
             <Link>Resources\net90\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Collections.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Collections.dll" WithCulture="false">
             <LogicalName>net90.System.Collections</LogicalName>
             <Link>Resources\net90\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Collections.Immutable.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Collections.Immutable.dll" WithCulture="false">
             <LogicalName>net90.System.Collections.Immutable</LogicalName>
             <Link>Resources\net90\System.Collections.Immutable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Collections.NonGeneric.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Collections.NonGeneric.dll" WithCulture="false">
             <LogicalName>net90.System.Collections.NonGeneric</LogicalName>
             <Link>Resources\net90\System.Collections.NonGeneric.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Collections.Specialized.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Collections.Specialized.dll" WithCulture="false">
             <LogicalName>net90.System.Collections.Specialized</LogicalName>
             <Link>Resources\net90\System.Collections.Specialized.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ComponentModel.Annotations.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ComponentModel.Annotations.dll" WithCulture="false">
             <LogicalName>net90.System.ComponentModel.Annotations</LogicalName>
             <Link>Resources\net90\System.ComponentModel.Annotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ComponentModel.DataAnnotations.dll" WithCulture="false">
             <LogicalName>net90.System.ComponentModel.DataAnnotations</LogicalName>
             <Link>Resources\net90\System.ComponentModel.DataAnnotations.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ComponentModel.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ComponentModel.dll" WithCulture="false">
             <LogicalName>net90.System.ComponentModel</LogicalName>
             <Link>Resources\net90\System.ComponentModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ComponentModel.EventBasedAsync.dll" WithCulture="false">
             <LogicalName>net90.System.ComponentModel.EventBasedAsync</LogicalName>
             <Link>Resources\net90\System.ComponentModel.EventBasedAsync.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ComponentModel.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ComponentModel.Primitives.dll" WithCulture="false">
             <LogicalName>net90.System.ComponentModel.Primitives</LogicalName>
             <Link>Resources\net90\System.ComponentModel.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ComponentModel.TypeConverter.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ComponentModel.TypeConverter.dll" WithCulture="false">
             <LogicalName>net90.System.ComponentModel.TypeConverter</LogicalName>
             <Link>Resources\net90\System.ComponentModel.TypeConverter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Configuration.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Configuration.dll" WithCulture="false">
             <LogicalName>net90.System.Configuration</LogicalName>
             <Link>Resources\net90\System.Configuration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Console.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Console.dll" WithCulture="false">
             <LogicalName>net90.System.Console</LogicalName>
             <Link>Resources\net90\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Core.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Core.dll" WithCulture="false">
             <LogicalName>net90.System.Core</LogicalName>
             <Link>Resources\net90\System.Core.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Data.Common.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Data.Common.dll" WithCulture="false">
             <LogicalName>net90.System.Data.Common</LogicalName>
             <Link>Resources\net90\System.Data.Common.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Data.DataSetExtensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Data.DataSetExtensions.dll" WithCulture="false">
             <LogicalName>net90.System.Data.DataSetExtensions</LogicalName>
             <Link>Resources\net90\System.Data.DataSetExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Data.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Data.dll" WithCulture="false">
             <LogicalName>net90.System.Data</LogicalName>
             <Link>Resources\net90\System.Data.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.Contracts.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.Contracts.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.Contracts</LogicalName>
             <Link>Resources\net90\System.Diagnostics.Contracts.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.Debug.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.Debug.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.Debug</LogicalName>
             <Link>Resources\net90\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.DiagnosticSource.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.DiagnosticSource</LogicalName>
             <Link>Resources\net90\System.Diagnostics.DiagnosticSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.FileVersionInfo</LogicalName>
             <Link>Resources\net90\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.Process.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.Process.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.Process</LogicalName>
             <Link>Resources\net90\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.StackTrace.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.StackTrace.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.StackTrace</LogicalName>
             <Link>Resources\net90\System.Diagnostics.StackTrace.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.TextWriterTraceListener.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.TextWriterTraceListener</LogicalName>
             <Link>Resources\net90\System.Diagnostics.TextWriterTraceListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.Tools.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.Tools.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.Tools</LogicalName>
             <Link>Resources\net90\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.TraceSource.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.TraceSource.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.TraceSource</LogicalName>
             <Link>Resources\net90\System.Diagnostics.TraceSource.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Diagnostics.Tracing.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Diagnostics.Tracing.dll" WithCulture="false">
             <LogicalName>net90.System.Diagnostics.Tracing</LogicalName>
             <Link>Resources\net90\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.dll" WithCulture="false">
             <LogicalName>net90.System</LogicalName>
             <Link>Resources\net90\System.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Drawing.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Drawing.dll" WithCulture="false">
             <LogicalName>net90.System.Drawing</LogicalName>
             <Link>Resources\net90\System.Drawing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Drawing.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Drawing.Primitives.dll" WithCulture="false">
             <LogicalName>net90.System.Drawing.Primitives</LogicalName>
             <Link>Resources\net90\System.Drawing.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Dynamic.Runtime.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Dynamic.Runtime.dll" WithCulture="false">
             <LogicalName>net90.System.Dynamic.Runtime</LogicalName>
             <Link>Resources\net90\System.Dynamic.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Formats.Asn1.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Formats.Asn1.dll" WithCulture="false">
             <LogicalName>net90.System.Formats.Asn1</LogicalName>
             <Link>Resources\net90\System.Formats.Asn1.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Formats.Tar.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Formats.Tar.dll" WithCulture="false">
             <LogicalName>net90.System.Formats.Tar</LogicalName>
             <Link>Resources\net90\System.Formats.Tar.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Globalization.Calendars.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Globalization.Calendars.dll" WithCulture="false">
             <LogicalName>net90.System.Globalization.Calendars</LogicalName>
             <Link>Resources\net90\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Globalization.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Globalization.dll" WithCulture="false">
             <LogicalName>net90.System.Globalization</LogicalName>
             <Link>Resources\net90\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Globalization.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Globalization.Extensions.dll" WithCulture="false">
             <LogicalName>net90.System.Globalization.Extensions</LogicalName>
             <Link>Resources\net90\System.Globalization.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.Compression.Brotli.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.Compression.Brotli.dll" WithCulture="false">
             <LogicalName>net90.System.IO.Compression.Brotli</LogicalName>
             <Link>Resources\net90\System.IO.Compression.Brotli.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.Compression.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.Compression.dll" WithCulture="false">
             <LogicalName>net90.System.IO.Compression</LogicalName>
             <Link>Resources\net90\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.Compression.FileSystem.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.Compression.FileSystem.dll" WithCulture="false">
             <LogicalName>net90.System.IO.Compression.FileSystem</LogicalName>
             <Link>Resources\net90\System.IO.Compression.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.Compression.ZipFile.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.Compression.ZipFile.dll" WithCulture="false">
             <LogicalName>net90.System.IO.Compression.ZipFile</LogicalName>
             <Link>Resources\net90\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.dll" WithCulture="false">
             <LogicalName>net90.System.IO</LogicalName>
             <Link>Resources\net90\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.FileSystem.AccessControl.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.FileSystem.AccessControl.dll" WithCulture="false">
             <LogicalName>net90.System.IO.FileSystem.AccessControl</LogicalName>
             <Link>Resources\net90\System.IO.FileSystem.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.FileSystem.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.FileSystem.dll" WithCulture="false">
             <LogicalName>net90.System.IO.FileSystem</LogicalName>
             <Link>Resources\net90\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.FileSystem.DriveInfo.dll" WithCulture="false">
             <LogicalName>net90.System.IO.FileSystem.DriveInfo</LogicalName>
             <Link>Resources\net90\System.IO.FileSystem.DriveInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.FileSystem.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.FileSystem.Primitives.dll" WithCulture="false">
             <LogicalName>net90.System.IO.FileSystem.Primitives</LogicalName>
             <Link>Resources\net90\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.FileSystem.Watcher.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.FileSystem.Watcher.dll" WithCulture="false">
             <LogicalName>net90.System.IO.FileSystem.Watcher</LogicalName>
             <Link>Resources\net90\System.IO.FileSystem.Watcher.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.IsolatedStorage.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.IsolatedStorage.dll" WithCulture="false">
             <LogicalName>net90.System.IO.IsolatedStorage</LogicalName>
             <Link>Resources\net90\System.IO.IsolatedStorage.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.MemoryMappedFiles.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.MemoryMappedFiles.dll" WithCulture="false">
             <LogicalName>net90.System.IO.MemoryMappedFiles</LogicalName>
             <Link>Resources\net90\System.IO.MemoryMappedFiles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.Pipes.AccessControl.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.Pipelines.dll" WithCulture="false">
+            <LogicalName>net90.System.IO.Pipelines</LogicalName>
+            <Link>Resources\net90\System.IO.Pipelines.dll</Link>
+        </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.Pipes.AccessControl.dll" WithCulture="false">
             <LogicalName>net90.System.IO.Pipes.AccessControl</LogicalName>
             <Link>Resources\net90\System.IO.Pipes.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.Pipes.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.Pipes.dll" WithCulture="false">
             <LogicalName>net90.System.IO.Pipes</LogicalName>
             <Link>Resources\net90\System.IO.Pipes.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.IO.UnmanagedMemoryStream.dll" WithCulture="false">
             <LogicalName>net90.System.IO.UnmanagedMemoryStream</LogicalName>
             <Link>Resources\net90\System.IO.UnmanagedMemoryStream.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Linq.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Linq.dll" WithCulture="false">
             <LogicalName>net90.System.Linq</LogicalName>
             <Link>Resources\net90\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Linq.Expressions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Linq.Expressions.dll" WithCulture="false">
             <LogicalName>net90.System.Linq.Expressions</LogicalName>
             <Link>Resources\net90\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Linq.Parallel.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Linq.Parallel.dll" WithCulture="false">
             <LogicalName>net90.System.Linq.Parallel</LogicalName>
             <Link>Resources\net90\System.Linq.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Linq.Queryable.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Linq.Queryable.dll" WithCulture="false">
             <LogicalName>net90.System.Linq.Queryable</LogicalName>
             <Link>Resources\net90\System.Linq.Queryable.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Memory.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Memory.dll" WithCulture="false">
             <LogicalName>net90.System.Memory</LogicalName>
             <Link>Resources\net90\System.Memory.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.dll" WithCulture="false">
             <LogicalName>net90.System.Net</LogicalName>
             <Link>Resources\net90\System.Net.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Http.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Http.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Http</LogicalName>
             <Link>Resources\net90\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Http.Json.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Http.Json.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Http.Json</LogicalName>
             <Link>Resources\net90\System.Net.Http.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.HttpListener.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.HttpListener.dll" WithCulture="false">
             <LogicalName>net90.System.Net.HttpListener</LogicalName>
             <Link>Resources\net90\System.Net.HttpListener.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Mail.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Mail.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Mail</LogicalName>
             <Link>Resources\net90\System.Net.Mail.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.NameResolution.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.NameResolution.dll" WithCulture="false">
             <LogicalName>net90.System.Net.NameResolution</LogicalName>
             <Link>Resources\net90\System.Net.NameResolution.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.NetworkInformation.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.NetworkInformation.dll" WithCulture="false">
             <LogicalName>net90.System.Net.NetworkInformation</LogicalName>
             <Link>Resources\net90\System.Net.NetworkInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Ping.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Ping.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Ping</LogicalName>
             <Link>Resources\net90\System.Net.Ping.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Primitives.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Primitives</LogicalName>
             <Link>Resources\net90\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Quic.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Quic.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Quic</LogicalName>
             <Link>Resources\net90\System.Net.Quic.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Requests.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Requests.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Requests</LogicalName>
             <Link>Resources\net90\System.Net.Requests.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Security.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Security.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Security</LogicalName>
             <Link>Resources\net90\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.ServicePoint.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.ServicePoint.dll" WithCulture="false">
             <LogicalName>net90.System.Net.ServicePoint</LogicalName>
             <Link>Resources\net90\System.Net.ServicePoint.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.Sockets.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.Sockets.dll" WithCulture="false">
             <LogicalName>net90.System.Net.Sockets</LogicalName>
             <Link>Resources\net90\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.WebClient.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.WebClient.dll" WithCulture="false">
             <LogicalName>net90.System.Net.WebClient</LogicalName>
             <Link>Resources\net90\System.Net.WebClient.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.WebHeaderCollection.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.WebHeaderCollection.dll" WithCulture="false">
             <LogicalName>net90.System.Net.WebHeaderCollection</LogicalName>
             <Link>Resources\net90\System.Net.WebHeaderCollection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.WebProxy.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.WebProxy.dll" WithCulture="false">
             <LogicalName>net90.System.Net.WebProxy</LogicalName>
             <Link>Resources\net90\System.Net.WebProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.WebSockets.Client.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.WebSockets.Client.dll" WithCulture="false">
             <LogicalName>net90.System.Net.WebSockets.Client</LogicalName>
             <Link>Resources\net90\System.Net.WebSockets.Client.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Net.WebSockets.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Net.WebSockets.dll" WithCulture="false">
             <LogicalName>net90.System.Net.WebSockets</LogicalName>
             <Link>Resources\net90\System.Net.WebSockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Numerics.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Numerics.dll" WithCulture="false">
             <LogicalName>net90.System.Numerics</LogicalName>
             <Link>Resources\net90\System.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Numerics.Vectors.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Numerics.Vectors.dll" WithCulture="false">
             <LogicalName>net90.System.Numerics.Vectors</LogicalName>
             <Link>Resources\net90\System.Numerics.Vectors.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ObjectModel.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ObjectModel.dll" WithCulture="false">
             <LogicalName>net90.System.ObjectModel</LogicalName>
             <Link>Resources\net90\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.DispatchProxy.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.DispatchProxy.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.DispatchProxy</LogicalName>
             <Link>Resources\net90\System.Reflection.DispatchProxy.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection</LogicalName>
             <Link>Resources\net90\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.Emit.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.Emit.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.Emit</LogicalName>
             <Link>Resources\net90\System.Reflection.Emit.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.Emit.ILGeneration.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.Emit.ILGeneration</LogicalName>
             <Link>Resources\net90\System.Reflection.Emit.ILGeneration.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.Emit.Lightweight.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.Emit.Lightweight</LogicalName>
             <Link>Resources\net90\System.Reflection.Emit.Lightweight.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.Extensions.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.Extensions</LogicalName>
             <Link>Resources\net90\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.Metadata.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.Metadata.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.Metadata</LogicalName>
             <Link>Resources\net90\System.Reflection.Metadata.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.Primitives.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.Primitives</LogicalName>
             <Link>Resources\net90\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Reflection.TypeExtensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Reflection.TypeExtensions.dll" WithCulture="false">
             <LogicalName>net90.System.Reflection.TypeExtensions</LogicalName>
             <Link>Resources\net90\System.Reflection.TypeExtensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Resources.Reader.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Resources.Reader.dll" WithCulture="false">
             <LogicalName>net90.System.Resources.Reader</LogicalName>
             <Link>Resources\net90\System.Resources.Reader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Resources.ResourceManager.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Resources.ResourceManager.dll" WithCulture="false">
             <LogicalName>net90.System.Resources.ResourceManager</LogicalName>
             <Link>Resources\net90\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Resources.Writer.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Resources.Writer.dll" WithCulture="false">
             <LogicalName>net90.System.Resources.Writer</LogicalName>
             <Link>Resources\net90\System.Resources.Writer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.CompilerServices.Unsafe.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.CompilerServices.Unsafe</LogicalName>
             <Link>Resources\net90\System.Runtime.CompilerServices.Unsafe.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.CompilerServices.VisualC.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.CompilerServices.VisualC</LogicalName>
             <Link>Resources\net90\System.Runtime.CompilerServices.VisualC.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime</LogicalName>
             <Link>Resources\net90\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Extensions.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Extensions</LogicalName>
             <Link>Resources\net90\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Handles.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Handles.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Handles</LogicalName>
             <Link>Resources\net90\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.InteropServices.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.InteropServices.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.InteropServices</LogicalName>
             <Link>Resources\net90\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.InteropServices.JavaScript.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.InteropServices.JavaScript.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.InteropServices.JavaScript</LogicalName>
             <Link>Resources\net90\System.Runtime.InteropServices.JavaScript.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
             <Link>Resources\net90\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Intrinsics.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Intrinsics.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Intrinsics</LogicalName>
             <Link>Resources\net90\System.Runtime.Intrinsics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Loader.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Loader.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Loader</LogicalName>
             <Link>Resources\net90\System.Runtime.Loader.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Numerics.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Numerics.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Numerics</LogicalName>
             <Link>Resources\net90\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Serialization.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Serialization.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Serialization</LogicalName>
             <Link>Resources\net90\System.Runtime.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Serialization.Formatters.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Serialization.Formatters</LogicalName>
             <Link>Resources\net90\System.Runtime.Serialization.Formatters.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Serialization.Json.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Serialization.Json.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Serialization.Json</LogicalName>
             <Link>Resources\net90\System.Runtime.Serialization.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Serialization.Primitives</LogicalName>
             <Link>Resources\net90\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Runtime.Serialization.Xml.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Runtime.Serialization.Xml.dll" WithCulture="false">
             <LogicalName>net90.System.Runtime.Serialization.Xml</LogicalName>
             <Link>Resources\net90\System.Runtime.Serialization.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.AccessControl.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.AccessControl.dll" WithCulture="false">
             <LogicalName>net90.System.Security.AccessControl</LogicalName>
             <Link>Resources\net90\System.Security.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Claims.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Claims.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Claims</LogicalName>
             <Link>Resources\net90\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography.Algorithms</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.Cng.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.Cng.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography.Cng</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.Cng.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.Csp.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.Csp.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography.Csp</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.Encoding.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.Encoding.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography.Encoding</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.OpenSsl.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.OpenSsl.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography.OpenSsl</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.OpenSsl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.Primitives.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography.Primitives</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Cryptography.X509Certificates</LogicalName>
             <Link>Resources\net90\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.dll" WithCulture="false">
             <LogicalName>net90.System.Security</LogicalName>
             <Link>Resources\net90\System.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Principal.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Principal.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Principal</LogicalName>
             <Link>Resources\net90\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.Principal.Windows.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.Principal.Windows.dll" WithCulture="false">
             <LogicalName>net90.System.Security.Principal.Windows</LogicalName>
             <Link>Resources\net90\System.Security.Principal.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Security.SecureString.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Security.SecureString.dll" WithCulture="false">
             <LogicalName>net90.System.Security.SecureString</LogicalName>
             <Link>Resources\net90\System.Security.SecureString.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ServiceModel.Web.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ServiceModel.Web.dll" WithCulture="false">
             <LogicalName>net90.System.ServiceModel.Web</LogicalName>
             <Link>Resources\net90\System.ServiceModel.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ServiceProcess.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ServiceProcess.dll" WithCulture="false">
             <LogicalName>net90.System.ServiceProcess</LogicalName>
             <Link>Resources\net90\System.ServiceProcess.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Text.Encoding.CodePages.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Text.Encoding.CodePages.dll" WithCulture="false">
             <LogicalName>net90.System.Text.Encoding.CodePages</LogicalName>
             <Link>Resources\net90\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Text.Encoding.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Text.Encoding.dll" WithCulture="false">
             <LogicalName>net90.System.Text.Encoding</LogicalName>
             <Link>Resources\net90\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Text.Encoding.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Text.Encoding.Extensions.dll" WithCulture="false">
             <LogicalName>net90.System.Text.Encoding.Extensions</LogicalName>
             <Link>Resources\net90\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Text.Encodings.Web.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Text.Encodings.Web.dll" WithCulture="false">
             <LogicalName>net90.System.Text.Encodings.Web</LogicalName>
             <Link>Resources\net90\System.Text.Encodings.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Text.Json.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Text.Json.dll" WithCulture="false">
             <LogicalName>net90.System.Text.Json</LogicalName>
             <Link>Resources\net90\System.Text.Json.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Text.RegularExpressions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Text.RegularExpressions.dll" WithCulture="false">
             <LogicalName>net90.System.Text.RegularExpressions</LogicalName>
             <Link>Resources\net90\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Channels.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Channels.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Channels</LogicalName>
             <Link>Resources\net90\System.Threading.Channels.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.dll" WithCulture="false">
             <LogicalName>net90.System.Threading</LogicalName>
             <Link>Resources\net90\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Overlapped.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Overlapped.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Overlapped</LogicalName>
             <Link>Resources\net90\System.Threading.Overlapped.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Tasks.Dataflow.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Tasks.Dataflow</LogicalName>
             <Link>Resources\net90\System.Threading.Tasks.Dataflow.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Tasks.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Tasks.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Tasks</LogicalName>
             <Link>Resources\net90\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Tasks.Extensions</LogicalName>
             <Link>Resources\net90\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Tasks.Parallel.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Tasks.Parallel.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Tasks.Parallel</LogicalName>
             <Link>Resources\net90\System.Threading.Tasks.Parallel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Thread.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Thread.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Thread</LogicalName>
             <Link>Resources\net90\System.Threading.Thread.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.ThreadPool.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.ThreadPool.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.ThreadPool</LogicalName>
             <Link>Resources\net90\System.Threading.ThreadPool.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Threading.Timer.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Threading.Timer.dll" WithCulture="false">
             <LogicalName>net90.System.Threading.Timer</LogicalName>
             <Link>Resources\net90\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Transactions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Transactions.dll" WithCulture="false">
             <LogicalName>net90.System.Transactions</LogicalName>
             <Link>Resources\net90\System.Transactions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Transactions.Local.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Transactions.Local.dll" WithCulture="false">
             <LogicalName>net90.System.Transactions.Local</LogicalName>
             <Link>Resources\net90\System.Transactions.Local.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.ValueTuple.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.ValueTuple.dll" WithCulture="false">
             <LogicalName>net90.System.ValueTuple</LogicalName>
             <Link>Resources\net90\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Web.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Web.dll" WithCulture="false">
             <LogicalName>net90.System.Web</LogicalName>
             <Link>Resources\net90\System.Web.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Web.HttpUtility.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Web.HttpUtility.dll" WithCulture="false">
             <LogicalName>net90.System.Web.HttpUtility</LogicalName>
             <Link>Resources\net90\System.Web.HttpUtility.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Windows.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Windows.dll" WithCulture="false">
             <LogicalName>net90.System.Windows</LogicalName>
             <Link>Resources\net90\System.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.dll" WithCulture="false">
             <LogicalName>net90.System.Xml</LogicalName>
             <Link>Resources\net90\System.Xml.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.Linq.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.Linq.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.Linq</LogicalName>
             <Link>Resources\net90\System.Xml.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.ReaderWriter.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.ReaderWriter.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.ReaderWriter</LogicalName>
             <Link>Resources\net90\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.Serialization.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.Serialization.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.Serialization</LogicalName>
             <Link>Resources\net90\System.Xml.Serialization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.XDocument.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.XDocument.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.XDocument</LogicalName>
             <Link>Resources\net90\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.XmlDocument.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.XmlDocument.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.XmlDocument</LogicalName>
             <Link>Resources\net90\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.XmlSerializer.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.XmlSerializer.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.XmlSerializer</LogicalName>
             <Link>Resources\net90\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.XPath.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.XPath.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.XPath</LogicalName>
             <Link>Resources\net90\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\System.Xml.XPath.XDocument.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\System.Xml.XPath.XDocument.dll" WithCulture="false">
             <LogicalName>net90.System.Xml.XPath.XDocument</LogicalName>
             <Link>Resources\net90\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0\WindowsBase.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0\WindowsBase.dll" WithCulture="false">
             <LogicalName>net90.WindowsBase</LogicalName>
             <Link>Resources\net90\WindowsBase.dll</Link>
         </EmbeddedResource>

--- a/Basic.Reference.Assemblies.NetStandard13/Generated.targets
+++ b/Basic.Reference.Assemblies.NetStandard13/Generated.targets
@@ -1,234 +1,234 @@
 <Project>
     <ItemGroup>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\Microsoft.Win32.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\Microsoft.Win32.Primitives.dll" WithCulture="false">
             <LogicalName>netstandard13.Microsoft.Win32.Primitives</LogicalName>
             <Link>Resources\netstandard13\Microsoft.Win32.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.AppContext.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.AppContext.dll" WithCulture="false">
             <LogicalName>netstandard13.System.AppContext</LogicalName>
             <Link>Resources\netstandard13\System.AppContext.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Collections.Concurrent.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Collections.Concurrent.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Collections.Concurrent</LogicalName>
             <Link>Resources\netstandard13\System.Collections.Concurrent.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Collections.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Collections.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Collections</LogicalName>
             <Link>Resources\netstandard13\System.Collections.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Console.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Console.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Console</LogicalName>
             <Link>Resources\netstandard13\System.Console.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Debug.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Diagnostics.Debug.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Diagnostics.Debug</LogicalName>
             <Link>Resources\netstandard13\System.Diagnostics.Debug.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Diagnostics.FileVersionInfo.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Diagnostics.FileVersionInfo</LogicalName>
             <Link>Resources\netstandard13\System.Diagnostics.FileVersionInfo.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Process.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Diagnostics.Process.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Diagnostics.Process</LogicalName>
             <Link>Resources\netstandard13\System.Diagnostics.Process.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Tools.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Diagnostics.Tools.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Diagnostics.Tools</LogicalName>
             <Link>Resources\netstandard13\System.Diagnostics.Tools.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Diagnostics.Tracing.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Diagnostics.Tracing.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Diagnostics.Tracing</LogicalName>
             <Link>Resources\netstandard13\System.Diagnostics.Tracing.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Globalization.Calendars.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Globalization.Calendars.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Globalization.Calendars</LogicalName>
             <Link>Resources\netstandard13\System.Globalization.Calendars.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Globalization.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Globalization.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Globalization</LogicalName>
             <Link>Resources\netstandard13\System.Globalization.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.Compression.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.IO.Compression.dll" WithCulture="false">
             <LogicalName>netstandard13.System.IO.Compression</LogicalName>
             <Link>Resources\netstandard13\System.IO.Compression.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.Compression.ZipFile.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.IO.Compression.ZipFile.dll" WithCulture="false">
             <LogicalName>netstandard13.System.IO.Compression.ZipFile</LogicalName>
             <Link>Resources\netstandard13\System.IO.Compression.ZipFile.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.IO.dll" WithCulture="false">
             <LogicalName>netstandard13.System.IO</LogicalName>
             <Link>Resources\netstandard13\System.IO.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.FileSystem.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.IO.FileSystem.dll" WithCulture="false">
             <LogicalName>netstandard13.System.IO.FileSystem</LogicalName>
             <Link>Resources\netstandard13\System.IO.FileSystem.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.IO.FileSystem.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.IO.FileSystem.Primitives.dll" WithCulture="false">
             <LogicalName>netstandard13.System.IO.FileSystem.Primitives</LogicalName>
             <Link>Resources\netstandard13\System.IO.FileSystem.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Linq.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Linq.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Linq</LogicalName>
             <Link>Resources\netstandard13\System.Linq.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Linq.Expressions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Linq.Expressions.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Linq.Expressions</LogicalName>
             <Link>Resources\netstandard13\System.Linq.Expressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Http.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Net.Http.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Net.Http</LogicalName>
             <Link>Resources\netstandard13\System.Net.Http.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Net.Primitives.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Net.Primitives</LogicalName>
             <Link>Resources\netstandard13\System.Net.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Security.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Net.Security.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Net.Security</LogicalName>
             <Link>Resources\netstandard13\System.Net.Security.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Net.Sockets.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Net.Sockets.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Net.Sockets</LogicalName>
             <Link>Resources\netstandard13\System.Net.Sockets.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.ObjectModel.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.ObjectModel.dll" WithCulture="false">
             <LogicalName>netstandard13.System.ObjectModel</LogicalName>
             <Link>Resources\netstandard13\System.ObjectModel.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Reflection.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Reflection</LogicalName>
             <Link>Resources\netstandard13\System.Reflection.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Reflection.Extensions.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Reflection.Extensions</LogicalName>
             <Link>Resources\netstandard13\System.Reflection.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Reflection.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Reflection.Primitives.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Reflection.Primitives</LogicalName>
             <Link>Resources\netstandard13\System.Reflection.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Resources.ResourceManager.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Resources.ResourceManager.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Resources.ResourceManager</LogicalName>
             <Link>Resources\netstandard13\System.Resources.ResourceManager.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Runtime.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Runtime</LogicalName>
             <Link>Resources\netstandard13\System.Runtime.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Runtime.Extensions.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Runtime.Extensions</LogicalName>
             <Link>Resources\netstandard13\System.Runtime.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Handles.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Runtime.Handles.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Runtime.Handles</LogicalName>
             <Link>Resources\netstandard13\System.Runtime.Handles.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.InteropServices.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Runtime.InteropServices.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Runtime.InteropServices</LogicalName>
             <Link>Resources\netstandard13\System.Runtime.InteropServices.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Runtime.InteropServices.RuntimeInformation.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Runtime.InteropServices.RuntimeInformation</LogicalName>
             <Link>Resources\netstandard13\System.Runtime.InteropServices.RuntimeInformation.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Numerics.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Runtime.Numerics.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Runtime.Numerics</LogicalName>
             <Link>Resources\netstandard13\System.Runtime.Numerics.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Runtime.Serialization.Primitives.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Runtime.Serialization.Primitives</LogicalName>
             <Link>Resources\netstandard13\System.Runtime.Serialization.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.AccessControl.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.AccessControl.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.AccessControl</LogicalName>
             <Link>Resources\netstandard13\System.Security.AccessControl.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Claims.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Claims.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Claims</LogicalName>
             <Link>Resources\netstandard13\System.Security.Claims.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Cryptography.Algorithms.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Cryptography.Algorithms</LogicalName>
             <Link>Resources\netstandard13\System.Security.Cryptography.Algorithms.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Csp.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Cryptography.Csp.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Cryptography.Csp</LogicalName>
             <Link>Resources\netstandard13\System.Security.Cryptography.Csp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Encoding.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Cryptography.Encoding.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Cryptography.Encoding</LogicalName>
             <Link>Resources\netstandard13\System.Security.Cryptography.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.Primitives.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Cryptography.Primitives.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Cryptography.Primitives</LogicalName>
             <Link>Resources\netstandard13\System.Security.Cryptography.Primitives.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Cryptography.X509Certificates.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Cryptography.X509Certificates</LogicalName>
             <Link>Resources\netstandard13\System.Security.Cryptography.X509Certificates.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Principal.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Principal.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Principal</LogicalName>
             <Link>Resources\netstandard13\System.Security.Principal.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Security.Principal.Windows.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Security.Principal.Windows.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Security.Principal.Windows</LogicalName>
             <Link>Resources\netstandard13\System.Security.Principal.Windows.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.CodePages.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Text.Encoding.CodePages.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Text.Encoding.CodePages</LogicalName>
             <Link>Resources\netstandard13\System.Text.Encoding.CodePages.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Text.Encoding.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Text.Encoding</LogicalName>
             <Link>Resources\netstandard13\System.Text.Encoding.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.Encoding.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Text.Encoding.Extensions.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Text.Encoding.Extensions</LogicalName>
             <Link>Resources\netstandard13\System.Text.Encoding.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Text.RegularExpressions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Text.RegularExpressions.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Text.RegularExpressions</LogicalName>
             <Link>Resources\netstandard13\System.Text.RegularExpressions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Threading.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Threading</LogicalName>
             <Link>Resources\netstandard13\System.Threading.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Tasks.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Threading.Tasks.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Threading.Tasks</LogicalName>
             <Link>Resources\netstandard13\System.Threading.Tasks.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Tasks.Extensions.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Threading.Tasks.Extensions.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Threading.Tasks.Extensions</LogicalName>
             <Link>Resources\netstandard13\System.Threading.Tasks.Extensions.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Threading.Timer.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Threading.Timer.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Threading.Timer</LogicalName>
             <Link>Resources\netstandard13\System.Threading.Timer.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.ValueTuple.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.ValueTuple.dll" WithCulture="false">
             <LogicalName>netstandard13.System.ValueTuple</LogicalName>
             <Link>Resources\netstandard13\System.ValueTuple.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.ReaderWriter.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Xml.ReaderWriter.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Xml.ReaderWriter</LogicalName>
             <Link>Resources\netstandard13\System.Xml.ReaderWriter.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XDocument.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Xml.XDocument.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Xml.XDocument</LogicalName>
             <Link>Resources\netstandard13\System.Xml.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XmlDocument.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Xml.XmlDocument.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Xml.XmlDocument</LogicalName>
             <Link>Resources\netstandard13\System.Xml.XmlDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XPath.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Xml.XPath.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Xml.XPath</LogicalName>
             <Link>Resources\netstandard13\System.Xml.XPath.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\\Resources\netstandard1.3\System.Xml.XPath.XDocument.dll" WithCulture="false">
+        <EmbeddedResource Include="$(MSBuildThisFileDirectory)..\Resources\netstandard1.3\System.Xml.XPath.XDocument.dll" WithCulture="false">
             <LogicalName>netstandard13.System.Xml.XPath.XDocument</LogicalName>
             <Link>Resources\netstandard13\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>

--- a/Generate/Program.cs
+++ b/Generate/Program.cs
@@ -75,7 +75,7 @@ void Net80()
 
 void Net90()
 {
-    var content = GetGeneratedContent("Net90", [@"microsoft.netcore.app.ref\9.0.0-preview.3.24172.9\ref\net9.0"]);
+    var content = GetGeneratedContent("Net90", [@"microsoft.netcore.app.ref\9.0.0-preview.6.24327.7\ref\net9.0"]);
     var targetDir = Path.Combine(workspacePath, "Basic.Reference.Assemblies.Net90");
     File.WriteAllText(Path.Combine(targetDir, "Generated.cs"), content.CodeContent, encoding);
     File.WriteAllText(Path.Combine(targetDir, "Generated.targets"), content.TargetsContent, encoding);
@@ -312,7 +312,7 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
         var mvid = GetMvid(dllPath);
         var dll = Path.GetFileNameWithoutExtension(dllName);
         var logicalName = $"{lowerName}.{dll}";
-        var dllResourcePath = $@"{targetsPrefix}\{dllPath.Substring(realPackagePrefix.Length)}";
+        var dllResourcePath = Path.Join(targetsPrefix, dllPath.Substring(realPackagePrefix.Length));
 
         targetsContent.AppendLine($$"""
                     <EmbeddedResource Include="{{dllResourcePath}}" WithCulture="false">


### PR DESCRIPTION
- update net 9.0 (e.g. for OverloadResolutionPriorityAttribute)
- fix path generation (never two slashes)