### PR TITLE
Include extra references

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,37 +1,39 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{            
-			"label": "build",
+    "version": "2.0.0",
+    "tasks": [
+        {            
+            "label": "build",
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
                 "${workspaceFolder}/Basic.Reference.Assemblies.sln",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary",
+                "/tl:off"
             ],
             "problemMatcher": "$msCompile",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-		},
-		{            
-			"label": "build generate",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+        },
+        {            
+            "label": "build generate",
             "command": "dotnet",
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/Generate/Generate.csproj",
+                "${workspaceFolder}/Src/Generate/Generate.csproj",
                 "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary"
+                "/consoleloggerparameters:NoSummary",
+                "/tl:off"
             ],
             "problemMatcher": "$msCompile",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-		}
-	]
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+        }
+    ]
 }

--- a/Src/Basic.Reference.Assemblies.AspNet80/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.AspNet80/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -1820,6 +1820,7 @@ public static partial class AspNet80
 
     }
 }
+
 public static partial class AspNet80
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.AspNet80/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.AspNet80/Generated.cs
@@ -9,1820 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class AspNet80
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "aspnet80.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "aspnet80.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "aspnet80.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "aspnet80.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "aspnet80.Microsoft.Win32.Registry");
-        private static byte[]? _MicrosoftWin32Registry;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "aspnet80.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "aspnet80.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "aspnet80.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "aspnet80.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "aspnet80.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "aspnet80.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "aspnet80.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "aspnet80.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "aspnet80.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "aspnet80.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "aspnet80.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "aspnet80.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "aspnet80.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "aspnet80.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "aspnet80.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "aspnet80.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "aspnet80.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "aspnet80.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "aspnet80.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "aspnet80.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "aspnet80.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "aspnet80.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "aspnet80.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "aspnet80.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "aspnet80.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "aspnet80.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "aspnet80.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "aspnet80.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "aspnet80.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "aspnet80.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "aspnet80.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "aspnet80.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "aspnet80.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "aspnet80.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "aspnet80.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "aspnet80.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Tar.dll
-        /// </summary>
-        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "aspnet80.System.Formats.Tar");
-        private static byte[]? _SystemFormatsTar;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "aspnet80.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "aspnet80.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "aspnet80.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "aspnet80.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "aspnet80.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "aspnet80.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "aspnet80.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "aspnet80.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "aspnet80.System.IO.FileSystem.AccessControl");
-        private static byte[]? _SystemIOFileSystemAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "aspnet80.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "aspnet80.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "aspnet80.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "aspnet80.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "aspnet80.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "aspnet80.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "aspnet80.System.IO.Pipes.AccessControl");
-        private static byte[]? _SystemIOPipesAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "aspnet80.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "aspnet80.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "aspnet80.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "aspnet80.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "aspnet80.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "aspnet80.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "aspnet80.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "aspnet80.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "aspnet80.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "aspnet80.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "aspnet80.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "aspnet80.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "aspnet80.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "aspnet80.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "aspnet80.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "aspnet80.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Quic.dll
-        /// </summary>
-        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "aspnet80.System.Net.Quic");
-        private static byte[]? _SystemNetQuic;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "aspnet80.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "aspnet80.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "aspnet80.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "aspnet80.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "aspnet80.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "aspnet80.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "aspnet80.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "aspnet80.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "aspnet80.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "aspnet80.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "aspnet80.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "aspnet80.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "aspnet80.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "aspnet80.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "aspnet80.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "aspnet80.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "aspnet80.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "aspnet80.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "aspnet80.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "aspnet80.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "aspnet80.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "aspnet80.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "aspnet80.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "aspnet80.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "aspnet80.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "aspnet80.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "aspnet80.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "aspnet80.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "aspnet80.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "aspnet80.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "aspnet80.System.Runtime.InteropServices.JavaScript");
-        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "aspnet80.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "aspnet80.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "aspnet80.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "aspnet80.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "aspnet80.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "aspnet80.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "aspnet80.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "aspnet80.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "aspnet80.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "aspnet80.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "aspnet80.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "aspnet80.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Cng.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "aspnet80.System.Security.Cryptography.Cng");
-        private static byte[]? _SystemSecurityCryptographyCng;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "aspnet80.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "aspnet80.System.Security.Cryptography");
-        private static byte[]? _SystemSecurityCryptography;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "aspnet80.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "aspnet80.System.Security.Cryptography.OpenSsl");
-        private static byte[]? _SystemSecurityCryptographyOpenSsl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "aspnet80.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "aspnet80.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "aspnet80.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "aspnet80.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "aspnet80.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "aspnet80.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "aspnet80.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "aspnet80.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "aspnet80.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "aspnet80.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "aspnet80.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "aspnet80.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "aspnet80.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "aspnet80.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "aspnet80.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "aspnet80.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "aspnet80.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "aspnet80.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "aspnet80.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "aspnet80.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "aspnet80.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "aspnet80.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "aspnet80.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "aspnet80.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "aspnet80.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "aspnet80.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "aspnet80.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "aspnet80.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "aspnet80.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "aspnet80.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "aspnet80.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "aspnet80.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "aspnet80.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "aspnet80.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "aspnet80.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "aspnet80.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "aspnet80.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "aspnet80.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "aspnet80.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "aspnet80.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Antiforgery.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAntiforgery => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAntiforgery, "aspnet80.Microsoft.AspNetCore.Antiforgery");
-        private static byte[]? _MicrosoftAspNetCoreAntiforgery;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationAbstractions, "aspnet80.Microsoft.AspNetCore.Authentication.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.BearerToken.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationBearerToken => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationBearerToken, "aspnet80.Microsoft.AspNetCore.Authentication.BearerToken");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationBearerToken;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.Cookies.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationCookies => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCookies, "aspnet80.Microsoft.AspNetCore.Authentication.Cookies");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationCookies;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCore, "aspnet80.Microsoft.AspNetCore.Authentication.Core");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthentication => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthentication, "aspnet80.Microsoft.AspNetCore.Authentication");
-        private static byte[]? _MicrosoftAspNetCoreAuthentication;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.OAuth.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationOAuth => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationOAuth, "aspnet80.Microsoft.AspNetCore.Authentication.OAuth");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationOAuth;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authorization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorization, "aspnet80.Microsoft.AspNetCore.Authorization");
-        private static byte[]? _MicrosoftAspNetCoreAuthorization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authorization.Policy.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthorizationPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorizationPolicy, "aspnet80.Microsoft.AspNetCore.Authorization.Policy");
-        private static byte[]? _MicrosoftAspNetCoreAuthorizationPolicy;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Authorization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsAuthorization, "aspnet80.Microsoft.AspNetCore.Components.Authorization");
-        private static byte[]? _MicrosoftAspNetCoreComponentsAuthorization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponents => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponents, "aspnet80.Microsoft.AspNetCore.Components");
-        private static byte[]? _MicrosoftAspNetCoreComponents;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Endpoints.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsEndpoints => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsEndpoints, "aspnet80.Microsoft.AspNetCore.Components.Endpoints");
-        private static byte[]? _MicrosoftAspNetCoreComponentsEndpoints;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Forms.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsForms, "aspnet80.Microsoft.AspNetCore.Components.Forms");
-        private static byte[]? _MicrosoftAspNetCoreComponentsForms;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Server.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsServer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsServer, "aspnet80.Microsoft.AspNetCore.Components.Server");
-        private static byte[]? _MicrosoftAspNetCoreComponentsServer;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Web.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsWeb => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsWeb, "aspnet80.Microsoft.AspNetCore.Components.Web");
-        private static byte[]? _MicrosoftAspNetCoreComponentsWeb;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Connections.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreConnectionsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreConnectionsAbstractions, "aspnet80.Microsoft.AspNetCore.Connections.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreConnectionsAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.CookiePolicy.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCookiePolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCookiePolicy, "aspnet80.Microsoft.AspNetCore.CookiePolicy");
-        private static byte[]? _MicrosoftAspNetCoreCookiePolicy;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Cors.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCors, "aspnet80.Microsoft.AspNetCore.Cors");
-        private static byte[]? _MicrosoftAspNetCoreCors;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Cryptography.Internal.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCryptographyInternal => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyInternal, "aspnet80.Microsoft.AspNetCore.Cryptography.Internal");
-        private static byte[]? _MicrosoftAspNetCoreCryptographyInternal;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCryptographyKeyDerivation => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyKeyDerivation, "aspnet80.Microsoft.AspNetCore.Cryptography.KeyDerivation");
-        private static byte[]? _MicrosoftAspNetCoreCryptographyKeyDerivation;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.DataProtection.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDataProtectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionAbstractions, "aspnet80.Microsoft.AspNetCore.DataProtection.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreDataProtectionAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.DataProtection.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDataProtection => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtection, "aspnet80.Microsoft.AspNetCore.DataProtection");
-        private static byte[]? _MicrosoftAspNetCoreDataProtection;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.DataProtection.Extensions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDataProtectionExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionExtensions, "aspnet80.Microsoft.AspNetCore.DataProtection.Extensions");
-        private static byte[]? _MicrosoftAspNetCoreDataProtectionExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Diagnostics.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsAbstractions, "aspnet80.Microsoft.AspNetCore.Diagnostics.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreDiagnosticsAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Diagnostics.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnostics, "aspnet80.Microsoft.AspNetCore.Diagnostics");
-        private static byte[]? _MicrosoftAspNetCoreDiagnostics;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsHealthChecks, "aspnet80.Microsoft.AspNetCore.Diagnostics.HealthChecks");
-        private static byte[]? _MicrosoftAspNetCoreDiagnosticsHealthChecks;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCore, "aspnet80.Microsoft.AspNetCore");
-        private static byte[]? _MicrosoftAspNetCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HostFiltering.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHostFiltering => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostFiltering, "aspnet80.Microsoft.AspNetCore.HostFiltering");
-        private static byte[]? _MicrosoftAspNetCoreHostFiltering;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Hosting.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingAbstractions, "aspnet80.Microsoft.AspNetCore.Hosting.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHostingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Hosting.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHosting, "aspnet80.Microsoft.AspNetCore.Hosting");
-        private static byte[]? _MicrosoftAspNetCoreHosting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHostingServerAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingServerAbstractions, "aspnet80.Microsoft.AspNetCore.Hosting.Server.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHostingServerAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Html.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHtmlAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHtmlAbstractions, "aspnet80.Microsoft.AspNetCore.Html.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHtmlAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpAbstractions, "aspnet80.Microsoft.AspNetCore.Http.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHttpAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Connections.Common.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpConnectionsCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnectionsCommon, "aspnet80.Microsoft.AspNetCore.Http.Connections.Common");
-        private static byte[]? _MicrosoftAspNetCoreHttpConnectionsCommon;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Connections.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpConnections => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnections, "aspnet80.Microsoft.AspNetCore.Http.Connections");
-        private static byte[]? _MicrosoftAspNetCoreHttpConnections;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttp, "aspnet80.Microsoft.AspNetCore.Http");
-        private static byte[]? _MicrosoftAspNetCoreHttp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Extensions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpExtensions, "aspnet80.Microsoft.AspNetCore.Http.Extensions");
-        private static byte[]? _MicrosoftAspNetCoreHttpExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Features.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpFeatures, "aspnet80.Microsoft.AspNetCore.Http.Features");
-        private static byte[]? _MicrosoftAspNetCoreHttpFeatures;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Results.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpResults => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpResults, "aspnet80.Microsoft.AspNetCore.Http.Results");
-        private static byte[]? _MicrosoftAspNetCoreHttpResults;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HttpLogging.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpLogging, "aspnet80.Microsoft.AspNetCore.HttpLogging");
-        private static byte[]? _MicrosoftAspNetCoreHttpLogging;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HttpOverrides.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpOverrides => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpOverrides, "aspnet80.Microsoft.AspNetCore.HttpOverrides");
-        private static byte[]? _MicrosoftAspNetCoreHttpOverrides;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HttpsPolicy.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpsPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpsPolicy, "aspnet80.Microsoft.AspNetCore.HttpsPolicy");
-        private static byte[]? _MicrosoftAspNetCoreHttpsPolicy;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Identity.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreIdentity => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreIdentity, "aspnet80.Microsoft.AspNetCore.Identity");
-        private static byte[]? _MicrosoftAspNetCoreIdentity;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Localization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalization, "aspnet80.Microsoft.AspNetCore.Localization");
-        private static byte[]? _MicrosoftAspNetCoreLocalization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Localization.Routing.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreLocalizationRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalizationRouting, "aspnet80.Microsoft.AspNetCore.Localization.Routing");
-        private static byte[]? _MicrosoftAspNetCoreLocalizationRouting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Metadata.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMetadata => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMetadata, "aspnet80.Microsoft.AspNetCore.Metadata");
-        private static byte[]? _MicrosoftAspNetCoreMetadata;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcAbstractions, "aspnet80.Microsoft.AspNetCore.Mvc.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreMvcAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.ApiExplorer.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcApiExplorer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcApiExplorer, "aspnet80.Microsoft.AspNetCore.Mvc.ApiExplorer");
-        private static byte[]? _MicrosoftAspNetCoreMvcApiExplorer;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCore, "aspnet80.Microsoft.AspNetCore.Mvc.Core");
-        private static byte[]? _MicrosoftAspNetCoreMvcCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Cors.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCors, "aspnet80.Microsoft.AspNetCore.Mvc.Cors");
-        private static byte[]? _MicrosoftAspNetCoreMvcCors;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.DataAnnotations.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcDataAnnotations, "aspnet80.Microsoft.AspNetCore.Mvc.DataAnnotations");
-        private static byte[]? _MicrosoftAspNetCoreMvcDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvc => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvc, "aspnet80.Microsoft.AspNetCore.Mvc");
-        private static byte[]? _MicrosoftAspNetCoreMvc;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Json.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcFormattersJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersJson, "aspnet80.Microsoft.AspNetCore.Mvc.Formatters.Json");
-        private static byte[]? _MicrosoftAspNetCoreMvcFormattersJson;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcFormattersXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersXml, "aspnet80.Microsoft.AspNetCore.Mvc.Formatters.Xml");
-        private static byte[]? _MicrosoftAspNetCoreMvcFormattersXml;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Localization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcLocalization, "aspnet80.Microsoft.AspNetCore.Mvc.Localization");
-        private static byte[]? _MicrosoftAspNetCoreMvcLocalization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Razor.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazor, "aspnet80.Microsoft.AspNetCore.Mvc.Razor");
-        private static byte[]? _MicrosoftAspNetCoreMvcRazor;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.RazorPages.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcRazorPages => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazorPages, "aspnet80.Microsoft.AspNetCore.Mvc.RazorPages");
-        private static byte[]? _MicrosoftAspNetCoreMvcRazorPages;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.TagHelpers.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcTagHelpers => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcTagHelpers, "aspnet80.Microsoft.AspNetCore.Mvc.TagHelpers");
-        private static byte[]? _MicrosoftAspNetCoreMvcTagHelpers;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.ViewFeatures.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcViewFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcViewFeatures, "aspnet80.Microsoft.AspNetCore.Mvc.ViewFeatures");
-        private static byte[]? _MicrosoftAspNetCoreMvcViewFeatures;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.OutputCaching.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreOutputCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreOutputCaching, "aspnet80.Microsoft.AspNetCore.OutputCaching");
-        private static byte[]? _MicrosoftAspNetCoreOutputCaching;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.RateLimiting.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRateLimiting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRateLimiting, "aspnet80.Microsoft.AspNetCore.RateLimiting");
-        private static byte[]? _MicrosoftAspNetCoreRateLimiting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Razor.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazor, "aspnet80.Microsoft.AspNetCore.Razor");
-        private static byte[]? _MicrosoftAspNetCoreRazor;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Razor.Runtime.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRazorRuntime => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazorRuntime, "aspnet80.Microsoft.AspNetCore.Razor.Runtime");
-        private static byte[]? _MicrosoftAspNetCoreRazorRuntime;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.RequestDecompression.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRequestDecompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRequestDecompression, "aspnet80.Microsoft.AspNetCore.RequestDecompression");
-        private static byte[]? _MicrosoftAspNetCoreRequestDecompression;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreResponseCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCachingAbstractions, "aspnet80.Microsoft.AspNetCore.ResponseCaching.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreResponseCachingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreResponseCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCaching, "aspnet80.Microsoft.AspNetCore.ResponseCaching");
-        private static byte[]? _MicrosoftAspNetCoreResponseCaching;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.ResponseCompression.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreResponseCompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCompression, "aspnet80.Microsoft.AspNetCore.ResponseCompression");
-        private static byte[]? _MicrosoftAspNetCoreResponseCompression;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Rewrite.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRewrite => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRewrite, "aspnet80.Microsoft.AspNetCore.Rewrite");
-        private static byte[]? _MicrosoftAspNetCoreRewrite;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Routing.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRoutingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRoutingAbstractions, "aspnet80.Microsoft.AspNetCore.Routing.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreRoutingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Routing.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRouting, "aspnet80.Microsoft.AspNetCore.Routing");
-        private static byte[]? _MicrosoftAspNetCoreRouting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.HttpSys.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerHttpSys => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerHttpSys, "aspnet80.Microsoft.AspNetCore.Server.HttpSys");
-        private static byte[]? _MicrosoftAspNetCoreServerHttpSys;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.IIS.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerIIS => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIIS, "aspnet80.Microsoft.AspNetCore.Server.IIS");
-        private static byte[]? _MicrosoftAspNetCoreServerIIS;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.IISIntegration.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerIISIntegration => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIISIntegration, "aspnet80.Microsoft.AspNetCore.Server.IISIntegration");
-        private static byte[]? _MicrosoftAspNetCoreServerIISIntegration;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelCore, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Core");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrel => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrel, "aspnet80.Microsoft.AspNetCore.Server.Kestrel");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrel;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelTransportNamedPipes => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportNamedPipes, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportNamedPipes;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelTransportQuic => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportQuic, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.Quic");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportQuic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelTransportSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportSockets, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportSockets;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Session.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSession => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSession, "aspnet80.Microsoft.AspNetCore.Session");
-        private static byte[]? _MicrosoftAspNetCoreSession;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.Common.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalRCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCommon, "aspnet80.Microsoft.AspNetCore.SignalR.Common");
-        private static byte[]? _MicrosoftAspNetCoreSignalRCommon;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalRCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCore, "aspnet80.Microsoft.AspNetCore.SignalR.Core");
-        private static byte[]? _MicrosoftAspNetCoreSignalRCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalR => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalR, "aspnet80.Microsoft.AspNetCore.SignalR");
-        private static byte[]? _MicrosoftAspNetCoreSignalR;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.Protocols.Json.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalRProtocolsJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRProtocolsJson, "aspnet80.Microsoft.AspNetCore.SignalR.Protocols.Json");
-        private static byte[]? _MicrosoftAspNetCoreSignalRProtocolsJson;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.StaticFiles.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreStaticFiles => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreStaticFiles, "aspnet80.Microsoft.AspNetCore.StaticFiles");
-        private static byte[]? _MicrosoftAspNetCoreStaticFiles;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.WebSockets.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreWebSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebSockets, "aspnet80.Microsoft.AspNetCore.WebSockets");
-        private static byte[]? _MicrosoftAspNetCoreWebSockets;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.WebUtilities.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreWebUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebUtilities, "aspnet80.Microsoft.AspNetCore.WebUtilities");
-        private static byte[]? _MicrosoftAspNetCoreWebUtilities;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Caching.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingAbstractions, "aspnet80.Microsoft.Extensions.Caching.Abstractions");
-        private static byte[]? _MicrosoftExtensionsCachingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Caching.Memory.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsCachingMemory => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingMemory, "aspnet80.Microsoft.Extensions.Caching.Memory");
-        private static byte[]? _MicrosoftExtensionsCachingMemory;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationAbstractions, "aspnet80.Microsoft.Extensions.Configuration.Abstractions");
-        private static byte[]? _MicrosoftExtensionsConfigurationAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Binder.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationBinder => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationBinder, "aspnet80.Microsoft.Extensions.Configuration.Binder");
-        private static byte[]? _MicrosoftExtensionsConfigurationBinder;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.CommandLine.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationCommandLine => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationCommandLine, "aspnet80.Microsoft.Extensions.Configuration.CommandLine");
-        private static byte[]? _MicrosoftExtensionsConfigurationCommandLine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfiguration, "aspnet80.Microsoft.Extensions.Configuration");
-        private static byte[]? _MicrosoftExtensionsConfiguration;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.EnvironmentVariables.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationEnvironmentVariables => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationEnvironmentVariables, "aspnet80.Microsoft.Extensions.Configuration.EnvironmentVariables");
-        private static byte[]? _MicrosoftExtensionsConfigurationEnvironmentVariables;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.FileExtensions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationFileExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationFileExtensions, "aspnet80.Microsoft.Extensions.Configuration.FileExtensions");
-        private static byte[]? _MicrosoftExtensionsConfigurationFileExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Ini.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationIni => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationIni, "aspnet80.Microsoft.Extensions.Configuration.Ini");
-        private static byte[]? _MicrosoftExtensionsConfigurationIni;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Json.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationJson, "aspnet80.Microsoft.Extensions.Configuration.Json");
-        private static byte[]? _MicrosoftExtensionsConfigurationJson;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.KeyPerFile.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationKeyPerFile => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationKeyPerFile, "aspnet80.Microsoft.Extensions.Configuration.KeyPerFile");
-        private static byte[]? _MicrosoftExtensionsConfigurationKeyPerFile;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.UserSecrets.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationUserSecrets => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationUserSecrets, "aspnet80.Microsoft.Extensions.Configuration.UserSecrets");
-        private static byte[]? _MicrosoftExtensionsConfigurationUserSecrets;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Xml.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationXml, "aspnet80.Microsoft.Extensions.Configuration.Xml");
-        private static byte[]? _MicrosoftExtensionsConfigurationXml;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.DependencyInjection.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDependencyInjectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjectionAbstractions, "aspnet80.Microsoft.Extensions.DependencyInjection.Abstractions");
-        private static byte[]? _MicrosoftExtensionsDependencyInjectionAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.DependencyInjection.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDependencyInjection => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjection, "aspnet80.Microsoft.Extensions.DependencyInjection");
-        private static byte[]? _MicrosoftExtensionsDependencyInjection;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsAbstractions, "aspnet80.Microsoft.Extensions.Diagnostics.Abstractions");
-        private static byte[]? _MicrosoftExtensionsDiagnosticsAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnostics, "aspnet80.Microsoft.Extensions.Diagnostics");
-        private static byte[]? _MicrosoftExtensionsDiagnostics;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecksAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions, "aspnet80.Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions");
-        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecks, "aspnet80.Microsoft.Extensions.Diagnostics.HealthChecks");
-        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecks;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Features.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFeatures, "aspnet80.Microsoft.Extensions.Features");
-        private static byte[]? _MicrosoftExtensionsFeatures;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersAbstractions, "aspnet80.Microsoft.Extensions.FileProviders.Abstractions");
-        private static byte[]? _MicrosoftExtensionsFileProvidersAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Composite.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersComposite => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersComposite, "aspnet80.Microsoft.Extensions.FileProviders.Composite");
-        private static byte[]? _MicrosoftExtensionsFileProvidersComposite;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Embedded.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersEmbedded => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersEmbedded, "aspnet80.Microsoft.Extensions.FileProviders.Embedded");
-        private static byte[]? _MicrosoftExtensionsFileProvidersEmbedded;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Physical.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersPhysical => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersPhysical, "aspnet80.Microsoft.Extensions.FileProviders.Physical");
-        private static byte[]? _MicrosoftExtensionsFileProvidersPhysical;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileSystemGlobbing.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileSystemGlobbing => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileSystemGlobbing, "aspnet80.Microsoft.Extensions.FileSystemGlobbing");
-        private static byte[]? _MicrosoftExtensionsFileSystemGlobbing;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Hosting.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHostingAbstractions, "aspnet80.Microsoft.Extensions.Hosting.Abstractions");
-        private static byte[]? _MicrosoftExtensionsHostingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Hosting.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHosting, "aspnet80.Microsoft.Extensions.Hosting");
-        private static byte[]? _MicrosoftExtensionsHosting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Http.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHttp, "aspnet80.Microsoft.Extensions.Http");
-        private static byte[]? _MicrosoftExtensionsHttp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Identity.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsIdentityCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityCore, "aspnet80.Microsoft.Extensions.Identity.Core");
-        private static byte[]? _MicrosoftExtensionsIdentityCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Identity.Stores.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsIdentityStores => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityStores, "aspnet80.Microsoft.Extensions.Identity.Stores");
-        private static byte[]? _MicrosoftExtensionsIdentityStores;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Localization.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLocalizationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalizationAbstractions, "aspnet80.Microsoft.Extensions.Localization.Abstractions");
-        private static byte[]? _MicrosoftExtensionsLocalizationAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Localization.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalization, "aspnet80.Microsoft.Extensions.Localization");
-        private static byte[]? _MicrosoftExtensionsLocalization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingAbstractions, "aspnet80.Microsoft.Extensions.Logging.Abstractions");
-        private static byte[]? _MicrosoftExtensionsLoggingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Configuration.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConfiguration, "aspnet80.Microsoft.Extensions.Logging.Configuration");
-        private static byte[]? _MicrosoftExtensionsLoggingConfiguration;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Console.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingConsole => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConsole, "aspnet80.Microsoft.Extensions.Logging.Console");
-        private static byte[]? _MicrosoftExtensionsLoggingConsole;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Debug.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingDebug => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingDebug, "aspnet80.Microsoft.Extensions.Logging.Debug");
-        private static byte[]? _MicrosoftExtensionsLoggingDebug;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLogging, "aspnet80.Microsoft.Extensions.Logging");
-        private static byte[]? _MicrosoftExtensionsLogging;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.EventLog.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingEventLog => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventLog, "aspnet80.Microsoft.Extensions.Logging.EventLog");
-        private static byte[]? _MicrosoftExtensionsLoggingEventLog;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.EventSource.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingEventSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventSource, "aspnet80.Microsoft.Extensions.Logging.EventSource");
-        private static byte[]? _MicrosoftExtensionsLoggingEventSource;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.TraceSource.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingTraceSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingTraceSource, "aspnet80.Microsoft.Extensions.Logging.TraceSource");
-        private static byte[]? _MicrosoftExtensionsLoggingTraceSource;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.ObjectPool.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsObjectPool => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsObjectPool, "aspnet80.Microsoft.Extensions.ObjectPool");
-        private static byte[]? _MicrosoftExtensionsObjectPool;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Options.ConfigurationExtensions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsOptionsConfigurationExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsConfigurationExtensions, "aspnet80.Microsoft.Extensions.Options.ConfigurationExtensions");
-        private static byte[]? _MicrosoftExtensionsOptionsConfigurationExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Options.DataAnnotations.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsOptionsDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsDataAnnotations, "aspnet80.Microsoft.Extensions.Options.DataAnnotations");
-        private static byte[]? _MicrosoftExtensionsOptionsDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Options.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsOptions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptions, "aspnet80.Microsoft.Extensions.Options");
-        private static byte[]? _MicrosoftExtensionsOptions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsPrimitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsPrimitives, "aspnet80.Microsoft.Extensions.Primitives");
-        private static byte[]? _MicrosoftExtensionsPrimitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.WebEncoders.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsWebEncoders => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsWebEncoders, "aspnet80.Microsoft.Extensions.WebEncoders");
-        private static byte[]? _MicrosoftExtensionsWebEncoders;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JSInterop.dll
-        /// </summary>
-        public static byte[] MicrosoftJSInterop => ResourceLoader.GetOrCreateResource(ref _MicrosoftJSInterop, "aspnet80.Microsoft.JSInterop");
-        private static byte[]? _MicrosoftJSInterop;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Net.Http.Headers.dll
-        /// </summary>
-        public static byte[] MicrosoftNetHttpHeaders => ResourceLoader.GetOrCreateResource(ref _MicrosoftNetHttpHeaders, "aspnet80.Microsoft.Net.Http.Headers");
-        private static byte[]? _MicrosoftNetHttpHeaders;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.EventLog.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "aspnet80.System.Diagnostics.EventLog");
-        private static byte[]? _SystemDiagnosticsEventLog;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipelines.dll
-        /// </summary>
-        public static byte[] SystemIOPipelines => ResourceLoader.GetOrCreateResource(ref _SystemIOPipelines, "aspnet80.System.IO.Pipelines");
-        private static byte[]? _SystemIOPipelines;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Xml.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "aspnet80.System.Security.Cryptography.Xml");
-        private static byte[]? _SystemSecurityCryptographyXml;
-
-        /// <summary>
-        /// The image bytes for System.Threading.RateLimiting.dll
-        /// </summary>
-        public static byte[] SystemThreadingRateLimiting => ResourceLoader.GetOrCreateResource(ref _SystemThreadingRateLimiting, "aspnet80.System.Threading.RateLimiting");
-        private static byte[]? _SystemThreadingRateLimiting;
-
-
-    }
-}
-
-public static partial class AspNet80
-{
     public static class ReferenceInfos
     {
 
@@ -9086,6 +7272,1820 @@ public static partial class AspNet80
                 return _all;
             }
         }
+    }
+}
+
+public static partial class AspNet80
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "aspnet80.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "aspnet80.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "aspnet80.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "aspnet80.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "aspnet80.Microsoft.Win32.Registry");
+        private static byte[]? _MicrosoftWin32Registry;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "aspnet80.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "aspnet80.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "aspnet80.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "aspnet80.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "aspnet80.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "aspnet80.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "aspnet80.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "aspnet80.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "aspnet80.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "aspnet80.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "aspnet80.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "aspnet80.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "aspnet80.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "aspnet80.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "aspnet80.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "aspnet80.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "aspnet80.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "aspnet80.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "aspnet80.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "aspnet80.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "aspnet80.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "aspnet80.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "aspnet80.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "aspnet80.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "aspnet80.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "aspnet80.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "aspnet80.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "aspnet80.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "aspnet80.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "aspnet80.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "aspnet80.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "aspnet80.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "aspnet80.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "aspnet80.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "aspnet80.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "aspnet80.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Tar.dll
+        /// </summary>
+        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "aspnet80.System.Formats.Tar");
+        private static byte[]? _SystemFormatsTar;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "aspnet80.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "aspnet80.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "aspnet80.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "aspnet80.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "aspnet80.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "aspnet80.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "aspnet80.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "aspnet80.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "aspnet80.System.IO.FileSystem.AccessControl");
+        private static byte[]? _SystemIOFileSystemAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "aspnet80.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "aspnet80.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "aspnet80.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "aspnet80.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "aspnet80.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "aspnet80.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "aspnet80.System.IO.Pipes.AccessControl");
+        private static byte[]? _SystemIOPipesAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "aspnet80.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "aspnet80.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "aspnet80.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "aspnet80.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "aspnet80.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "aspnet80.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "aspnet80.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "aspnet80.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "aspnet80.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "aspnet80.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "aspnet80.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "aspnet80.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "aspnet80.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "aspnet80.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "aspnet80.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "aspnet80.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Quic.dll
+        /// </summary>
+        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "aspnet80.System.Net.Quic");
+        private static byte[]? _SystemNetQuic;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "aspnet80.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "aspnet80.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "aspnet80.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "aspnet80.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "aspnet80.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "aspnet80.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "aspnet80.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "aspnet80.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "aspnet80.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "aspnet80.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "aspnet80.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "aspnet80.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "aspnet80.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "aspnet80.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "aspnet80.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "aspnet80.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "aspnet80.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "aspnet80.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "aspnet80.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "aspnet80.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "aspnet80.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "aspnet80.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "aspnet80.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "aspnet80.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "aspnet80.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "aspnet80.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "aspnet80.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "aspnet80.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "aspnet80.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "aspnet80.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "aspnet80.System.Runtime.InteropServices.JavaScript");
+        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "aspnet80.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "aspnet80.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "aspnet80.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "aspnet80.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "aspnet80.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "aspnet80.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "aspnet80.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "aspnet80.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "aspnet80.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "aspnet80.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "aspnet80.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "aspnet80.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Cng.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "aspnet80.System.Security.Cryptography.Cng");
+        private static byte[]? _SystemSecurityCryptographyCng;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "aspnet80.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "aspnet80.System.Security.Cryptography");
+        private static byte[]? _SystemSecurityCryptography;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "aspnet80.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "aspnet80.System.Security.Cryptography.OpenSsl");
+        private static byte[]? _SystemSecurityCryptographyOpenSsl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "aspnet80.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "aspnet80.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "aspnet80.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "aspnet80.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "aspnet80.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "aspnet80.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "aspnet80.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "aspnet80.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "aspnet80.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "aspnet80.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "aspnet80.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "aspnet80.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "aspnet80.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "aspnet80.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "aspnet80.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "aspnet80.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "aspnet80.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "aspnet80.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "aspnet80.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "aspnet80.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "aspnet80.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "aspnet80.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "aspnet80.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "aspnet80.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "aspnet80.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "aspnet80.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "aspnet80.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "aspnet80.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "aspnet80.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "aspnet80.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "aspnet80.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "aspnet80.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "aspnet80.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "aspnet80.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "aspnet80.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "aspnet80.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "aspnet80.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "aspnet80.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "aspnet80.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "aspnet80.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Antiforgery.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAntiforgery => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAntiforgery, "aspnet80.Microsoft.AspNetCore.Antiforgery");
+        private static byte[]? _MicrosoftAspNetCoreAntiforgery;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationAbstractions, "aspnet80.Microsoft.AspNetCore.Authentication.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.BearerToken.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationBearerToken => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationBearerToken, "aspnet80.Microsoft.AspNetCore.Authentication.BearerToken");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationBearerToken;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.Cookies.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationCookies => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCookies, "aspnet80.Microsoft.AspNetCore.Authentication.Cookies");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationCookies;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCore, "aspnet80.Microsoft.AspNetCore.Authentication.Core");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthentication => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthentication, "aspnet80.Microsoft.AspNetCore.Authentication");
+        private static byte[]? _MicrosoftAspNetCoreAuthentication;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.OAuth.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationOAuth => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationOAuth, "aspnet80.Microsoft.AspNetCore.Authentication.OAuth");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationOAuth;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authorization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorization, "aspnet80.Microsoft.AspNetCore.Authorization");
+        private static byte[]? _MicrosoftAspNetCoreAuthorization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authorization.Policy.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthorizationPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorizationPolicy, "aspnet80.Microsoft.AspNetCore.Authorization.Policy");
+        private static byte[]? _MicrosoftAspNetCoreAuthorizationPolicy;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Authorization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsAuthorization, "aspnet80.Microsoft.AspNetCore.Components.Authorization");
+        private static byte[]? _MicrosoftAspNetCoreComponentsAuthorization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponents => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponents, "aspnet80.Microsoft.AspNetCore.Components");
+        private static byte[]? _MicrosoftAspNetCoreComponents;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Endpoints.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsEndpoints => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsEndpoints, "aspnet80.Microsoft.AspNetCore.Components.Endpoints");
+        private static byte[]? _MicrosoftAspNetCoreComponentsEndpoints;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Forms.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsForms, "aspnet80.Microsoft.AspNetCore.Components.Forms");
+        private static byte[]? _MicrosoftAspNetCoreComponentsForms;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Server.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsServer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsServer, "aspnet80.Microsoft.AspNetCore.Components.Server");
+        private static byte[]? _MicrosoftAspNetCoreComponentsServer;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Web.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsWeb => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsWeb, "aspnet80.Microsoft.AspNetCore.Components.Web");
+        private static byte[]? _MicrosoftAspNetCoreComponentsWeb;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Connections.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreConnectionsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreConnectionsAbstractions, "aspnet80.Microsoft.AspNetCore.Connections.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreConnectionsAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.CookiePolicy.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCookiePolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCookiePolicy, "aspnet80.Microsoft.AspNetCore.CookiePolicy");
+        private static byte[]? _MicrosoftAspNetCoreCookiePolicy;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Cors.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCors, "aspnet80.Microsoft.AspNetCore.Cors");
+        private static byte[]? _MicrosoftAspNetCoreCors;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Cryptography.Internal.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCryptographyInternal => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyInternal, "aspnet80.Microsoft.AspNetCore.Cryptography.Internal");
+        private static byte[]? _MicrosoftAspNetCoreCryptographyInternal;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCryptographyKeyDerivation => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyKeyDerivation, "aspnet80.Microsoft.AspNetCore.Cryptography.KeyDerivation");
+        private static byte[]? _MicrosoftAspNetCoreCryptographyKeyDerivation;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.DataProtection.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDataProtectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionAbstractions, "aspnet80.Microsoft.AspNetCore.DataProtection.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreDataProtectionAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.DataProtection.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDataProtection => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtection, "aspnet80.Microsoft.AspNetCore.DataProtection");
+        private static byte[]? _MicrosoftAspNetCoreDataProtection;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.DataProtection.Extensions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDataProtectionExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionExtensions, "aspnet80.Microsoft.AspNetCore.DataProtection.Extensions");
+        private static byte[]? _MicrosoftAspNetCoreDataProtectionExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsAbstractions, "aspnet80.Microsoft.AspNetCore.Diagnostics.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreDiagnosticsAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Diagnostics.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnostics, "aspnet80.Microsoft.AspNetCore.Diagnostics");
+        private static byte[]? _MicrosoftAspNetCoreDiagnostics;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsHealthChecks, "aspnet80.Microsoft.AspNetCore.Diagnostics.HealthChecks");
+        private static byte[]? _MicrosoftAspNetCoreDiagnosticsHealthChecks;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCore, "aspnet80.Microsoft.AspNetCore");
+        private static byte[]? _MicrosoftAspNetCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HostFiltering.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHostFiltering => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostFiltering, "aspnet80.Microsoft.AspNetCore.HostFiltering");
+        private static byte[]? _MicrosoftAspNetCoreHostFiltering;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Hosting.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingAbstractions, "aspnet80.Microsoft.AspNetCore.Hosting.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHostingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Hosting.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHosting, "aspnet80.Microsoft.AspNetCore.Hosting");
+        private static byte[]? _MicrosoftAspNetCoreHosting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHostingServerAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingServerAbstractions, "aspnet80.Microsoft.AspNetCore.Hosting.Server.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHostingServerAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Html.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHtmlAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHtmlAbstractions, "aspnet80.Microsoft.AspNetCore.Html.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHtmlAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpAbstractions, "aspnet80.Microsoft.AspNetCore.Http.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHttpAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Connections.Common.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpConnectionsCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnectionsCommon, "aspnet80.Microsoft.AspNetCore.Http.Connections.Common");
+        private static byte[]? _MicrosoftAspNetCoreHttpConnectionsCommon;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Connections.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpConnections => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnections, "aspnet80.Microsoft.AspNetCore.Http.Connections");
+        private static byte[]? _MicrosoftAspNetCoreHttpConnections;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttp, "aspnet80.Microsoft.AspNetCore.Http");
+        private static byte[]? _MicrosoftAspNetCoreHttp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Extensions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpExtensions, "aspnet80.Microsoft.AspNetCore.Http.Extensions");
+        private static byte[]? _MicrosoftAspNetCoreHttpExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Features.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpFeatures, "aspnet80.Microsoft.AspNetCore.Http.Features");
+        private static byte[]? _MicrosoftAspNetCoreHttpFeatures;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Results.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpResults => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpResults, "aspnet80.Microsoft.AspNetCore.Http.Results");
+        private static byte[]? _MicrosoftAspNetCoreHttpResults;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HttpLogging.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpLogging, "aspnet80.Microsoft.AspNetCore.HttpLogging");
+        private static byte[]? _MicrosoftAspNetCoreHttpLogging;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HttpOverrides.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpOverrides => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpOverrides, "aspnet80.Microsoft.AspNetCore.HttpOverrides");
+        private static byte[]? _MicrosoftAspNetCoreHttpOverrides;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HttpsPolicy.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpsPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpsPolicy, "aspnet80.Microsoft.AspNetCore.HttpsPolicy");
+        private static byte[]? _MicrosoftAspNetCoreHttpsPolicy;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Identity.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreIdentity => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreIdentity, "aspnet80.Microsoft.AspNetCore.Identity");
+        private static byte[]? _MicrosoftAspNetCoreIdentity;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Localization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalization, "aspnet80.Microsoft.AspNetCore.Localization");
+        private static byte[]? _MicrosoftAspNetCoreLocalization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Localization.Routing.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreLocalizationRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalizationRouting, "aspnet80.Microsoft.AspNetCore.Localization.Routing");
+        private static byte[]? _MicrosoftAspNetCoreLocalizationRouting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Metadata.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMetadata => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMetadata, "aspnet80.Microsoft.AspNetCore.Metadata");
+        private static byte[]? _MicrosoftAspNetCoreMetadata;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcAbstractions, "aspnet80.Microsoft.AspNetCore.Mvc.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreMvcAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcApiExplorer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcApiExplorer, "aspnet80.Microsoft.AspNetCore.Mvc.ApiExplorer");
+        private static byte[]? _MicrosoftAspNetCoreMvcApiExplorer;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCore, "aspnet80.Microsoft.AspNetCore.Mvc.Core");
+        private static byte[]? _MicrosoftAspNetCoreMvcCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Cors.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCors, "aspnet80.Microsoft.AspNetCore.Mvc.Cors");
+        private static byte[]? _MicrosoftAspNetCoreMvcCors;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcDataAnnotations, "aspnet80.Microsoft.AspNetCore.Mvc.DataAnnotations");
+        private static byte[]? _MicrosoftAspNetCoreMvcDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvc => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvc, "aspnet80.Microsoft.AspNetCore.Mvc");
+        private static byte[]? _MicrosoftAspNetCoreMvc;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcFormattersJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersJson, "aspnet80.Microsoft.AspNetCore.Mvc.Formatters.Json");
+        private static byte[]? _MicrosoftAspNetCoreMvcFormattersJson;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcFormattersXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersXml, "aspnet80.Microsoft.AspNetCore.Mvc.Formatters.Xml");
+        private static byte[]? _MicrosoftAspNetCoreMvcFormattersXml;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Localization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcLocalization, "aspnet80.Microsoft.AspNetCore.Mvc.Localization");
+        private static byte[]? _MicrosoftAspNetCoreMvcLocalization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Razor.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazor, "aspnet80.Microsoft.AspNetCore.Mvc.Razor");
+        private static byte[]? _MicrosoftAspNetCoreMvcRazor;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.RazorPages.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcRazorPages => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazorPages, "aspnet80.Microsoft.AspNetCore.Mvc.RazorPages");
+        private static byte[]? _MicrosoftAspNetCoreMvcRazorPages;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.TagHelpers.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcTagHelpers => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcTagHelpers, "aspnet80.Microsoft.AspNetCore.Mvc.TagHelpers");
+        private static byte[]? _MicrosoftAspNetCoreMvcTagHelpers;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcViewFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcViewFeatures, "aspnet80.Microsoft.AspNetCore.Mvc.ViewFeatures");
+        private static byte[]? _MicrosoftAspNetCoreMvcViewFeatures;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.OutputCaching.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreOutputCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreOutputCaching, "aspnet80.Microsoft.AspNetCore.OutputCaching");
+        private static byte[]? _MicrosoftAspNetCoreOutputCaching;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.RateLimiting.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRateLimiting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRateLimiting, "aspnet80.Microsoft.AspNetCore.RateLimiting");
+        private static byte[]? _MicrosoftAspNetCoreRateLimiting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Razor.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazor, "aspnet80.Microsoft.AspNetCore.Razor");
+        private static byte[]? _MicrosoftAspNetCoreRazor;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Razor.Runtime.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRazorRuntime => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazorRuntime, "aspnet80.Microsoft.AspNetCore.Razor.Runtime");
+        private static byte[]? _MicrosoftAspNetCoreRazorRuntime;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.RequestDecompression.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRequestDecompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRequestDecompression, "aspnet80.Microsoft.AspNetCore.RequestDecompression");
+        private static byte[]? _MicrosoftAspNetCoreRequestDecompression;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreResponseCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCachingAbstractions, "aspnet80.Microsoft.AspNetCore.ResponseCaching.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreResponseCachingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreResponseCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCaching, "aspnet80.Microsoft.AspNetCore.ResponseCaching");
+        private static byte[]? _MicrosoftAspNetCoreResponseCaching;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.ResponseCompression.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreResponseCompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCompression, "aspnet80.Microsoft.AspNetCore.ResponseCompression");
+        private static byte[]? _MicrosoftAspNetCoreResponseCompression;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Rewrite.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRewrite => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRewrite, "aspnet80.Microsoft.AspNetCore.Rewrite");
+        private static byte[]? _MicrosoftAspNetCoreRewrite;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Routing.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRoutingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRoutingAbstractions, "aspnet80.Microsoft.AspNetCore.Routing.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreRoutingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Routing.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRouting, "aspnet80.Microsoft.AspNetCore.Routing");
+        private static byte[]? _MicrosoftAspNetCoreRouting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.HttpSys.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerHttpSys => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerHttpSys, "aspnet80.Microsoft.AspNetCore.Server.HttpSys");
+        private static byte[]? _MicrosoftAspNetCoreServerHttpSys;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.IIS.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerIIS => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIIS, "aspnet80.Microsoft.AspNetCore.Server.IIS");
+        private static byte[]? _MicrosoftAspNetCoreServerIIS;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.IISIntegration.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerIISIntegration => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIISIntegration, "aspnet80.Microsoft.AspNetCore.Server.IISIntegration");
+        private static byte[]? _MicrosoftAspNetCoreServerIISIntegration;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelCore, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Core");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrel => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrel, "aspnet80.Microsoft.AspNetCore.Server.Kestrel");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrel;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelTransportNamedPipes => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportNamedPipes, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportNamedPipes;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelTransportQuic => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportQuic, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.Quic");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportQuic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelTransportSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportSockets, "aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportSockets;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Session.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSession => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSession, "aspnet80.Microsoft.AspNetCore.Session");
+        private static byte[]? _MicrosoftAspNetCoreSession;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.Common.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalRCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCommon, "aspnet80.Microsoft.AspNetCore.SignalR.Common");
+        private static byte[]? _MicrosoftAspNetCoreSignalRCommon;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalRCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCore, "aspnet80.Microsoft.AspNetCore.SignalR.Core");
+        private static byte[]? _MicrosoftAspNetCoreSignalRCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalR => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalR, "aspnet80.Microsoft.AspNetCore.SignalR");
+        private static byte[]? _MicrosoftAspNetCoreSignalR;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalRProtocolsJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRProtocolsJson, "aspnet80.Microsoft.AspNetCore.SignalR.Protocols.Json");
+        private static byte[]? _MicrosoftAspNetCoreSignalRProtocolsJson;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.StaticFiles.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreStaticFiles => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreStaticFiles, "aspnet80.Microsoft.AspNetCore.StaticFiles");
+        private static byte[]? _MicrosoftAspNetCoreStaticFiles;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.WebSockets.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreWebSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebSockets, "aspnet80.Microsoft.AspNetCore.WebSockets");
+        private static byte[]? _MicrosoftAspNetCoreWebSockets;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.WebUtilities.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreWebUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebUtilities, "aspnet80.Microsoft.AspNetCore.WebUtilities");
+        private static byte[]? _MicrosoftAspNetCoreWebUtilities;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Caching.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingAbstractions, "aspnet80.Microsoft.Extensions.Caching.Abstractions");
+        private static byte[]? _MicrosoftExtensionsCachingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Caching.Memory.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsCachingMemory => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingMemory, "aspnet80.Microsoft.Extensions.Caching.Memory");
+        private static byte[]? _MicrosoftExtensionsCachingMemory;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationAbstractions, "aspnet80.Microsoft.Extensions.Configuration.Abstractions");
+        private static byte[]? _MicrosoftExtensionsConfigurationAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Binder.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationBinder => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationBinder, "aspnet80.Microsoft.Extensions.Configuration.Binder");
+        private static byte[]? _MicrosoftExtensionsConfigurationBinder;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.CommandLine.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationCommandLine => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationCommandLine, "aspnet80.Microsoft.Extensions.Configuration.CommandLine");
+        private static byte[]? _MicrosoftExtensionsConfigurationCommandLine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfiguration, "aspnet80.Microsoft.Extensions.Configuration");
+        private static byte[]? _MicrosoftExtensionsConfiguration;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationEnvironmentVariables => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationEnvironmentVariables, "aspnet80.Microsoft.Extensions.Configuration.EnvironmentVariables");
+        private static byte[]? _MicrosoftExtensionsConfigurationEnvironmentVariables;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.FileExtensions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationFileExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationFileExtensions, "aspnet80.Microsoft.Extensions.Configuration.FileExtensions");
+        private static byte[]? _MicrosoftExtensionsConfigurationFileExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Ini.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationIni => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationIni, "aspnet80.Microsoft.Extensions.Configuration.Ini");
+        private static byte[]? _MicrosoftExtensionsConfigurationIni;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Json.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationJson, "aspnet80.Microsoft.Extensions.Configuration.Json");
+        private static byte[]? _MicrosoftExtensionsConfigurationJson;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.KeyPerFile.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationKeyPerFile => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationKeyPerFile, "aspnet80.Microsoft.Extensions.Configuration.KeyPerFile");
+        private static byte[]? _MicrosoftExtensionsConfigurationKeyPerFile;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.UserSecrets.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationUserSecrets => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationUserSecrets, "aspnet80.Microsoft.Extensions.Configuration.UserSecrets");
+        private static byte[]? _MicrosoftExtensionsConfigurationUserSecrets;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Xml.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationXml, "aspnet80.Microsoft.Extensions.Configuration.Xml");
+        private static byte[]? _MicrosoftExtensionsConfigurationXml;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.DependencyInjection.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDependencyInjectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjectionAbstractions, "aspnet80.Microsoft.Extensions.DependencyInjection.Abstractions");
+        private static byte[]? _MicrosoftExtensionsDependencyInjectionAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.DependencyInjection.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDependencyInjection => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjection, "aspnet80.Microsoft.Extensions.DependencyInjection");
+        private static byte[]? _MicrosoftExtensionsDependencyInjection;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsAbstractions, "aspnet80.Microsoft.Extensions.Diagnostics.Abstractions");
+        private static byte[]? _MicrosoftExtensionsDiagnosticsAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnostics, "aspnet80.Microsoft.Extensions.Diagnostics");
+        private static byte[]? _MicrosoftExtensionsDiagnostics;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecksAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions, "aspnet80.Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions");
+        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecks, "aspnet80.Microsoft.Extensions.Diagnostics.HealthChecks");
+        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecks;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Features.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFeatures, "aspnet80.Microsoft.Extensions.Features");
+        private static byte[]? _MicrosoftExtensionsFeatures;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersAbstractions, "aspnet80.Microsoft.Extensions.FileProviders.Abstractions");
+        private static byte[]? _MicrosoftExtensionsFileProvidersAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Composite.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersComposite => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersComposite, "aspnet80.Microsoft.Extensions.FileProviders.Composite");
+        private static byte[]? _MicrosoftExtensionsFileProvidersComposite;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Embedded.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersEmbedded => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersEmbedded, "aspnet80.Microsoft.Extensions.FileProviders.Embedded");
+        private static byte[]? _MicrosoftExtensionsFileProvidersEmbedded;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Physical.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersPhysical => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersPhysical, "aspnet80.Microsoft.Extensions.FileProviders.Physical");
+        private static byte[]? _MicrosoftExtensionsFileProvidersPhysical;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileSystemGlobbing.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileSystemGlobbing => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileSystemGlobbing, "aspnet80.Microsoft.Extensions.FileSystemGlobbing");
+        private static byte[]? _MicrosoftExtensionsFileSystemGlobbing;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Hosting.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHostingAbstractions, "aspnet80.Microsoft.Extensions.Hosting.Abstractions");
+        private static byte[]? _MicrosoftExtensionsHostingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Hosting.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHosting, "aspnet80.Microsoft.Extensions.Hosting");
+        private static byte[]? _MicrosoftExtensionsHosting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Http.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHttp, "aspnet80.Microsoft.Extensions.Http");
+        private static byte[]? _MicrosoftExtensionsHttp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Identity.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsIdentityCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityCore, "aspnet80.Microsoft.Extensions.Identity.Core");
+        private static byte[]? _MicrosoftExtensionsIdentityCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Identity.Stores.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsIdentityStores => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityStores, "aspnet80.Microsoft.Extensions.Identity.Stores");
+        private static byte[]? _MicrosoftExtensionsIdentityStores;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Localization.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLocalizationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalizationAbstractions, "aspnet80.Microsoft.Extensions.Localization.Abstractions");
+        private static byte[]? _MicrosoftExtensionsLocalizationAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Localization.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalization, "aspnet80.Microsoft.Extensions.Localization");
+        private static byte[]? _MicrosoftExtensionsLocalization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingAbstractions, "aspnet80.Microsoft.Extensions.Logging.Abstractions");
+        private static byte[]? _MicrosoftExtensionsLoggingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Configuration.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConfiguration, "aspnet80.Microsoft.Extensions.Logging.Configuration");
+        private static byte[]? _MicrosoftExtensionsLoggingConfiguration;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Console.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingConsole => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConsole, "aspnet80.Microsoft.Extensions.Logging.Console");
+        private static byte[]? _MicrosoftExtensionsLoggingConsole;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Debug.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingDebug => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingDebug, "aspnet80.Microsoft.Extensions.Logging.Debug");
+        private static byte[]? _MicrosoftExtensionsLoggingDebug;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLogging, "aspnet80.Microsoft.Extensions.Logging");
+        private static byte[]? _MicrosoftExtensionsLogging;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.EventLog.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingEventLog => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventLog, "aspnet80.Microsoft.Extensions.Logging.EventLog");
+        private static byte[]? _MicrosoftExtensionsLoggingEventLog;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.EventSource.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingEventSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventSource, "aspnet80.Microsoft.Extensions.Logging.EventSource");
+        private static byte[]? _MicrosoftExtensionsLoggingEventSource;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.TraceSource.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingTraceSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingTraceSource, "aspnet80.Microsoft.Extensions.Logging.TraceSource");
+        private static byte[]? _MicrosoftExtensionsLoggingTraceSource;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.ObjectPool.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsObjectPool => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsObjectPool, "aspnet80.Microsoft.Extensions.ObjectPool");
+        private static byte[]? _MicrosoftExtensionsObjectPool;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Options.ConfigurationExtensions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsOptionsConfigurationExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsConfigurationExtensions, "aspnet80.Microsoft.Extensions.Options.ConfigurationExtensions");
+        private static byte[]? _MicrosoftExtensionsOptionsConfigurationExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Options.DataAnnotations.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsOptionsDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsDataAnnotations, "aspnet80.Microsoft.Extensions.Options.DataAnnotations");
+        private static byte[]? _MicrosoftExtensionsOptionsDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Options.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsOptions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptions, "aspnet80.Microsoft.Extensions.Options");
+        private static byte[]? _MicrosoftExtensionsOptions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsPrimitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsPrimitives, "aspnet80.Microsoft.Extensions.Primitives");
+        private static byte[]? _MicrosoftExtensionsPrimitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.WebEncoders.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsWebEncoders => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsWebEncoders, "aspnet80.Microsoft.Extensions.WebEncoders");
+        private static byte[]? _MicrosoftExtensionsWebEncoders;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JSInterop.dll
+        /// </summary>
+        public static byte[] MicrosoftJSInterop => ResourceLoader.GetOrCreateResource(ref _MicrosoftJSInterop, "aspnet80.Microsoft.JSInterop");
+        private static byte[]? _MicrosoftJSInterop;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Net.Http.Headers.dll
+        /// </summary>
+        public static byte[] MicrosoftNetHttpHeaders => ResourceLoader.GetOrCreateResource(ref _MicrosoftNetHttpHeaders, "aspnet80.Microsoft.Net.Http.Headers");
+        private static byte[]? _MicrosoftNetHttpHeaders;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.EventLog.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "aspnet80.System.Diagnostics.EventLog");
+        private static byte[]? _SystemDiagnosticsEventLog;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipelines.dll
+        /// </summary>
+        public static byte[] SystemIOPipelines => ResourceLoader.GetOrCreateResource(ref _SystemIOPipelines, "aspnet80.System.IO.Pipelines");
+        private static byte[]? _SystemIOPipelines;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Xml.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "aspnet80.System.Security.Cryptography.Xml");
+        private static byte[]? _SystemSecurityCryptographyXml;
+
+        /// <summary>
+        /// The image bytes for System.Threading.RateLimiting.dll
+        /// </summary>
+        public static byte[] SystemThreadingRateLimiting => ResourceLoader.GetOrCreateResource(ref _SystemThreadingRateLimiting, "aspnet80.System.Threading.RateLimiting");
+        private static byte[]? _SystemThreadingRateLimiting;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.AspNet90/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.AspNet90/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -1826,6 +1826,7 @@ public static partial class AspNet90
 
     }
 }
+
 public static partial class AspNet90
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.AspNet90/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.AspNet90/Generated.cs
@@ -9,1826 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class AspNet90
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "aspnet90.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "aspnet90.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "aspnet90.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "aspnet90.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "aspnet90.Microsoft.Win32.Registry");
-        private static byte[]? _MicrosoftWin32Registry;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "aspnet90.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "aspnet90.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "aspnet90.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "aspnet90.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "aspnet90.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "aspnet90.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "aspnet90.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "aspnet90.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "aspnet90.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "aspnet90.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "aspnet90.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "aspnet90.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "aspnet90.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "aspnet90.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "aspnet90.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "aspnet90.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "aspnet90.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "aspnet90.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "aspnet90.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "aspnet90.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "aspnet90.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "aspnet90.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "aspnet90.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "aspnet90.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "aspnet90.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "aspnet90.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "aspnet90.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "aspnet90.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "aspnet90.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "aspnet90.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "aspnet90.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "aspnet90.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "aspnet90.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "aspnet90.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "aspnet90.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "aspnet90.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Tar.dll
-        /// </summary>
-        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "aspnet90.System.Formats.Tar");
-        private static byte[]? _SystemFormatsTar;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "aspnet90.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "aspnet90.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "aspnet90.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "aspnet90.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "aspnet90.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "aspnet90.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "aspnet90.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "aspnet90.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "aspnet90.System.IO.FileSystem.AccessControl");
-        private static byte[]? _SystemIOFileSystemAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "aspnet90.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "aspnet90.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "aspnet90.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "aspnet90.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "aspnet90.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "aspnet90.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipelines.dll
-        /// </summary>
-        public static byte[] SystemIOPipelines => ResourceLoader.GetOrCreateResource(ref _SystemIOPipelines, "aspnet90.System.IO.Pipelines");
-        private static byte[]? _SystemIOPipelines;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "aspnet90.System.IO.Pipes.AccessControl");
-        private static byte[]? _SystemIOPipesAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "aspnet90.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "aspnet90.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "aspnet90.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "aspnet90.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "aspnet90.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "aspnet90.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "aspnet90.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "aspnet90.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "aspnet90.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "aspnet90.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "aspnet90.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "aspnet90.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "aspnet90.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "aspnet90.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "aspnet90.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "aspnet90.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Quic.dll
-        /// </summary>
-        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "aspnet90.System.Net.Quic");
-        private static byte[]? _SystemNetQuic;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "aspnet90.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "aspnet90.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "aspnet90.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "aspnet90.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "aspnet90.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "aspnet90.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "aspnet90.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "aspnet90.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "aspnet90.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "aspnet90.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "aspnet90.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "aspnet90.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "aspnet90.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "aspnet90.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "aspnet90.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "aspnet90.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "aspnet90.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "aspnet90.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "aspnet90.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "aspnet90.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "aspnet90.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "aspnet90.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "aspnet90.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "aspnet90.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "aspnet90.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "aspnet90.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "aspnet90.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "aspnet90.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "aspnet90.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "aspnet90.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "aspnet90.System.Runtime.InteropServices.JavaScript");
-        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "aspnet90.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "aspnet90.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "aspnet90.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "aspnet90.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "aspnet90.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "aspnet90.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "aspnet90.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "aspnet90.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "aspnet90.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "aspnet90.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "aspnet90.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "aspnet90.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Cng.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "aspnet90.System.Security.Cryptography.Cng");
-        private static byte[]? _SystemSecurityCryptographyCng;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "aspnet90.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "aspnet90.System.Security.Cryptography");
-        private static byte[]? _SystemSecurityCryptography;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "aspnet90.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "aspnet90.System.Security.Cryptography.OpenSsl");
-        private static byte[]? _SystemSecurityCryptographyOpenSsl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "aspnet90.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "aspnet90.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "aspnet90.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "aspnet90.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "aspnet90.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "aspnet90.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "aspnet90.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "aspnet90.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "aspnet90.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "aspnet90.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "aspnet90.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "aspnet90.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "aspnet90.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "aspnet90.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "aspnet90.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "aspnet90.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "aspnet90.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "aspnet90.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "aspnet90.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "aspnet90.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "aspnet90.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "aspnet90.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "aspnet90.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "aspnet90.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "aspnet90.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "aspnet90.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "aspnet90.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "aspnet90.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "aspnet90.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "aspnet90.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "aspnet90.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "aspnet90.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "aspnet90.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "aspnet90.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "aspnet90.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "aspnet90.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "aspnet90.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "aspnet90.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "aspnet90.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "aspnet90.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Antiforgery.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAntiforgery => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAntiforgery, "aspnet90.Microsoft.AspNetCore.Antiforgery");
-        private static byte[]? _MicrosoftAspNetCoreAntiforgery;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationAbstractions, "aspnet90.Microsoft.AspNetCore.Authentication.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.BearerToken.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationBearerToken => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationBearerToken, "aspnet90.Microsoft.AspNetCore.Authentication.BearerToken");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationBearerToken;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.Cookies.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationCookies => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCookies, "aspnet90.Microsoft.AspNetCore.Authentication.Cookies");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationCookies;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCore, "aspnet90.Microsoft.AspNetCore.Authentication.Core");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthentication => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthentication, "aspnet90.Microsoft.AspNetCore.Authentication");
-        private static byte[]? _MicrosoftAspNetCoreAuthentication;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authentication.OAuth.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthenticationOAuth => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationOAuth, "aspnet90.Microsoft.AspNetCore.Authentication.OAuth");
-        private static byte[]? _MicrosoftAspNetCoreAuthenticationOAuth;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authorization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorization, "aspnet90.Microsoft.AspNetCore.Authorization");
-        private static byte[]? _MicrosoftAspNetCoreAuthorization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Authorization.Policy.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreAuthorizationPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorizationPolicy, "aspnet90.Microsoft.AspNetCore.Authorization.Policy");
-        private static byte[]? _MicrosoftAspNetCoreAuthorizationPolicy;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Authorization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsAuthorization, "aspnet90.Microsoft.AspNetCore.Components.Authorization");
-        private static byte[]? _MicrosoftAspNetCoreComponentsAuthorization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponents => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponents, "aspnet90.Microsoft.AspNetCore.Components");
-        private static byte[]? _MicrosoftAspNetCoreComponents;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Endpoints.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsEndpoints => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsEndpoints, "aspnet90.Microsoft.AspNetCore.Components.Endpoints");
-        private static byte[]? _MicrosoftAspNetCoreComponentsEndpoints;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Forms.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsForms, "aspnet90.Microsoft.AspNetCore.Components.Forms");
-        private static byte[]? _MicrosoftAspNetCoreComponentsForms;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Server.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsServer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsServer, "aspnet90.Microsoft.AspNetCore.Components.Server");
-        private static byte[]? _MicrosoftAspNetCoreComponentsServer;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Components.Web.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreComponentsWeb => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsWeb, "aspnet90.Microsoft.AspNetCore.Components.Web");
-        private static byte[]? _MicrosoftAspNetCoreComponentsWeb;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Connections.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreConnectionsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreConnectionsAbstractions, "aspnet90.Microsoft.AspNetCore.Connections.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreConnectionsAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.CookiePolicy.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCookiePolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCookiePolicy, "aspnet90.Microsoft.AspNetCore.CookiePolicy");
-        private static byte[]? _MicrosoftAspNetCoreCookiePolicy;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Cors.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCors, "aspnet90.Microsoft.AspNetCore.Cors");
-        private static byte[]? _MicrosoftAspNetCoreCors;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Cryptography.Internal.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCryptographyInternal => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyInternal, "aspnet90.Microsoft.AspNetCore.Cryptography.Internal");
-        private static byte[]? _MicrosoftAspNetCoreCryptographyInternal;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreCryptographyKeyDerivation => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyKeyDerivation, "aspnet90.Microsoft.AspNetCore.Cryptography.KeyDerivation");
-        private static byte[]? _MicrosoftAspNetCoreCryptographyKeyDerivation;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.DataProtection.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDataProtectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionAbstractions, "aspnet90.Microsoft.AspNetCore.DataProtection.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreDataProtectionAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.DataProtection.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDataProtection => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtection, "aspnet90.Microsoft.AspNetCore.DataProtection");
-        private static byte[]? _MicrosoftAspNetCoreDataProtection;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.DataProtection.Extensions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDataProtectionExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionExtensions, "aspnet90.Microsoft.AspNetCore.DataProtection.Extensions");
-        private static byte[]? _MicrosoftAspNetCoreDataProtectionExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Diagnostics.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsAbstractions, "aspnet90.Microsoft.AspNetCore.Diagnostics.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreDiagnosticsAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Diagnostics.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnostics, "aspnet90.Microsoft.AspNetCore.Diagnostics");
-        private static byte[]? _MicrosoftAspNetCoreDiagnostics;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsHealthChecks, "aspnet90.Microsoft.AspNetCore.Diagnostics.HealthChecks");
-        private static byte[]? _MicrosoftAspNetCoreDiagnosticsHealthChecks;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCore, "aspnet90.Microsoft.AspNetCore");
-        private static byte[]? _MicrosoftAspNetCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HostFiltering.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHostFiltering => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostFiltering, "aspnet90.Microsoft.AspNetCore.HostFiltering");
-        private static byte[]? _MicrosoftAspNetCoreHostFiltering;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Hosting.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingAbstractions, "aspnet90.Microsoft.AspNetCore.Hosting.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHostingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Hosting.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHosting, "aspnet90.Microsoft.AspNetCore.Hosting");
-        private static byte[]? _MicrosoftAspNetCoreHosting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHostingServerAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingServerAbstractions, "aspnet90.Microsoft.AspNetCore.Hosting.Server.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHostingServerAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Html.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHtmlAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHtmlAbstractions, "aspnet90.Microsoft.AspNetCore.Html.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHtmlAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpAbstractions, "aspnet90.Microsoft.AspNetCore.Http.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreHttpAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Connections.Common.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpConnectionsCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnectionsCommon, "aspnet90.Microsoft.AspNetCore.Http.Connections.Common");
-        private static byte[]? _MicrosoftAspNetCoreHttpConnectionsCommon;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Connections.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpConnections => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnections, "aspnet90.Microsoft.AspNetCore.Http.Connections");
-        private static byte[]? _MicrosoftAspNetCoreHttpConnections;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttp, "aspnet90.Microsoft.AspNetCore.Http");
-        private static byte[]? _MicrosoftAspNetCoreHttp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Extensions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpExtensions, "aspnet90.Microsoft.AspNetCore.Http.Extensions");
-        private static byte[]? _MicrosoftAspNetCoreHttpExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Features.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpFeatures, "aspnet90.Microsoft.AspNetCore.Http.Features");
-        private static byte[]? _MicrosoftAspNetCoreHttpFeatures;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Http.Results.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpResults => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpResults, "aspnet90.Microsoft.AspNetCore.Http.Results");
-        private static byte[]? _MicrosoftAspNetCoreHttpResults;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HttpLogging.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpLogging, "aspnet90.Microsoft.AspNetCore.HttpLogging");
-        private static byte[]? _MicrosoftAspNetCoreHttpLogging;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HttpOverrides.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpOverrides => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpOverrides, "aspnet90.Microsoft.AspNetCore.HttpOverrides");
-        private static byte[]? _MicrosoftAspNetCoreHttpOverrides;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.HttpsPolicy.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreHttpsPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpsPolicy, "aspnet90.Microsoft.AspNetCore.HttpsPolicy");
-        private static byte[]? _MicrosoftAspNetCoreHttpsPolicy;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Identity.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreIdentity => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreIdentity, "aspnet90.Microsoft.AspNetCore.Identity");
-        private static byte[]? _MicrosoftAspNetCoreIdentity;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Localization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalization, "aspnet90.Microsoft.AspNetCore.Localization");
-        private static byte[]? _MicrosoftAspNetCoreLocalization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Localization.Routing.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreLocalizationRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalizationRouting, "aspnet90.Microsoft.AspNetCore.Localization.Routing");
-        private static byte[]? _MicrosoftAspNetCoreLocalizationRouting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Metadata.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMetadata => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMetadata, "aspnet90.Microsoft.AspNetCore.Metadata");
-        private static byte[]? _MicrosoftAspNetCoreMetadata;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcAbstractions, "aspnet90.Microsoft.AspNetCore.Mvc.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreMvcAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.ApiExplorer.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcApiExplorer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcApiExplorer, "aspnet90.Microsoft.AspNetCore.Mvc.ApiExplorer");
-        private static byte[]? _MicrosoftAspNetCoreMvcApiExplorer;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCore, "aspnet90.Microsoft.AspNetCore.Mvc.Core");
-        private static byte[]? _MicrosoftAspNetCoreMvcCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Cors.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCors, "aspnet90.Microsoft.AspNetCore.Mvc.Cors");
-        private static byte[]? _MicrosoftAspNetCoreMvcCors;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.DataAnnotations.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcDataAnnotations, "aspnet90.Microsoft.AspNetCore.Mvc.DataAnnotations");
-        private static byte[]? _MicrosoftAspNetCoreMvcDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvc => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvc, "aspnet90.Microsoft.AspNetCore.Mvc");
-        private static byte[]? _MicrosoftAspNetCoreMvc;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Json.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcFormattersJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersJson, "aspnet90.Microsoft.AspNetCore.Mvc.Formatters.Json");
-        private static byte[]? _MicrosoftAspNetCoreMvcFormattersJson;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcFormattersXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersXml, "aspnet90.Microsoft.AspNetCore.Mvc.Formatters.Xml");
-        private static byte[]? _MicrosoftAspNetCoreMvcFormattersXml;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Localization.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcLocalization, "aspnet90.Microsoft.AspNetCore.Mvc.Localization");
-        private static byte[]? _MicrosoftAspNetCoreMvcLocalization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.Razor.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazor, "aspnet90.Microsoft.AspNetCore.Mvc.Razor");
-        private static byte[]? _MicrosoftAspNetCoreMvcRazor;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.RazorPages.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcRazorPages => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazorPages, "aspnet90.Microsoft.AspNetCore.Mvc.RazorPages");
-        private static byte[]? _MicrosoftAspNetCoreMvcRazorPages;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.TagHelpers.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcTagHelpers => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcTagHelpers, "aspnet90.Microsoft.AspNetCore.Mvc.TagHelpers");
-        private static byte[]? _MicrosoftAspNetCoreMvcTagHelpers;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Mvc.ViewFeatures.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreMvcViewFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcViewFeatures, "aspnet90.Microsoft.AspNetCore.Mvc.ViewFeatures");
-        private static byte[]? _MicrosoftAspNetCoreMvcViewFeatures;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.OutputCaching.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreOutputCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreOutputCaching, "aspnet90.Microsoft.AspNetCore.OutputCaching");
-        private static byte[]? _MicrosoftAspNetCoreOutputCaching;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.RateLimiting.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRateLimiting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRateLimiting, "aspnet90.Microsoft.AspNetCore.RateLimiting");
-        private static byte[]? _MicrosoftAspNetCoreRateLimiting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Razor.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazor, "aspnet90.Microsoft.AspNetCore.Razor");
-        private static byte[]? _MicrosoftAspNetCoreRazor;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Razor.Runtime.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRazorRuntime => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazorRuntime, "aspnet90.Microsoft.AspNetCore.Razor.Runtime");
-        private static byte[]? _MicrosoftAspNetCoreRazorRuntime;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.RequestDecompression.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRequestDecompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRequestDecompression, "aspnet90.Microsoft.AspNetCore.RequestDecompression");
-        private static byte[]? _MicrosoftAspNetCoreRequestDecompression;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreResponseCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCachingAbstractions, "aspnet90.Microsoft.AspNetCore.ResponseCaching.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreResponseCachingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreResponseCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCaching, "aspnet90.Microsoft.AspNetCore.ResponseCaching");
-        private static byte[]? _MicrosoftAspNetCoreResponseCaching;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.ResponseCompression.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreResponseCompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCompression, "aspnet90.Microsoft.AspNetCore.ResponseCompression");
-        private static byte[]? _MicrosoftAspNetCoreResponseCompression;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Rewrite.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRewrite => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRewrite, "aspnet90.Microsoft.AspNetCore.Rewrite");
-        private static byte[]? _MicrosoftAspNetCoreRewrite;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Routing.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRoutingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRoutingAbstractions, "aspnet90.Microsoft.AspNetCore.Routing.Abstractions");
-        private static byte[]? _MicrosoftAspNetCoreRoutingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Routing.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRouting, "aspnet90.Microsoft.AspNetCore.Routing");
-        private static byte[]? _MicrosoftAspNetCoreRouting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.HttpSys.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerHttpSys => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerHttpSys, "aspnet90.Microsoft.AspNetCore.Server.HttpSys");
-        private static byte[]? _MicrosoftAspNetCoreServerHttpSys;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.IIS.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerIIS => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIIS, "aspnet90.Microsoft.AspNetCore.Server.IIS");
-        private static byte[]? _MicrosoftAspNetCoreServerIIS;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.IISIntegration.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerIISIntegration => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIISIntegration, "aspnet90.Microsoft.AspNetCore.Server.IISIntegration");
-        private static byte[]? _MicrosoftAspNetCoreServerIISIntegration;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelCore, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Core");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrel => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrel, "aspnet90.Microsoft.AspNetCore.Server.Kestrel");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrel;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelTransportNamedPipes => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportNamedPipes, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportNamedPipes;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelTransportQuic => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportQuic, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.Quic");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportQuic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreServerKestrelTransportSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportSockets, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets");
-        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportSockets;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.Session.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSession => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSession, "aspnet90.Microsoft.AspNetCore.Session");
-        private static byte[]? _MicrosoftAspNetCoreSession;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.Common.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalRCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCommon, "aspnet90.Microsoft.AspNetCore.SignalR.Common");
-        private static byte[]? _MicrosoftAspNetCoreSignalRCommon;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalRCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCore, "aspnet90.Microsoft.AspNetCore.SignalR.Core");
-        private static byte[]? _MicrosoftAspNetCoreSignalRCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalR => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalR, "aspnet90.Microsoft.AspNetCore.SignalR");
-        private static byte[]? _MicrosoftAspNetCoreSignalR;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.SignalR.Protocols.Json.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreSignalRProtocolsJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRProtocolsJson, "aspnet90.Microsoft.AspNetCore.SignalR.Protocols.Json");
-        private static byte[]? _MicrosoftAspNetCoreSignalRProtocolsJson;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.StaticAssets.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreStaticAssets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreStaticAssets, "aspnet90.Microsoft.AspNetCore.StaticAssets");
-        private static byte[]? _MicrosoftAspNetCoreStaticAssets;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.StaticFiles.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreStaticFiles => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreStaticFiles, "aspnet90.Microsoft.AspNetCore.StaticFiles");
-        private static byte[]? _MicrosoftAspNetCoreStaticFiles;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.WebSockets.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreWebSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebSockets, "aspnet90.Microsoft.AspNetCore.WebSockets");
-        private static byte[]? _MicrosoftAspNetCoreWebSockets;
-
-        /// <summary>
-        /// The image bytes for Microsoft.AspNetCore.WebUtilities.dll
-        /// </summary>
-        public static byte[] MicrosoftAspNetCoreWebUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebUtilities, "aspnet90.Microsoft.AspNetCore.WebUtilities");
-        private static byte[]? _MicrosoftAspNetCoreWebUtilities;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Caching.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingAbstractions, "aspnet90.Microsoft.Extensions.Caching.Abstractions");
-        private static byte[]? _MicrosoftExtensionsCachingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Caching.Memory.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsCachingMemory => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingMemory, "aspnet90.Microsoft.Extensions.Caching.Memory");
-        private static byte[]? _MicrosoftExtensionsCachingMemory;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationAbstractions, "aspnet90.Microsoft.Extensions.Configuration.Abstractions");
-        private static byte[]? _MicrosoftExtensionsConfigurationAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Binder.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationBinder => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationBinder, "aspnet90.Microsoft.Extensions.Configuration.Binder");
-        private static byte[]? _MicrosoftExtensionsConfigurationBinder;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.CommandLine.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationCommandLine => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationCommandLine, "aspnet90.Microsoft.Extensions.Configuration.CommandLine");
-        private static byte[]? _MicrosoftExtensionsConfigurationCommandLine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfiguration, "aspnet90.Microsoft.Extensions.Configuration");
-        private static byte[]? _MicrosoftExtensionsConfiguration;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.EnvironmentVariables.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationEnvironmentVariables => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationEnvironmentVariables, "aspnet90.Microsoft.Extensions.Configuration.EnvironmentVariables");
-        private static byte[]? _MicrosoftExtensionsConfigurationEnvironmentVariables;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.FileExtensions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationFileExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationFileExtensions, "aspnet90.Microsoft.Extensions.Configuration.FileExtensions");
-        private static byte[]? _MicrosoftExtensionsConfigurationFileExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Ini.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationIni => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationIni, "aspnet90.Microsoft.Extensions.Configuration.Ini");
-        private static byte[]? _MicrosoftExtensionsConfigurationIni;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Json.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationJson, "aspnet90.Microsoft.Extensions.Configuration.Json");
-        private static byte[]? _MicrosoftExtensionsConfigurationJson;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.KeyPerFile.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationKeyPerFile => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationKeyPerFile, "aspnet90.Microsoft.Extensions.Configuration.KeyPerFile");
-        private static byte[]? _MicrosoftExtensionsConfigurationKeyPerFile;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.UserSecrets.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationUserSecrets => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationUserSecrets, "aspnet90.Microsoft.Extensions.Configuration.UserSecrets");
-        private static byte[]? _MicrosoftExtensionsConfigurationUserSecrets;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Configuration.Xml.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsConfigurationXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationXml, "aspnet90.Microsoft.Extensions.Configuration.Xml");
-        private static byte[]? _MicrosoftExtensionsConfigurationXml;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.DependencyInjection.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDependencyInjectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjectionAbstractions, "aspnet90.Microsoft.Extensions.DependencyInjection.Abstractions");
-        private static byte[]? _MicrosoftExtensionsDependencyInjectionAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.DependencyInjection.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDependencyInjection => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjection, "aspnet90.Microsoft.Extensions.DependencyInjection");
-        private static byte[]? _MicrosoftExtensionsDependencyInjection;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsAbstractions, "aspnet90.Microsoft.Extensions.Diagnostics.Abstractions");
-        private static byte[]? _MicrosoftExtensionsDiagnosticsAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnostics, "aspnet90.Microsoft.Extensions.Diagnostics");
-        private static byte[]? _MicrosoftExtensionsDiagnostics;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecksAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions, "aspnet90.Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions");
-        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecks, "aspnet90.Microsoft.Extensions.Diagnostics.HealthChecks");
-        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecks;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Features.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFeatures, "aspnet90.Microsoft.Extensions.Features");
-        private static byte[]? _MicrosoftExtensionsFeatures;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersAbstractions, "aspnet90.Microsoft.Extensions.FileProviders.Abstractions");
-        private static byte[]? _MicrosoftExtensionsFileProvidersAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Composite.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersComposite => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersComposite, "aspnet90.Microsoft.Extensions.FileProviders.Composite");
-        private static byte[]? _MicrosoftExtensionsFileProvidersComposite;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Embedded.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersEmbedded => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersEmbedded, "aspnet90.Microsoft.Extensions.FileProviders.Embedded");
-        private static byte[]? _MicrosoftExtensionsFileProvidersEmbedded;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileProviders.Physical.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileProvidersPhysical => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersPhysical, "aspnet90.Microsoft.Extensions.FileProviders.Physical");
-        private static byte[]? _MicrosoftExtensionsFileProvidersPhysical;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.FileSystemGlobbing.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsFileSystemGlobbing => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileSystemGlobbing, "aspnet90.Microsoft.Extensions.FileSystemGlobbing");
-        private static byte[]? _MicrosoftExtensionsFileSystemGlobbing;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Hosting.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHostingAbstractions, "aspnet90.Microsoft.Extensions.Hosting.Abstractions");
-        private static byte[]? _MicrosoftExtensionsHostingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Hosting.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHosting, "aspnet90.Microsoft.Extensions.Hosting");
-        private static byte[]? _MicrosoftExtensionsHosting;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Http.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHttp, "aspnet90.Microsoft.Extensions.Http");
-        private static byte[]? _MicrosoftExtensionsHttp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Identity.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsIdentityCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityCore, "aspnet90.Microsoft.Extensions.Identity.Core");
-        private static byte[]? _MicrosoftExtensionsIdentityCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Identity.Stores.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsIdentityStores => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityStores, "aspnet90.Microsoft.Extensions.Identity.Stores");
-        private static byte[]? _MicrosoftExtensionsIdentityStores;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Localization.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLocalizationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalizationAbstractions, "aspnet90.Microsoft.Extensions.Localization.Abstractions");
-        private static byte[]? _MicrosoftExtensionsLocalizationAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Localization.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalization, "aspnet90.Microsoft.Extensions.Localization");
-        private static byte[]? _MicrosoftExtensionsLocalization;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Abstractions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingAbstractions, "aspnet90.Microsoft.Extensions.Logging.Abstractions");
-        private static byte[]? _MicrosoftExtensionsLoggingAbstractions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Configuration.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConfiguration, "aspnet90.Microsoft.Extensions.Logging.Configuration");
-        private static byte[]? _MicrosoftExtensionsLoggingConfiguration;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Console.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingConsole => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConsole, "aspnet90.Microsoft.Extensions.Logging.Console");
-        private static byte[]? _MicrosoftExtensionsLoggingConsole;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.Debug.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingDebug => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingDebug, "aspnet90.Microsoft.Extensions.Logging.Debug");
-        private static byte[]? _MicrosoftExtensionsLoggingDebug;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLogging, "aspnet90.Microsoft.Extensions.Logging");
-        private static byte[]? _MicrosoftExtensionsLogging;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.EventLog.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingEventLog => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventLog, "aspnet90.Microsoft.Extensions.Logging.EventLog");
-        private static byte[]? _MicrosoftExtensionsLoggingEventLog;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.EventSource.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingEventSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventSource, "aspnet90.Microsoft.Extensions.Logging.EventSource");
-        private static byte[]? _MicrosoftExtensionsLoggingEventSource;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Logging.TraceSource.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsLoggingTraceSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingTraceSource, "aspnet90.Microsoft.Extensions.Logging.TraceSource");
-        private static byte[]? _MicrosoftExtensionsLoggingTraceSource;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.ObjectPool.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsObjectPool => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsObjectPool, "aspnet90.Microsoft.Extensions.ObjectPool");
-        private static byte[]? _MicrosoftExtensionsObjectPool;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Options.ConfigurationExtensions.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsOptionsConfigurationExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsConfigurationExtensions, "aspnet90.Microsoft.Extensions.Options.ConfigurationExtensions");
-        private static byte[]? _MicrosoftExtensionsOptionsConfigurationExtensions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Options.DataAnnotations.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsOptionsDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsDataAnnotations, "aspnet90.Microsoft.Extensions.Options.DataAnnotations");
-        private static byte[]? _MicrosoftExtensionsOptionsDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Options.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsOptions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptions, "aspnet90.Microsoft.Extensions.Options");
-        private static byte[]? _MicrosoftExtensionsOptions;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsPrimitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsPrimitives, "aspnet90.Microsoft.Extensions.Primitives");
-        private static byte[]? _MicrosoftExtensionsPrimitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Extensions.WebEncoders.dll
-        /// </summary>
-        public static byte[] MicrosoftExtensionsWebEncoders => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsWebEncoders, "aspnet90.Microsoft.Extensions.WebEncoders");
-        private static byte[]? _MicrosoftExtensionsWebEncoders;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JSInterop.dll
-        /// </summary>
-        public static byte[] MicrosoftJSInterop => ResourceLoader.GetOrCreateResource(ref _MicrosoftJSInterop, "aspnet90.Microsoft.JSInterop");
-        private static byte[]? _MicrosoftJSInterop;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Net.Http.Headers.dll
-        /// </summary>
-        public static byte[] MicrosoftNetHttpHeaders => ResourceLoader.GetOrCreateResource(ref _MicrosoftNetHttpHeaders, "aspnet90.Microsoft.Net.Http.Headers");
-        private static byte[]? _MicrosoftNetHttpHeaders;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.EventLog.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "aspnet90.System.Diagnostics.EventLog");
-        private static byte[]? _SystemDiagnosticsEventLog;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Xml.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "aspnet90.System.Security.Cryptography.Xml");
-        private static byte[]? _SystemSecurityCryptographyXml;
-
-        /// <summary>
-        /// The image bytes for System.Threading.RateLimiting.dll
-        /// </summary>
-        public static byte[] SystemThreadingRateLimiting => ResourceLoader.GetOrCreateResource(ref _SystemThreadingRateLimiting, "aspnet90.System.Threading.RateLimiting");
-        private static byte[]? _SystemThreadingRateLimiting;
-
-
-    }
-}
-
-public static partial class AspNet90
-{
     public static class ReferenceInfos
     {
 
@@ -9116,6 +7296,1826 @@ public static partial class AspNet90
                 return _all;
             }
         }
+    }
+}
+
+public static partial class AspNet90
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "aspnet90.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "aspnet90.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "aspnet90.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "aspnet90.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "aspnet90.Microsoft.Win32.Registry");
+        private static byte[]? _MicrosoftWin32Registry;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "aspnet90.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "aspnet90.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "aspnet90.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "aspnet90.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "aspnet90.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "aspnet90.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "aspnet90.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "aspnet90.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "aspnet90.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "aspnet90.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "aspnet90.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "aspnet90.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "aspnet90.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "aspnet90.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "aspnet90.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "aspnet90.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "aspnet90.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "aspnet90.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "aspnet90.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "aspnet90.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "aspnet90.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "aspnet90.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "aspnet90.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "aspnet90.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "aspnet90.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "aspnet90.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "aspnet90.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "aspnet90.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "aspnet90.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "aspnet90.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "aspnet90.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "aspnet90.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "aspnet90.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "aspnet90.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "aspnet90.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "aspnet90.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Tar.dll
+        /// </summary>
+        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "aspnet90.System.Formats.Tar");
+        private static byte[]? _SystemFormatsTar;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "aspnet90.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "aspnet90.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "aspnet90.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "aspnet90.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "aspnet90.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "aspnet90.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "aspnet90.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "aspnet90.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "aspnet90.System.IO.FileSystem.AccessControl");
+        private static byte[]? _SystemIOFileSystemAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "aspnet90.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "aspnet90.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "aspnet90.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "aspnet90.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "aspnet90.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "aspnet90.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipelines.dll
+        /// </summary>
+        public static byte[] SystemIOPipelines => ResourceLoader.GetOrCreateResource(ref _SystemIOPipelines, "aspnet90.System.IO.Pipelines");
+        private static byte[]? _SystemIOPipelines;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "aspnet90.System.IO.Pipes.AccessControl");
+        private static byte[]? _SystemIOPipesAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "aspnet90.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "aspnet90.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "aspnet90.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "aspnet90.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "aspnet90.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "aspnet90.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "aspnet90.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "aspnet90.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "aspnet90.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "aspnet90.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "aspnet90.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "aspnet90.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "aspnet90.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "aspnet90.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "aspnet90.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "aspnet90.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Quic.dll
+        /// </summary>
+        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "aspnet90.System.Net.Quic");
+        private static byte[]? _SystemNetQuic;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "aspnet90.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "aspnet90.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "aspnet90.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "aspnet90.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "aspnet90.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "aspnet90.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "aspnet90.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "aspnet90.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "aspnet90.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "aspnet90.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "aspnet90.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "aspnet90.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "aspnet90.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "aspnet90.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "aspnet90.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "aspnet90.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "aspnet90.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "aspnet90.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "aspnet90.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "aspnet90.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "aspnet90.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "aspnet90.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "aspnet90.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "aspnet90.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "aspnet90.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "aspnet90.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "aspnet90.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "aspnet90.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "aspnet90.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "aspnet90.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "aspnet90.System.Runtime.InteropServices.JavaScript");
+        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "aspnet90.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "aspnet90.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "aspnet90.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "aspnet90.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "aspnet90.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "aspnet90.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "aspnet90.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "aspnet90.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "aspnet90.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "aspnet90.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "aspnet90.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "aspnet90.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Cng.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "aspnet90.System.Security.Cryptography.Cng");
+        private static byte[]? _SystemSecurityCryptographyCng;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "aspnet90.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "aspnet90.System.Security.Cryptography");
+        private static byte[]? _SystemSecurityCryptography;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "aspnet90.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "aspnet90.System.Security.Cryptography.OpenSsl");
+        private static byte[]? _SystemSecurityCryptographyOpenSsl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "aspnet90.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "aspnet90.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "aspnet90.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "aspnet90.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "aspnet90.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "aspnet90.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "aspnet90.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "aspnet90.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "aspnet90.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "aspnet90.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "aspnet90.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "aspnet90.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "aspnet90.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "aspnet90.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "aspnet90.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "aspnet90.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "aspnet90.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "aspnet90.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "aspnet90.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "aspnet90.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "aspnet90.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "aspnet90.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "aspnet90.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "aspnet90.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "aspnet90.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "aspnet90.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "aspnet90.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "aspnet90.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "aspnet90.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "aspnet90.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "aspnet90.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "aspnet90.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "aspnet90.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "aspnet90.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "aspnet90.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "aspnet90.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "aspnet90.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "aspnet90.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "aspnet90.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "aspnet90.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Antiforgery.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAntiforgery => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAntiforgery, "aspnet90.Microsoft.AspNetCore.Antiforgery");
+        private static byte[]? _MicrosoftAspNetCoreAntiforgery;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationAbstractions, "aspnet90.Microsoft.AspNetCore.Authentication.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.BearerToken.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationBearerToken => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationBearerToken, "aspnet90.Microsoft.AspNetCore.Authentication.BearerToken");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationBearerToken;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.Cookies.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationCookies => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCookies, "aspnet90.Microsoft.AspNetCore.Authentication.Cookies");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationCookies;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationCore, "aspnet90.Microsoft.AspNetCore.Authentication.Core");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthentication => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthentication, "aspnet90.Microsoft.AspNetCore.Authentication");
+        private static byte[]? _MicrosoftAspNetCoreAuthentication;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authentication.OAuth.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthenticationOAuth => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthenticationOAuth, "aspnet90.Microsoft.AspNetCore.Authentication.OAuth");
+        private static byte[]? _MicrosoftAspNetCoreAuthenticationOAuth;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authorization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorization, "aspnet90.Microsoft.AspNetCore.Authorization");
+        private static byte[]? _MicrosoftAspNetCoreAuthorization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Authorization.Policy.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreAuthorizationPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreAuthorizationPolicy, "aspnet90.Microsoft.AspNetCore.Authorization.Policy");
+        private static byte[]? _MicrosoftAspNetCoreAuthorizationPolicy;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Authorization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsAuthorization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsAuthorization, "aspnet90.Microsoft.AspNetCore.Components.Authorization");
+        private static byte[]? _MicrosoftAspNetCoreComponentsAuthorization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponents => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponents, "aspnet90.Microsoft.AspNetCore.Components");
+        private static byte[]? _MicrosoftAspNetCoreComponents;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Endpoints.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsEndpoints => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsEndpoints, "aspnet90.Microsoft.AspNetCore.Components.Endpoints");
+        private static byte[]? _MicrosoftAspNetCoreComponentsEndpoints;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Forms.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsForms, "aspnet90.Microsoft.AspNetCore.Components.Forms");
+        private static byte[]? _MicrosoftAspNetCoreComponentsForms;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Server.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsServer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsServer, "aspnet90.Microsoft.AspNetCore.Components.Server");
+        private static byte[]? _MicrosoftAspNetCoreComponentsServer;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Components.Web.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreComponentsWeb => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreComponentsWeb, "aspnet90.Microsoft.AspNetCore.Components.Web");
+        private static byte[]? _MicrosoftAspNetCoreComponentsWeb;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Connections.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreConnectionsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreConnectionsAbstractions, "aspnet90.Microsoft.AspNetCore.Connections.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreConnectionsAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.CookiePolicy.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCookiePolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCookiePolicy, "aspnet90.Microsoft.AspNetCore.CookiePolicy");
+        private static byte[]? _MicrosoftAspNetCoreCookiePolicy;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Cors.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCors, "aspnet90.Microsoft.AspNetCore.Cors");
+        private static byte[]? _MicrosoftAspNetCoreCors;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Cryptography.Internal.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCryptographyInternal => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyInternal, "aspnet90.Microsoft.AspNetCore.Cryptography.Internal");
+        private static byte[]? _MicrosoftAspNetCoreCryptographyInternal;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Cryptography.KeyDerivation.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreCryptographyKeyDerivation => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreCryptographyKeyDerivation, "aspnet90.Microsoft.AspNetCore.Cryptography.KeyDerivation");
+        private static byte[]? _MicrosoftAspNetCoreCryptographyKeyDerivation;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.DataProtection.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDataProtectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionAbstractions, "aspnet90.Microsoft.AspNetCore.DataProtection.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreDataProtectionAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.DataProtection.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDataProtection => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtection, "aspnet90.Microsoft.AspNetCore.DataProtection");
+        private static byte[]? _MicrosoftAspNetCoreDataProtection;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.DataProtection.Extensions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDataProtectionExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDataProtectionExtensions, "aspnet90.Microsoft.AspNetCore.DataProtection.Extensions");
+        private static byte[]? _MicrosoftAspNetCoreDataProtectionExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Diagnostics.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsAbstractions, "aspnet90.Microsoft.AspNetCore.Diagnostics.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreDiagnosticsAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Diagnostics.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnostics, "aspnet90.Microsoft.AspNetCore.Diagnostics");
+        private static byte[]? _MicrosoftAspNetCoreDiagnostics;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Diagnostics.HealthChecks.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreDiagnosticsHealthChecks, "aspnet90.Microsoft.AspNetCore.Diagnostics.HealthChecks");
+        private static byte[]? _MicrosoftAspNetCoreDiagnosticsHealthChecks;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCore, "aspnet90.Microsoft.AspNetCore");
+        private static byte[]? _MicrosoftAspNetCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HostFiltering.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHostFiltering => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostFiltering, "aspnet90.Microsoft.AspNetCore.HostFiltering");
+        private static byte[]? _MicrosoftAspNetCoreHostFiltering;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Hosting.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingAbstractions, "aspnet90.Microsoft.AspNetCore.Hosting.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHostingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Hosting.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHosting, "aspnet90.Microsoft.AspNetCore.Hosting");
+        private static byte[]? _MicrosoftAspNetCoreHosting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Hosting.Server.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHostingServerAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHostingServerAbstractions, "aspnet90.Microsoft.AspNetCore.Hosting.Server.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHostingServerAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Html.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHtmlAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHtmlAbstractions, "aspnet90.Microsoft.AspNetCore.Html.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHtmlAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpAbstractions, "aspnet90.Microsoft.AspNetCore.Http.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreHttpAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Connections.Common.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpConnectionsCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnectionsCommon, "aspnet90.Microsoft.AspNetCore.Http.Connections.Common");
+        private static byte[]? _MicrosoftAspNetCoreHttpConnectionsCommon;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Connections.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpConnections => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpConnections, "aspnet90.Microsoft.AspNetCore.Http.Connections");
+        private static byte[]? _MicrosoftAspNetCoreHttpConnections;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttp, "aspnet90.Microsoft.AspNetCore.Http");
+        private static byte[]? _MicrosoftAspNetCoreHttp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Extensions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpExtensions, "aspnet90.Microsoft.AspNetCore.Http.Extensions");
+        private static byte[]? _MicrosoftAspNetCoreHttpExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Features.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpFeatures, "aspnet90.Microsoft.AspNetCore.Http.Features");
+        private static byte[]? _MicrosoftAspNetCoreHttpFeatures;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Http.Results.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpResults => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpResults, "aspnet90.Microsoft.AspNetCore.Http.Results");
+        private static byte[]? _MicrosoftAspNetCoreHttpResults;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HttpLogging.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpLogging, "aspnet90.Microsoft.AspNetCore.HttpLogging");
+        private static byte[]? _MicrosoftAspNetCoreHttpLogging;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HttpOverrides.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpOverrides => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpOverrides, "aspnet90.Microsoft.AspNetCore.HttpOverrides");
+        private static byte[]? _MicrosoftAspNetCoreHttpOverrides;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.HttpsPolicy.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreHttpsPolicy => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreHttpsPolicy, "aspnet90.Microsoft.AspNetCore.HttpsPolicy");
+        private static byte[]? _MicrosoftAspNetCoreHttpsPolicy;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Identity.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreIdentity => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreIdentity, "aspnet90.Microsoft.AspNetCore.Identity");
+        private static byte[]? _MicrosoftAspNetCoreIdentity;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Localization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalization, "aspnet90.Microsoft.AspNetCore.Localization");
+        private static byte[]? _MicrosoftAspNetCoreLocalization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Localization.Routing.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreLocalizationRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreLocalizationRouting, "aspnet90.Microsoft.AspNetCore.Localization.Routing");
+        private static byte[]? _MicrosoftAspNetCoreLocalizationRouting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Metadata.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMetadata => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMetadata, "aspnet90.Microsoft.AspNetCore.Metadata");
+        private static byte[]? _MicrosoftAspNetCoreMetadata;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcAbstractions, "aspnet90.Microsoft.AspNetCore.Mvc.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreMvcAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.ApiExplorer.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcApiExplorer => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcApiExplorer, "aspnet90.Microsoft.AspNetCore.Mvc.ApiExplorer");
+        private static byte[]? _MicrosoftAspNetCoreMvcApiExplorer;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCore, "aspnet90.Microsoft.AspNetCore.Mvc.Core");
+        private static byte[]? _MicrosoftAspNetCoreMvcCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Cors.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcCors => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcCors, "aspnet90.Microsoft.AspNetCore.Mvc.Cors");
+        private static byte[]? _MicrosoftAspNetCoreMvcCors;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.DataAnnotations.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcDataAnnotations, "aspnet90.Microsoft.AspNetCore.Mvc.DataAnnotations");
+        private static byte[]? _MicrosoftAspNetCoreMvcDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvc => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvc, "aspnet90.Microsoft.AspNetCore.Mvc");
+        private static byte[]? _MicrosoftAspNetCoreMvc;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Json.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcFormattersJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersJson, "aspnet90.Microsoft.AspNetCore.Mvc.Formatters.Json");
+        private static byte[]? _MicrosoftAspNetCoreMvcFormattersJson;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Formatters.Xml.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcFormattersXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcFormattersXml, "aspnet90.Microsoft.AspNetCore.Mvc.Formatters.Xml");
+        private static byte[]? _MicrosoftAspNetCoreMvcFormattersXml;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Localization.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcLocalization, "aspnet90.Microsoft.AspNetCore.Mvc.Localization");
+        private static byte[]? _MicrosoftAspNetCoreMvcLocalization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.Razor.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazor, "aspnet90.Microsoft.AspNetCore.Mvc.Razor");
+        private static byte[]? _MicrosoftAspNetCoreMvcRazor;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.RazorPages.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcRazorPages => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcRazorPages, "aspnet90.Microsoft.AspNetCore.Mvc.RazorPages");
+        private static byte[]? _MicrosoftAspNetCoreMvcRazorPages;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.TagHelpers.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcTagHelpers => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcTagHelpers, "aspnet90.Microsoft.AspNetCore.Mvc.TagHelpers");
+        private static byte[]? _MicrosoftAspNetCoreMvcTagHelpers;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Mvc.ViewFeatures.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreMvcViewFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreMvcViewFeatures, "aspnet90.Microsoft.AspNetCore.Mvc.ViewFeatures");
+        private static byte[]? _MicrosoftAspNetCoreMvcViewFeatures;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.OutputCaching.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreOutputCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreOutputCaching, "aspnet90.Microsoft.AspNetCore.OutputCaching");
+        private static byte[]? _MicrosoftAspNetCoreOutputCaching;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.RateLimiting.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRateLimiting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRateLimiting, "aspnet90.Microsoft.AspNetCore.RateLimiting");
+        private static byte[]? _MicrosoftAspNetCoreRateLimiting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Razor.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRazor => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazor, "aspnet90.Microsoft.AspNetCore.Razor");
+        private static byte[]? _MicrosoftAspNetCoreRazor;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Razor.Runtime.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRazorRuntime => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRazorRuntime, "aspnet90.Microsoft.AspNetCore.Razor.Runtime");
+        private static byte[]? _MicrosoftAspNetCoreRazorRuntime;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.RequestDecompression.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRequestDecompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRequestDecompression, "aspnet90.Microsoft.AspNetCore.RequestDecompression");
+        private static byte[]? _MicrosoftAspNetCoreRequestDecompression;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreResponseCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCachingAbstractions, "aspnet90.Microsoft.AspNetCore.ResponseCaching.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreResponseCachingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.ResponseCaching.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreResponseCaching => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCaching, "aspnet90.Microsoft.AspNetCore.ResponseCaching");
+        private static byte[]? _MicrosoftAspNetCoreResponseCaching;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.ResponseCompression.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreResponseCompression => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreResponseCompression, "aspnet90.Microsoft.AspNetCore.ResponseCompression");
+        private static byte[]? _MicrosoftAspNetCoreResponseCompression;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Rewrite.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRewrite => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRewrite, "aspnet90.Microsoft.AspNetCore.Rewrite");
+        private static byte[]? _MicrosoftAspNetCoreRewrite;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Routing.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRoutingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRoutingAbstractions, "aspnet90.Microsoft.AspNetCore.Routing.Abstractions");
+        private static byte[]? _MicrosoftAspNetCoreRoutingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Routing.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreRouting => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreRouting, "aspnet90.Microsoft.AspNetCore.Routing");
+        private static byte[]? _MicrosoftAspNetCoreRouting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.HttpSys.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerHttpSys => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerHttpSys, "aspnet90.Microsoft.AspNetCore.Server.HttpSys");
+        private static byte[]? _MicrosoftAspNetCoreServerHttpSys;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.IIS.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerIIS => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIIS, "aspnet90.Microsoft.AspNetCore.Server.IIS");
+        private static byte[]? _MicrosoftAspNetCoreServerIIS;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.IISIntegration.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerIISIntegration => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerIISIntegration, "aspnet90.Microsoft.AspNetCore.Server.IISIntegration");
+        private static byte[]? _MicrosoftAspNetCoreServerIISIntegration;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelCore, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Core");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrel => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrel, "aspnet90.Microsoft.AspNetCore.Server.Kestrel");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrel;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelTransportNamedPipes => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportNamedPipes, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportNamedPipes;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelTransportQuic => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportQuic, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.Quic");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportQuic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreServerKestrelTransportSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreServerKestrelTransportSockets, "aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets");
+        private static byte[]? _MicrosoftAspNetCoreServerKestrelTransportSockets;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.Session.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSession => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSession, "aspnet90.Microsoft.AspNetCore.Session");
+        private static byte[]? _MicrosoftAspNetCoreSession;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.Common.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalRCommon => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCommon, "aspnet90.Microsoft.AspNetCore.SignalR.Common");
+        private static byte[]? _MicrosoftAspNetCoreSignalRCommon;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalRCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRCore, "aspnet90.Microsoft.AspNetCore.SignalR.Core");
+        private static byte[]? _MicrosoftAspNetCoreSignalRCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalR => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalR, "aspnet90.Microsoft.AspNetCore.SignalR");
+        private static byte[]? _MicrosoftAspNetCoreSignalR;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.SignalR.Protocols.Json.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreSignalRProtocolsJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreSignalRProtocolsJson, "aspnet90.Microsoft.AspNetCore.SignalR.Protocols.Json");
+        private static byte[]? _MicrosoftAspNetCoreSignalRProtocolsJson;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.StaticAssets.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreStaticAssets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreStaticAssets, "aspnet90.Microsoft.AspNetCore.StaticAssets");
+        private static byte[]? _MicrosoftAspNetCoreStaticAssets;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.StaticFiles.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreStaticFiles => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreStaticFiles, "aspnet90.Microsoft.AspNetCore.StaticFiles");
+        private static byte[]? _MicrosoftAspNetCoreStaticFiles;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.WebSockets.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreWebSockets => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebSockets, "aspnet90.Microsoft.AspNetCore.WebSockets");
+        private static byte[]? _MicrosoftAspNetCoreWebSockets;
+
+        /// <summary>
+        /// The image bytes for Microsoft.AspNetCore.WebUtilities.dll
+        /// </summary>
+        public static byte[] MicrosoftAspNetCoreWebUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftAspNetCoreWebUtilities, "aspnet90.Microsoft.AspNetCore.WebUtilities");
+        private static byte[]? _MicrosoftAspNetCoreWebUtilities;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Caching.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsCachingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingAbstractions, "aspnet90.Microsoft.Extensions.Caching.Abstractions");
+        private static byte[]? _MicrosoftExtensionsCachingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Caching.Memory.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsCachingMemory => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsCachingMemory, "aspnet90.Microsoft.Extensions.Caching.Memory");
+        private static byte[]? _MicrosoftExtensionsCachingMemory;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationAbstractions, "aspnet90.Microsoft.Extensions.Configuration.Abstractions");
+        private static byte[]? _MicrosoftExtensionsConfigurationAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Binder.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationBinder => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationBinder, "aspnet90.Microsoft.Extensions.Configuration.Binder");
+        private static byte[]? _MicrosoftExtensionsConfigurationBinder;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.CommandLine.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationCommandLine => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationCommandLine, "aspnet90.Microsoft.Extensions.Configuration.CommandLine");
+        private static byte[]? _MicrosoftExtensionsConfigurationCommandLine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfiguration, "aspnet90.Microsoft.Extensions.Configuration");
+        private static byte[]? _MicrosoftExtensionsConfiguration;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.EnvironmentVariables.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationEnvironmentVariables => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationEnvironmentVariables, "aspnet90.Microsoft.Extensions.Configuration.EnvironmentVariables");
+        private static byte[]? _MicrosoftExtensionsConfigurationEnvironmentVariables;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.FileExtensions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationFileExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationFileExtensions, "aspnet90.Microsoft.Extensions.Configuration.FileExtensions");
+        private static byte[]? _MicrosoftExtensionsConfigurationFileExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Ini.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationIni => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationIni, "aspnet90.Microsoft.Extensions.Configuration.Ini");
+        private static byte[]? _MicrosoftExtensionsConfigurationIni;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Json.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationJson => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationJson, "aspnet90.Microsoft.Extensions.Configuration.Json");
+        private static byte[]? _MicrosoftExtensionsConfigurationJson;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.KeyPerFile.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationKeyPerFile => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationKeyPerFile, "aspnet90.Microsoft.Extensions.Configuration.KeyPerFile");
+        private static byte[]? _MicrosoftExtensionsConfigurationKeyPerFile;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.UserSecrets.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationUserSecrets => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationUserSecrets, "aspnet90.Microsoft.Extensions.Configuration.UserSecrets");
+        private static byte[]? _MicrosoftExtensionsConfigurationUserSecrets;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Configuration.Xml.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsConfigurationXml => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsConfigurationXml, "aspnet90.Microsoft.Extensions.Configuration.Xml");
+        private static byte[]? _MicrosoftExtensionsConfigurationXml;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.DependencyInjection.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDependencyInjectionAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjectionAbstractions, "aspnet90.Microsoft.Extensions.DependencyInjection.Abstractions");
+        private static byte[]? _MicrosoftExtensionsDependencyInjectionAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.DependencyInjection.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDependencyInjection => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDependencyInjection, "aspnet90.Microsoft.Extensions.DependencyInjection");
+        private static byte[]? _MicrosoftExtensionsDependencyInjection;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnosticsAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsAbstractions, "aspnet90.Microsoft.Extensions.Diagnostics.Abstractions");
+        private static byte[]? _MicrosoftExtensionsDiagnosticsAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnostics => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnostics, "aspnet90.Microsoft.Extensions.Diagnostics");
+        private static byte[]? _MicrosoftExtensionsDiagnostics;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecksAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions, "aspnet90.Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions");
+        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Diagnostics.HealthChecks.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsDiagnosticsHealthChecks => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsDiagnosticsHealthChecks, "aspnet90.Microsoft.Extensions.Diagnostics.HealthChecks");
+        private static byte[]? _MicrosoftExtensionsDiagnosticsHealthChecks;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Features.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFeatures => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFeatures, "aspnet90.Microsoft.Extensions.Features");
+        private static byte[]? _MicrosoftExtensionsFeatures;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersAbstractions, "aspnet90.Microsoft.Extensions.FileProviders.Abstractions");
+        private static byte[]? _MicrosoftExtensionsFileProvidersAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Composite.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersComposite => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersComposite, "aspnet90.Microsoft.Extensions.FileProviders.Composite");
+        private static byte[]? _MicrosoftExtensionsFileProvidersComposite;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Embedded.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersEmbedded => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersEmbedded, "aspnet90.Microsoft.Extensions.FileProviders.Embedded");
+        private static byte[]? _MicrosoftExtensionsFileProvidersEmbedded;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileProviders.Physical.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileProvidersPhysical => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileProvidersPhysical, "aspnet90.Microsoft.Extensions.FileProviders.Physical");
+        private static byte[]? _MicrosoftExtensionsFileProvidersPhysical;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.FileSystemGlobbing.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsFileSystemGlobbing => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsFileSystemGlobbing, "aspnet90.Microsoft.Extensions.FileSystemGlobbing");
+        private static byte[]? _MicrosoftExtensionsFileSystemGlobbing;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Hosting.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsHostingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHostingAbstractions, "aspnet90.Microsoft.Extensions.Hosting.Abstractions");
+        private static byte[]? _MicrosoftExtensionsHostingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Hosting.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsHosting => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHosting, "aspnet90.Microsoft.Extensions.Hosting");
+        private static byte[]? _MicrosoftExtensionsHosting;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Http.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsHttp => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsHttp, "aspnet90.Microsoft.Extensions.Http");
+        private static byte[]? _MicrosoftExtensionsHttp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Identity.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsIdentityCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityCore, "aspnet90.Microsoft.Extensions.Identity.Core");
+        private static byte[]? _MicrosoftExtensionsIdentityCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Identity.Stores.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsIdentityStores => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsIdentityStores, "aspnet90.Microsoft.Extensions.Identity.Stores");
+        private static byte[]? _MicrosoftExtensionsIdentityStores;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Localization.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLocalizationAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalizationAbstractions, "aspnet90.Microsoft.Extensions.Localization.Abstractions");
+        private static byte[]? _MicrosoftExtensionsLocalizationAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Localization.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLocalization => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLocalization, "aspnet90.Microsoft.Extensions.Localization");
+        private static byte[]? _MicrosoftExtensionsLocalization;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Abstractions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingAbstractions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingAbstractions, "aspnet90.Microsoft.Extensions.Logging.Abstractions");
+        private static byte[]? _MicrosoftExtensionsLoggingAbstractions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Configuration.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingConfiguration => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConfiguration, "aspnet90.Microsoft.Extensions.Logging.Configuration");
+        private static byte[]? _MicrosoftExtensionsLoggingConfiguration;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Console.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingConsole => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingConsole, "aspnet90.Microsoft.Extensions.Logging.Console");
+        private static byte[]? _MicrosoftExtensionsLoggingConsole;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.Debug.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingDebug => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingDebug, "aspnet90.Microsoft.Extensions.Logging.Debug");
+        private static byte[]? _MicrosoftExtensionsLoggingDebug;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLogging => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLogging, "aspnet90.Microsoft.Extensions.Logging");
+        private static byte[]? _MicrosoftExtensionsLogging;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.EventLog.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingEventLog => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventLog, "aspnet90.Microsoft.Extensions.Logging.EventLog");
+        private static byte[]? _MicrosoftExtensionsLoggingEventLog;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.EventSource.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingEventSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingEventSource, "aspnet90.Microsoft.Extensions.Logging.EventSource");
+        private static byte[]? _MicrosoftExtensionsLoggingEventSource;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Logging.TraceSource.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsLoggingTraceSource => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsLoggingTraceSource, "aspnet90.Microsoft.Extensions.Logging.TraceSource");
+        private static byte[]? _MicrosoftExtensionsLoggingTraceSource;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.ObjectPool.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsObjectPool => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsObjectPool, "aspnet90.Microsoft.Extensions.ObjectPool");
+        private static byte[]? _MicrosoftExtensionsObjectPool;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Options.ConfigurationExtensions.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsOptionsConfigurationExtensions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsConfigurationExtensions, "aspnet90.Microsoft.Extensions.Options.ConfigurationExtensions");
+        private static byte[]? _MicrosoftExtensionsOptionsConfigurationExtensions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Options.DataAnnotations.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsOptionsDataAnnotations => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptionsDataAnnotations, "aspnet90.Microsoft.Extensions.Options.DataAnnotations");
+        private static byte[]? _MicrosoftExtensionsOptionsDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Options.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsOptions => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsOptions, "aspnet90.Microsoft.Extensions.Options");
+        private static byte[]? _MicrosoftExtensionsOptions;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsPrimitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsPrimitives, "aspnet90.Microsoft.Extensions.Primitives");
+        private static byte[]? _MicrosoftExtensionsPrimitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Extensions.WebEncoders.dll
+        /// </summary>
+        public static byte[] MicrosoftExtensionsWebEncoders => ResourceLoader.GetOrCreateResource(ref _MicrosoftExtensionsWebEncoders, "aspnet90.Microsoft.Extensions.WebEncoders");
+        private static byte[]? _MicrosoftExtensionsWebEncoders;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JSInterop.dll
+        /// </summary>
+        public static byte[] MicrosoftJSInterop => ResourceLoader.GetOrCreateResource(ref _MicrosoftJSInterop, "aspnet90.Microsoft.JSInterop");
+        private static byte[]? _MicrosoftJSInterop;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Net.Http.Headers.dll
+        /// </summary>
+        public static byte[] MicrosoftNetHttpHeaders => ResourceLoader.GetOrCreateResource(ref _MicrosoftNetHttpHeaders, "aspnet90.Microsoft.Net.Http.Headers");
+        private static byte[]? _MicrosoftNetHttpHeaders;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.EventLog.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "aspnet90.System.Diagnostics.EventLog");
+        private static byte[]? _SystemDiagnosticsEventLog;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Xml.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "aspnet90.System.Security.Cryptography.Xml");
+        private static byte[]? _SystemSecurityCryptographyXml;
+
+        /// <summary>
+        /// The image bytes for System.Threading.RateLimiting.dll
+        /// </summary>
+        public static byte[] SystemThreadingRateLimiting => ResourceLoader.GetOrCreateResource(ref _SystemThreadingRateLimiting, "aspnet90.System.Threading.RateLimiting");
+        private static byte[]? _SystemThreadingRateLimiting;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net20/Generated.cs
@@ -9,308 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net20
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net20.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for AspNetMMCExt.dll
-        /// </summary>
-        public static byte[] AspNetMMCExt => ResourceLoader.GetOrCreateResource(ref _AspNetMMCExt, "net20.AspNetMMCExt");
-        private static byte[]? _AspNetMMCExt;
-
-        /// <summary>
-        /// The image bytes for cscompmgd.dll
-        /// </summary>
-        public static byte[] cscompmgd => ResourceLoader.GetOrCreateResource(ref _cscompmgd, "net20.cscompmgd");
-        private static byte[]? _cscompmgd;
-
-        /// <summary>
-        /// The image bytes for CustomMarshalers.dll
-        /// </summary>
-        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net20.CustomMarshalers");
-        private static byte[]? _CustomMarshalers;
-
-        /// <summary>
-        /// The image bytes for IEExecRemote.dll
-        /// </summary>
-        public static byte[] IEExecRemote => ResourceLoader.GetOrCreateResource(ref _IEExecRemote, "net20.IEExecRemote");
-        private static byte[]? _IEExecRemote;
-
-        /// <summary>
-        /// The image bytes for IEHost.dll
-        /// </summary>
-        public static byte[] IEHost => ResourceLoader.GetOrCreateResource(ref _IEHost, "net20.IEHost");
-        private static byte[]? _IEHost;
-
-        /// <summary>
-        /// The image bytes for IIEHost.dll
-        /// </summary>
-        public static byte[] IIEHost => ResourceLoader.GetOrCreateResource(ref _IIEHost, "net20.IIEHost");
-        private static byte[]? _IIEHost;
-
-        /// <summary>
-        /// The image bytes for ISymWrapper.dll
-        /// </summary>
-        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net20.ISymWrapper");
-        private static byte[]? _ISymWrapper;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Engine.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net20.Microsoft.Build.Engine");
-        private static byte[]? _MicrosoftBuildEngine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Framework.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net20.Microsoft.Build.Framework");
-        private static byte[]? _MicrosoftBuildFramework;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Tasks.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildTasks => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasks, "net20.Microsoft.Build.Tasks");
-        private static byte[]? _MicrosoftBuildTasks;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Utilities.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilities, "net20.Microsoft.Build.Utilities");
-        private static byte[]? _MicrosoftBuildUtilities;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JScript.dll
-        /// </summary>
-        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net20.Microsoft.JScript");
-        private static byte[]? _MicrosoftJScript;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net20.Microsoft.VisualBasic.Compatibility.Data");
-        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net20.Microsoft.VisualBasic.Compatibility");
-        private static byte[]? _MicrosoftVisualBasicCompatibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net20.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Vsa.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicVsa, "net20.Microsoft.VisualBasic.Vsa");
-        private static byte[]? _MicrosoftVisualBasicVsa;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net20.Microsoft.VisualC");
-        private static byte[]? _MicrosoftVisualC;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Vsa.dll
-        /// </summary>
-        public static byte[] MicrosoftVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsa, "net20.Microsoft.Vsa");
-        private static byte[]? _MicrosoftVsa;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Vsa.Vb.CodeDOMProcessor.dll
-        /// </summary>
-        public static byte[] MicrosoftVsaVbCodeDOMProcessor => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsaVbCodeDOMProcessor, "net20.Microsoft.Vsa.Vb.CodeDOMProcessor");
-        private static byte[]? _MicrosoftVsaVbCodeDOMProcessor;
-
-        /// <summary>
-        /// The image bytes for Microsoft_VsaVb.dll
-        /// </summary>
-        public static byte[] Microsoft_VsaVb => ResourceLoader.GetOrCreateResource(ref _Microsoft_VsaVb, "net20.Microsoft_VsaVb");
-        private static byte[]? _Microsoft_VsaVb;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net20.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for sysglobl.dll
-        /// </summary>
-        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net20.sysglobl");
-        private static byte[]? _sysglobl;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net20.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.Install.dll
-        /// </summary>
-        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net20.System.Configuration.Install");
-        private static byte[]? _SystemConfigurationInstall;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net20.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Data.OracleClient.dll
-        /// </summary>
-        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net20.System.Data.OracleClient");
-        private static byte[]? _SystemDataOracleClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.SqlXml.dll
-        /// </summary>
-        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net20.System.Data.SqlXml");
-        private static byte[]? _SystemDataSqlXml;
-
-        /// <summary>
-        /// The image bytes for System.Deployment.dll
-        /// </summary>
-        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net20.System.Deployment");
-        private static byte[]? _SystemDeployment;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net20.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net20.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.Protocols.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net20.System.DirectoryServices.Protocols");
-        private static byte[]? _SystemDirectoryServicesProtocols;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net20.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net20.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net20.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.EnterpriseServices.dll
-        /// </summary>
-        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net20.System.EnterpriseServices");
-        private static byte[]? _SystemEnterpriseServices;
-
-        /// <summary>
-        /// The image bytes for System.Management.dll
-        /// </summary>
-        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net20.System.Management");
-        private static byte[]? _SystemManagement;
-
-        /// <summary>
-        /// The image bytes for System.Messaging.dll
-        /// </summary>
-        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net20.System.Messaging");
-        private static byte[]? _SystemMessaging;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Remoting.dll
-        /// </summary>
-        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net20.System.Runtime.Remoting");
-        private static byte[]? _SystemRuntimeRemoting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net20.System.Runtime.Serialization.Formatters.Soap");
-        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net20.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net20.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net20.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net20.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.Mobile.dll
-        /// </summary>
-        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net20.System.Web.Mobile");
-        private static byte[]? _SystemWebMobile;
-
-        /// <summary>
-        /// The image bytes for System.Web.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net20.System.Web.RegularExpressions");
-        private static byte[]? _SystemWebRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Services.dll
-        /// </summary>
-        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net20.System.Web.Services");
-        private static byte[]? _SystemWebServices;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net20.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net20.System.Xml");
-        private static byte[]? _SystemXml;
-
-
-    }
-}
-
-public static partial class Net20
-{
     public static class ReferenceInfos
     {
 
@@ -1526,6 +1224,308 @@ public static partial class Net20
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net20
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net20.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for AspNetMMCExt.dll
+        /// </summary>
+        public static byte[] AspNetMMCExt => ResourceLoader.GetOrCreateResource(ref _AspNetMMCExt, "net20.AspNetMMCExt");
+        private static byte[]? _AspNetMMCExt;
+
+        /// <summary>
+        /// The image bytes for cscompmgd.dll
+        /// </summary>
+        public static byte[] cscompmgd => ResourceLoader.GetOrCreateResource(ref _cscompmgd, "net20.cscompmgd");
+        private static byte[]? _cscompmgd;
+
+        /// <summary>
+        /// The image bytes for CustomMarshalers.dll
+        /// </summary>
+        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net20.CustomMarshalers");
+        private static byte[]? _CustomMarshalers;
+
+        /// <summary>
+        /// The image bytes for IEExecRemote.dll
+        /// </summary>
+        public static byte[] IEExecRemote => ResourceLoader.GetOrCreateResource(ref _IEExecRemote, "net20.IEExecRemote");
+        private static byte[]? _IEExecRemote;
+
+        /// <summary>
+        /// The image bytes for IEHost.dll
+        /// </summary>
+        public static byte[] IEHost => ResourceLoader.GetOrCreateResource(ref _IEHost, "net20.IEHost");
+        private static byte[]? _IEHost;
+
+        /// <summary>
+        /// The image bytes for IIEHost.dll
+        /// </summary>
+        public static byte[] IIEHost => ResourceLoader.GetOrCreateResource(ref _IIEHost, "net20.IIEHost");
+        private static byte[]? _IIEHost;
+
+        /// <summary>
+        /// The image bytes for ISymWrapper.dll
+        /// </summary>
+        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net20.ISymWrapper");
+        private static byte[]? _ISymWrapper;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Engine.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net20.Microsoft.Build.Engine");
+        private static byte[]? _MicrosoftBuildEngine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Framework.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net20.Microsoft.Build.Framework");
+        private static byte[]? _MicrosoftBuildFramework;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Tasks.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildTasks => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasks, "net20.Microsoft.Build.Tasks");
+        private static byte[]? _MicrosoftBuildTasks;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Utilities.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilities, "net20.Microsoft.Build.Utilities");
+        private static byte[]? _MicrosoftBuildUtilities;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JScript.dll
+        /// </summary>
+        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net20.Microsoft.JScript");
+        private static byte[]? _MicrosoftJScript;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net20.Microsoft.VisualBasic.Compatibility.Data");
+        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net20.Microsoft.VisualBasic.Compatibility");
+        private static byte[]? _MicrosoftVisualBasicCompatibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net20.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Vsa.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicVsa, "net20.Microsoft.VisualBasic.Vsa");
+        private static byte[]? _MicrosoftVisualBasicVsa;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net20.Microsoft.VisualC");
+        private static byte[]? _MicrosoftVisualC;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Vsa.dll
+        /// </summary>
+        public static byte[] MicrosoftVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsa, "net20.Microsoft.Vsa");
+        private static byte[]? _MicrosoftVsa;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Vsa.Vb.CodeDOMProcessor.dll
+        /// </summary>
+        public static byte[] MicrosoftVsaVbCodeDOMProcessor => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsaVbCodeDOMProcessor, "net20.Microsoft.Vsa.Vb.CodeDOMProcessor");
+        private static byte[]? _MicrosoftVsaVbCodeDOMProcessor;
+
+        /// <summary>
+        /// The image bytes for Microsoft_VsaVb.dll
+        /// </summary>
+        public static byte[] Microsoft_VsaVb => ResourceLoader.GetOrCreateResource(ref _Microsoft_VsaVb, "net20.Microsoft_VsaVb");
+        private static byte[]? _Microsoft_VsaVb;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net20.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for sysglobl.dll
+        /// </summary>
+        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net20.sysglobl");
+        private static byte[]? _sysglobl;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net20.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.Install.dll
+        /// </summary>
+        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net20.System.Configuration.Install");
+        private static byte[]? _SystemConfigurationInstall;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net20.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Data.OracleClient.dll
+        /// </summary>
+        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net20.System.Data.OracleClient");
+        private static byte[]? _SystemDataOracleClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.SqlXml.dll
+        /// </summary>
+        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net20.System.Data.SqlXml");
+        private static byte[]? _SystemDataSqlXml;
+
+        /// <summary>
+        /// The image bytes for System.Deployment.dll
+        /// </summary>
+        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net20.System.Deployment");
+        private static byte[]? _SystemDeployment;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net20.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net20.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.Protocols.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net20.System.DirectoryServices.Protocols");
+        private static byte[]? _SystemDirectoryServicesProtocols;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net20.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net20.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net20.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.EnterpriseServices.dll
+        /// </summary>
+        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net20.System.EnterpriseServices");
+        private static byte[]? _SystemEnterpriseServices;
+
+        /// <summary>
+        /// The image bytes for System.Management.dll
+        /// </summary>
+        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net20.System.Management");
+        private static byte[]? _SystemManagement;
+
+        /// <summary>
+        /// The image bytes for System.Messaging.dll
+        /// </summary>
+        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net20.System.Messaging");
+        private static byte[]? _SystemMessaging;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Remoting.dll
+        /// </summary>
+        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net20.System.Runtime.Remoting");
+        private static byte[]? _SystemRuntimeRemoting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net20.System.Runtime.Serialization.Formatters.Soap");
+        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net20.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net20.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net20.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net20.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.Mobile.dll
+        /// </summary>
+        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net20.System.Web.Mobile");
+        private static byte[]? _SystemWebMobile;
+
+        /// <summary>
+        /// The image bytes for System.Web.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net20.System.Web.RegularExpressions");
+        private static byte[]? _SystemWebRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Services.dll
+        /// </summary>
+        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net20.System.Web.Services");
+        private static byte[]? _SystemWebServices;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net20.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net20.System.Xml");
+        private static byte[]? _SystemXml;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net20/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -308,6 +308,7 @@ public static partial class Net20
 
     }
 }
+
 public static partial class Net20
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net35/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net35/Generated.cs
@@ -9,626 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net35
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net35.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for AspNetMMCExt.dll
-        /// </summary>
-        public static byte[] AspNetMMCExt => ResourceLoader.GetOrCreateResource(ref _AspNetMMCExt, "net35.AspNetMMCExt");
-        private static byte[]? _AspNetMMCExt;
-
-        /// <summary>
-        /// The image bytes for cscompmgd.dll
-        /// </summary>
-        public static byte[] cscompmgd => ResourceLoader.GetOrCreateResource(ref _cscompmgd, "net35.cscompmgd");
-        private static byte[]? _cscompmgd;
-
-        /// <summary>
-        /// The image bytes for CustomMarshalers.dll
-        /// </summary>
-        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net35.CustomMarshalers");
-        private static byte[]? _CustomMarshalers;
-
-        /// <summary>
-        /// The image bytes for IEExecRemote.dll
-        /// </summary>
-        public static byte[] IEExecRemote => ResourceLoader.GetOrCreateResource(ref _IEExecRemote, "net35.IEExecRemote");
-        private static byte[]? _IEExecRemote;
-
-        /// <summary>
-        /// The image bytes for IEHost.dll
-        /// </summary>
-        public static byte[] IEHost => ResourceLoader.GetOrCreateResource(ref _IEHost, "net35.IEHost");
-        private static byte[]? _IEHost;
-
-        /// <summary>
-        /// The image bytes for IIEHost.dll
-        /// </summary>
-        public static byte[] IIEHost => ResourceLoader.GetOrCreateResource(ref _IIEHost, "net35.IIEHost");
-        private static byte[]? _IIEHost;
-
-        /// <summary>
-        /// The image bytes for ISymWrapper.dll
-        /// </summary>
-        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net35.ISymWrapper");
-        private static byte[]? _ISymWrapper;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Conversion.v3.5.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildConversionv35 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv35, "net35.Microsoft.Build.Conversion.v3.5");
-        private static byte[]? _MicrosoftBuildConversionv35;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Engine.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net35.Microsoft.Build.Engine");
-        private static byte[]? _MicrosoftBuildEngine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Framework.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net35.Microsoft.Build.Framework");
-        private static byte[]? _MicrosoftBuildFramework;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Tasks.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildTasks => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasks, "net35.Microsoft.Build.Tasks");
-        private static byte[]? _MicrosoftBuildTasks;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Utilities.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilities, "net35.Microsoft.Build.Utilities");
-        private static byte[]? _MicrosoftBuildUtilities;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Utilities.v3.5.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildUtilitiesv35 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv35, "net35.Microsoft.Build.Utilities.v3.5");
-        private static byte[]? _MicrosoftBuildUtilitiesv35;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JScript.dll
-        /// </summary>
-        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net35.Microsoft.JScript");
-        private static byte[]? _MicrosoftJScript;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net35.Microsoft.VisualBasic.Compatibility.Data");
-        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net35.Microsoft.VisualBasic.Compatibility");
-        private static byte[]? _MicrosoftVisualBasicCompatibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net35.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Vsa.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicVsa, "net35.Microsoft.VisualBasic.Vsa");
-        private static byte[]? _MicrosoftVisualBasicVsa;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net35.Microsoft.VisualC");
-        private static byte[]? _MicrosoftVisualC;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.STLCLR.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net35.Microsoft.VisualC.STLCLR");
-        private static byte[]? _MicrosoftVisualCSTLCLR;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Vsa.dll
-        /// </summary>
-        public static byte[] MicrosoftVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsa, "net35.Microsoft.Vsa");
-        private static byte[]? _MicrosoftVsa;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Vsa.Vb.CodeDOMProcessor.dll
-        /// </summary>
-        public static byte[] MicrosoftVsaVbCodeDOMProcessor => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsaVbCodeDOMProcessor, "net35.Microsoft.Vsa.Vb.CodeDOMProcessor");
-        private static byte[]? _MicrosoftVsaVbCodeDOMProcessor;
-
-        /// <summary>
-        /// The image bytes for Microsoft_VsaVb.dll
-        /// </summary>
-        public static byte[] Microsoft_VsaVb => ResourceLoader.GetOrCreateResource(ref _Microsoft_VsaVb, "net35.Microsoft_VsaVb");
-        private static byte[]? _Microsoft_VsaVb;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net35.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for PresentationBuildTasks.dll
-        /// </summary>
-        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net35.PresentationBuildTasks");
-        private static byte[]? _PresentationBuildTasks;
-
-        /// <summary>
-        /// The image bytes for PresentationCore.dll
-        /// </summary>
-        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net35.PresentationCore");
-        private static byte[]? _PresentationCore;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net35.PresentationFramework.Aero");
-        private static byte[]? _PresentationFrameworkAero;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Classic.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net35.PresentationFramework.Classic");
-        private static byte[]? _PresentationFrameworkClassic;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.dll
-        /// </summary>
-        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net35.PresentationFramework");
-        private static byte[]? _PresentationFramework;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Luna.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net35.PresentationFramework.Luna");
-        private static byte[]? _PresentationFrameworkLuna;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Royale.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net35.PresentationFramework.Royale");
-        private static byte[]? _PresentationFrameworkRoyale;
-
-        /// <summary>
-        /// The image bytes for ReachFramework.dll
-        /// </summary>
-        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net35.ReachFramework");
-        private static byte[]? _ReachFramework;
-
-        /// <summary>
-        /// The image bytes for sysglobl.dll
-        /// </summary>
-        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net35.sysglobl");
-        private static byte[]? _sysglobl;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.Contract.dll
-        /// </summary>
-        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net35.System.AddIn.Contract");
-        private static byte[]? _SystemAddInContract;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.dll
-        /// </summary>
-        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net35.System.AddIn");
-        private static byte[]? _SystemAddIn;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net35.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net35.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.Install.dll
-        /// </summary>
-        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net35.System.Configuration.Install");
-        private static byte[]? _SystemConfigurationInstall;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net35.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net35.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net35.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net35.System.Data.Entity.Design");
-        private static byte[]? _SystemDataEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.dll
-        /// </summary>
-        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net35.System.Data.Entity");
-        private static byte[]? _SystemDataEntity;
-
-        /// <summary>
-        /// The image bytes for System.Data.Linq.dll
-        /// </summary>
-        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net35.System.Data.Linq");
-        private static byte[]? _SystemDataLinq;
-
-        /// <summary>
-        /// The image bytes for System.Data.OracleClient.dll
-        /// </summary>
-        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net35.System.Data.OracleClient");
-        private static byte[]? _SystemDataOracleClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Client.dll
-        /// </summary>
-        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net35.System.Data.Services.Client");
-        private static byte[]? _SystemDataServicesClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Design.dll
-        /// </summary>
-        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net35.System.Data.Services.Design");
-        private static byte[]? _SystemDataServicesDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.dll
-        /// </summary>
-        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net35.System.Data.Services");
-        private static byte[]? _SystemDataServices;
-
-        /// <summary>
-        /// The image bytes for System.Data.SqlXml.dll
-        /// </summary>
-        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net35.System.Data.SqlXml");
-        private static byte[]? _SystemDataSqlXml;
-
-        /// <summary>
-        /// The image bytes for System.Deployment.dll
-        /// </summary>
-        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net35.System.Deployment");
-        private static byte[]? _SystemDeployment;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net35.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.AccountManagement.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net35.System.DirectoryServices.AccountManagement");
-        private static byte[]? _SystemDirectoryServicesAccountManagement;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net35.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.Protocols.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net35.System.DirectoryServices.Protocols");
-        private static byte[]? _SystemDirectoryServicesProtocols;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net35.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net35.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net35.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.EnterpriseServices.dll
-        /// </summary>
-        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net35.System.EnterpriseServices");
-        private static byte[]? _SystemEnterpriseServices;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.dll
-        /// </summary>
-        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net35.System.IdentityModel");
-        private static byte[]? _SystemIdentityModel;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Selectors.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net35.System.IdentityModel.Selectors");
-        private static byte[]? _SystemIdentityModelSelectors;
-
-        /// <summary>
-        /// The image bytes for System.IO.Log.dll
-        /// </summary>
-        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net35.System.IO.Log");
-        private static byte[]? _SystemIOLog;
-
-        /// <summary>
-        /// The image bytes for System.Management.dll
-        /// </summary>
-        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net35.System.Management");
-        private static byte[]? _SystemManagement;
-
-        /// <summary>
-        /// The image bytes for System.Management.Instrumentation.dll
-        /// </summary>
-        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net35.System.Management.Instrumentation");
-        private static byte[]? _SystemManagementInstrumentation;
-
-        /// <summary>
-        /// The image bytes for System.Messaging.dll
-        /// </summary>
-        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net35.System.Messaging");
-        private static byte[]? _SystemMessaging;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net35.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Printing.dll
-        /// </summary>
-        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net35.System.Printing");
-        private static byte[]? _SystemPrinting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Remoting.dll
-        /// </summary>
-        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net35.System.Runtime.Remoting");
-        private static byte[]? _SystemRuntimeRemoting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net35.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net35.System.Runtime.Serialization.Formatters.Soap");
-        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net35.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.dll
-        /// </summary>
-        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net35.System.ServiceModel");
-        private static byte[]? _SystemServiceModel;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net35.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net35.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Speech.dll
-        /// </summary>
-        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net35.System.Speech");
-        private static byte[]? _SystemSpeech;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net35.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Abstractions.dll
-        /// </summary>
-        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net35.System.Web.Abstractions");
-        private static byte[]? _SystemWebAbstractions;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net35.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net35.System.Web.DynamicData.Design");
-        private static byte[]? _SystemWebDynamicDataDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net35.System.Web.DynamicData");
-        private static byte[]? _SystemWebDynamicData;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net35.System.Web.Entity.Design");
-        private static byte[]? _SystemWebEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.dll
-        /// </summary>
-        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net35.System.Web.Entity");
-        private static byte[]? _SystemWebEntity;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.Design.dll
-        /// </summary>
-        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net35.System.Web.Extensions.Design");
-        private static byte[]? _SystemWebExtensionsDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.dll
-        /// </summary>
-        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net35.System.Web.Extensions");
-        private static byte[]? _SystemWebExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Mobile.dll
-        /// </summary>
-        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net35.System.Web.Mobile");
-        private static byte[]? _SystemWebMobile;
-
-        /// <summary>
-        /// The image bytes for System.Web.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net35.System.Web.RegularExpressions");
-        private static byte[]? _SystemWebRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Routing.dll
-        /// </summary>
-        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net35.System.Web.Routing");
-        private static byte[]? _SystemWebRouting;
-
-        /// <summary>
-        /// The image bytes for System.Web.Services.dll
-        /// </summary>
-        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net35.System.Web.Services");
-        private static byte[]? _SystemWebServices;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net35.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Presentation.dll
-        /// </summary>
-        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net35.System.Windows.Presentation");
-        private static byte[]? _SystemWindowsPresentation;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Activities.dll
-        /// </summary>
-        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net35.System.Workflow.Activities");
-        private static byte[]? _SystemWorkflowActivities;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net35.System.Workflow.ComponentModel");
-        private static byte[]? _SystemWorkflowComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Runtime.dll
-        /// </summary>
-        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net35.System.Workflow.Runtime");
-        private static byte[]? _SystemWorkflowRuntime;
-
-        /// <summary>
-        /// The image bytes for System.WorkflowServices.dll
-        /// </summary>
-        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net35.System.WorkflowServices");
-        private static byte[]? _SystemWorkflowServices;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net35.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net35.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClient.dll
-        /// </summary>
-        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net35.UIAutomationClient");
-        private static byte[]? _UIAutomationClient;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClientsideProviders.dll
-        /// </summary>
-        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net35.UIAutomationClientsideProviders");
-        private static byte[]? _UIAutomationClientsideProviders;
-
-        /// <summary>
-        /// The image bytes for UIAutomationProvider.dll
-        /// </summary>
-        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net35.UIAutomationProvider");
-        private static byte[]? _UIAutomationProvider;
-
-        /// <summary>
-        /// The image bytes for UIAutomationTypes.dll
-        /// </summary>
-        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net35.UIAutomationTypes");
-        private static byte[]? _UIAutomationTypes;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net35.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for WindowsFormsIntegration.dll
-        /// </summary>
-        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net35.WindowsFormsIntegration");
-        private static byte[]? _WindowsFormsIntegration;
-
-
-    }
-}
-
-public static partial class Net35
-{
     public static class ReferenceInfos
     {
 
@@ -3116,6 +2496,626 @@ public static partial class Net35
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net35
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net35.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for AspNetMMCExt.dll
+        /// </summary>
+        public static byte[] AspNetMMCExt => ResourceLoader.GetOrCreateResource(ref _AspNetMMCExt, "net35.AspNetMMCExt");
+        private static byte[]? _AspNetMMCExt;
+
+        /// <summary>
+        /// The image bytes for cscompmgd.dll
+        /// </summary>
+        public static byte[] cscompmgd => ResourceLoader.GetOrCreateResource(ref _cscompmgd, "net35.cscompmgd");
+        private static byte[]? _cscompmgd;
+
+        /// <summary>
+        /// The image bytes for CustomMarshalers.dll
+        /// </summary>
+        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net35.CustomMarshalers");
+        private static byte[]? _CustomMarshalers;
+
+        /// <summary>
+        /// The image bytes for IEExecRemote.dll
+        /// </summary>
+        public static byte[] IEExecRemote => ResourceLoader.GetOrCreateResource(ref _IEExecRemote, "net35.IEExecRemote");
+        private static byte[]? _IEExecRemote;
+
+        /// <summary>
+        /// The image bytes for IEHost.dll
+        /// </summary>
+        public static byte[] IEHost => ResourceLoader.GetOrCreateResource(ref _IEHost, "net35.IEHost");
+        private static byte[]? _IEHost;
+
+        /// <summary>
+        /// The image bytes for IIEHost.dll
+        /// </summary>
+        public static byte[] IIEHost => ResourceLoader.GetOrCreateResource(ref _IIEHost, "net35.IIEHost");
+        private static byte[]? _IIEHost;
+
+        /// <summary>
+        /// The image bytes for ISymWrapper.dll
+        /// </summary>
+        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net35.ISymWrapper");
+        private static byte[]? _ISymWrapper;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Conversion.v3.5.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildConversionv35 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv35, "net35.Microsoft.Build.Conversion.v3.5");
+        private static byte[]? _MicrosoftBuildConversionv35;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Engine.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net35.Microsoft.Build.Engine");
+        private static byte[]? _MicrosoftBuildEngine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Framework.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net35.Microsoft.Build.Framework");
+        private static byte[]? _MicrosoftBuildFramework;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Tasks.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildTasks => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasks, "net35.Microsoft.Build.Tasks");
+        private static byte[]? _MicrosoftBuildTasks;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Utilities.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildUtilities => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilities, "net35.Microsoft.Build.Utilities");
+        private static byte[]? _MicrosoftBuildUtilities;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Utilities.v3.5.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildUtilitiesv35 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv35, "net35.Microsoft.Build.Utilities.v3.5");
+        private static byte[]? _MicrosoftBuildUtilitiesv35;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JScript.dll
+        /// </summary>
+        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net35.Microsoft.JScript");
+        private static byte[]? _MicrosoftJScript;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net35.Microsoft.VisualBasic.Compatibility.Data");
+        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net35.Microsoft.VisualBasic.Compatibility");
+        private static byte[]? _MicrosoftVisualBasicCompatibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net35.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Vsa.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicVsa, "net35.Microsoft.VisualBasic.Vsa");
+        private static byte[]? _MicrosoftVisualBasicVsa;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net35.Microsoft.VisualC");
+        private static byte[]? _MicrosoftVisualC;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.STLCLR.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net35.Microsoft.VisualC.STLCLR");
+        private static byte[]? _MicrosoftVisualCSTLCLR;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Vsa.dll
+        /// </summary>
+        public static byte[] MicrosoftVsa => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsa, "net35.Microsoft.Vsa");
+        private static byte[]? _MicrosoftVsa;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Vsa.Vb.CodeDOMProcessor.dll
+        /// </summary>
+        public static byte[] MicrosoftVsaVbCodeDOMProcessor => ResourceLoader.GetOrCreateResource(ref _MicrosoftVsaVbCodeDOMProcessor, "net35.Microsoft.Vsa.Vb.CodeDOMProcessor");
+        private static byte[]? _MicrosoftVsaVbCodeDOMProcessor;
+
+        /// <summary>
+        /// The image bytes for Microsoft_VsaVb.dll
+        /// </summary>
+        public static byte[] Microsoft_VsaVb => ResourceLoader.GetOrCreateResource(ref _Microsoft_VsaVb, "net35.Microsoft_VsaVb");
+        private static byte[]? _Microsoft_VsaVb;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net35.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for PresentationBuildTasks.dll
+        /// </summary>
+        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net35.PresentationBuildTasks");
+        private static byte[]? _PresentationBuildTasks;
+
+        /// <summary>
+        /// The image bytes for PresentationCore.dll
+        /// </summary>
+        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net35.PresentationCore");
+        private static byte[]? _PresentationCore;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net35.PresentationFramework.Aero");
+        private static byte[]? _PresentationFrameworkAero;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Classic.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net35.PresentationFramework.Classic");
+        private static byte[]? _PresentationFrameworkClassic;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.dll
+        /// </summary>
+        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net35.PresentationFramework");
+        private static byte[]? _PresentationFramework;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Luna.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net35.PresentationFramework.Luna");
+        private static byte[]? _PresentationFrameworkLuna;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Royale.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net35.PresentationFramework.Royale");
+        private static byte[]? _PresentationFrameworkRoyale;
+
+        /// <summary>
+        /// The image bytes for ReachFramework.dll
+        /// </summary>
+        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net35.ReachFramework");
+        private static byte[]? _ReachFramework;
+
+        /// <summary>
+        /// The image bytes for sysglobl.dll
+        /// </summary>
+        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net35.sysglobl");
+        private static byte[]? _sysglobl;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.Contract.dll
+        /// </summary>
+        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net35.System.AddIn.Contract");
+        private static byte[]? _SystemAddInContract;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.dll
+        /// </summary>
+        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net35.System.AddIn");
+        private static byte[]? _SystemAddIn;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net35.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net35.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.Install.dll
+        /// </summary>
+        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net35.System.Configuration.Install");
+        private static byte[]? _SystemConfigurationInstall;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net35.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net35.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net35.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net35.System.Data.Entity.Design");
+        private static byte[]? _SystemDataEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.dll
+        /// </summary>
+        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net35.System.Data.Entity");
+        private static byte[]? _SystemDataEntity;
+
+        /// <summary>
+        /// The image bytes for System.Data.Linq.dll
+        /// </summary>
+        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net35.System.Data.Linq");
+        private static byte[]? _SystemDataLinq;
+
+        /// <summary>
+        /// The image bytes for System.Data.OracleClient.dll
+        /// </summary>
+        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net35.System.Data.OracleClient");
+        private static byte[]? _SystemDataOracleClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Client.dll
+        /// </summary>
+        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net35.System.Data.Services.Client");
+        private static byte[]? _SystemDataServicesClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Design.dll
+        /// </summary>
+        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net35.System.Data.Services.Design");
+        private static byte[]? _SystemDataServicesDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.dll
+        /// </summary>
+        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net35.System.Data.Services");
+        private static byte[]? _SystemDataServices;
+
+        /// <summary>
+        /// The image bytes for System.Data.SqlXml.dll
+        /// </summary>
+        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net35.System.Data.SqlXml");
+        private static byte[]? _SystemDataSqlXml;
+
+        /// <summary>
+        /// The image bytes for System.Deployment.dll
+        /// </summary>
+        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net35.System.Deployment");
+        private static byte[]? _SystemDeployment;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net35.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.AccountManagement.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net35.System.DirectoryServices.AccountManagement");
+        private static byte[]? _SystemDirectoryServicesAccountManagement;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net35.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.Protocols.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net35.System.DirectoryServices.Protocols");
+        private static byte[]? _SystemDirectoryServicesProtocols;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net35.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net35.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net35.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.EnterpriseServices.dll
+        /// </summary>
+        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net35.System.EnterpriseServices");
+        private static byte[]? _SystemEnterpriseServices;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.dll
+        /// </summary>
+        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net35.System.IdentityModel");
+        private static byte[]? _SystemIdentityModel;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Selectors.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net35.System.IdentityModel.Selectors");
+        private static byte[]? _SystemIdentityModelSelectors;
+
+        /// <summary>
+        /// The image bytes for System.IO.Log.dll
+        /// </summary>
+        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net35.System.IO.Log");
+        private static byte[]? _SystemIOLog;
+
+        /// <summary>
+        /// The image bytes for System.Management.dll
+        /// </summary>
+        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net35.System.Management");
+        private static byte[]? _SystemManagement;
+
+        /// <summary>
+        /// The image bytes for System.Management.Instrumentation.dll
+        /// </summary>
+        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net35.System.Management.Instrumentation");
+        private static byte[]? _SystemManagementInstrumentation;
+
+        /// <summary>
+        /// The image bytes for System.Messaging.dll
+        /// </summary>
+        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net35.System.Messaging");
+        private static byte[]? _SystemMessaging;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net35.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Printing.dll
+        /// </summary>
+        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net35.System.Printing");
+        private static byte[]? _SystemPrinting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Remoting.dll
+        /// </summary>
+        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net35.System.Runtime.Remoting");
+        private static byte[]? _SystemRuntimeRemoting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net35.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net35.System.Runtime.Serialization.Formatters.Soap");
+        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net35.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.dll
+        /// </summary>
+        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net35.System.ServiceModel");
+        private static byte[]? _SystemServiceModel;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net35.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net35.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Speech.dll
+        /// </summary>
+        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net35.System.Speech");
+        private static byte[]? _SystemSpeech;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net35.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Abstractions.dll
+        /// </summary>
+        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net35.System.Web.Abstractions");
+        private static byte[]? _SystemWebAbstractions;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net35.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net35.System.Web.DynamicData.Design");
+        private static byte[]? _SystemWebDynamicDataDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net35.System.Web.DynamicData");
+        private static byte[]? _SystemWebDynamicData;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net35.System.Web.Entity.Design");
+        private static byte[]? _SystemWebEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.dll
+        /// </summary>
+        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net35.System.Web.Entity");
+        private static byte[]? _SystemWebEntity;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.Design.dll
+        /// </summary>
+        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net35.System.Web.Extensions.Design");
+        private static byte[]? _SystemWebExtensionsDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.dll
+        /// </summary>
+        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net35.System.Web.Extensions");
+        private static byte[]? _SystemWebExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Mobile.dll
+        /// </summary>
+        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net35.System.Web.Mobile");
+        private static byte[]? _SystemWebMobile;
+
+        /// <summary>
+        /// The image bytes for System.Web.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net35.System.Web.RegularExpressions");
+        private static byte[]? _SystemWebRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Routing.dll
+        /// </summary>
+        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net35.System.Web.Routing");
+        private static byte[]? _SystemWebRouting;
+
+        /// <summary>
+        /// The image bytes for System.Web.Services.dll
+        /// </summary>
+        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net35.System.Web.Services");
+        private static byte[]? _SystemWebServices;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net35.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Presentation.dll
+        /// </summary>
+        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net35.System.Windows.Presentation");
+        private static byte[]? _SystemWindowsPresentation;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Activities.dll
+        /// </summary>
+        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net35.System.Workflow.Activities");
+        private static byte[]? _SystemWorkflowActivities;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net35.System.Workflow.ComponentModel");
+        private static byte[]? _SystemWorkflowComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Runtime.dll
+        /// </summary>
+        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net35.System.Workflow.Runtime");
+        private static byte[]? _SystemWorkflowRuntime;
+
+        /// <summary>
+        /// The image bytes for System.WorkflowServices.dll
+        /// </summary>
+        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net35.System.WorkflowServices");
+        private static byte[]? _SystemWorkflowServices;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net35.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net35.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClient.dll
+        /// </summary>
+        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net35.UIAutomationClient");
+        private static byte[]? _UIAutomationClient;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClientsideProviders.dll
+        /// </summary>
+        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net35.UIAutomationClientsideProviders");
+        private static byte[]? _UIAutomationClientsideProviders;
+
+        /// <summary>
+        /// The image bytes for UIAutomationProvider.dll
+        /// </summary>
+        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net35.UIAutomationProvider");
+        private static byte[]? _UIAutomationProvider;
+
+        /// <summary>
+        /// The image bytes for UIAutomationTypes.dll
+        /// </summary>
+        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net35.UIAutomationTypes");
+        private static byte[]? _UIAutomationTypes;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net35.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for WindowsFormsIntegration.dll
+        /// </summary>
+        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net35.WindowsFormsIntegration");
+        private static byte[]? _WindowsFormsIntegration;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net35/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net35/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -626,6 +626,7 @@ public static partial class Net35
 
     }
 }
+
 public static partial class Net35
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net40/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net40/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -710,6 +710,7 @@ public static partial class Net40
 
     }
 }
+
 public static partial class Net40
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net40/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net40/Generated.cs
@@ -9,710 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net40
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net40.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for CustomMarshalers.dll
-        /// </summary>
-        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net40.CustomMarshalers");
-        private static byte[]? _CustomMarshalers;
-
-        /// <summary>
-        /// The image bytes for ISymWrapper.dll
-        /// </summary>
-        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net40.ISymWrapper");
-        private static byte[]? _ISymWrapper;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net40.Microsoft.Build.Conversion.v4.0");
-        private static byte[]? _MicrosoftBuildConversionv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.dll
-        /// </summary>
-        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net40.Microsoft.Build");
-        private static byte[]? _MicrosoftBuild;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Engine.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net40.Microsoft.Build.Engine");
-        private static byte[]? _MicrosoftBuildEngine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Framework.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net40.Microsoft.Build.Framework");
-        private static byte[]? _MicrosoftBuildFramework;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net40.Microsoft.Build.Tasks.v4.0");
-        private static byte[]? _MicrosoftBuildTasksv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net40.Microsoft.Build.Utilities.v4.0");
-        private static byte[]? _MicrosoftBuildUtilitiesv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net40.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JScript.dll
-        /// </summary>
-        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net40.Microsoft.JScript");
-        private static byte[]? _MicrosoftJScript;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net40.Microsoft.VisualBasic.Compatibility.Data");
-        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net40.Microsoft.VisualBasic.Compatibility");
-        private static byte[]? _MicrosoftVisualBasicCompatibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net40.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net40.Microsoft.VisualC");
-        private static byte[]? _MicrosoftVisualC;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.STLCLR.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net40.Microsoft.VisualC.STLCLR");
-        private static byte[]? _MicrosoftVisualCSTLCLR;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net40.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for PresentationBuildTasks.dll
-        /// </summary>
-        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net40.PresentationBuildTasks");
-        private static byte[]? _PresentationBuildTasks;
-
-        /// <summary>
-        /// The image bytes for PresentationCore.dll
-        /// </summary>
-        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net40.PresentationCore");
-        private static byte[]? _PresentationCore;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net40.PresentationFramework.Aero");
-        private static byte[]? _PresentationFrameworkAero;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Classic.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net40.PresentationFramework.Classic");
-        private static byte[]? _PresentationFrameworkClassic;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.dll
-        /// </summary>
-        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net40.PresentationFramework");
-        private static byte[]? _PresentationFramework;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Luna.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net40.PresentationFramework.Luna");
-        private static byte[]? _PresentationFrameworkLuna;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Royale.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net40.PresentationFramework.Royale");
-        private static byte[]? _PresentationFrameworkRoyale;
-
-        /// <summary>
-        /// The image bytes for ReachFramework.dll
-        /// </summary>
-        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net40.ReachFramework");
-        private static byte[]? _ReachFramework;
-
-        /// <summary>
-        /// The image bytes for sysglobl.dll
-        /// </summary>
-        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net40.sysglobl");
-        private static byte[]? _sysglobl;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Core.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net40.System.Activities.Core.Presentation");
-        private static byte[]? _SystemActivitiesCorePresentation;
-
-        /// <summary>
-        /// The image bytes for System.Activities.dll
-        /// </summary>
-        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net40.System.Activities");
-        private static byte[]? _SystemActivities;
-
-        /// <summary>
-        /// The image bytes for System.Activities.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net40.System.Activities.DurableInstancing");
-        private static byte[]? _SystemActivitiesDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net40.System.Activities.Presentation");
-        private static byte[]? _SystemActivitiesPresentation;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.Contract.dll
-        /// </summary>
-        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net40.System.AddIn.Contract");
-        private static byte[]? _SystemAddInContract;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.dll
-        /// </summary>
-        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net40.System.AddIn");
-        private static byte[]? _SystemAddIn;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.dll
-        /// </summary>
-        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net40.System.ComponentModel.Composition");
-        private static byte[]? _SystemComponentModelComposition;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net40.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net40.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.Install.dll
-        /// </summary>
-        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net40.System.Configuration.Install");
-        private static byte[]? _SystemConfigurationInstall;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net40.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net40.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net40.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net40.System.Data.Entity.Design");
-        private static byte[]? _SystemDataEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.dll
-        /// </summary>
-        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net40.System.Data.Entity");
-        private static byte[]? _SystemDataEntity;
-
-        /// <summary>
-        /// The image bytes for System.Data.Linq.dll
-        /// </summary>
-        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net40.System.Data.Linq");
-        private static byte[]? _SystemDataLinq;
-
-        /// <summary>
-        /// The image bytes for System.Data.OracleClient.dll
-        /// </summary>
-        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net40.System.Data.OracleClient");
-        private static byte[]? _SystemDataOracleClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Client.dll
-        /// </summary>
-        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net40.System.Data.Services.Client");
-        private static byte[]? _SystemDataServicesClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Design.dll
-        /// </summary>
-        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net40.System.Data.Services.Design");
-        private static byte[]? _SystemDataServicesDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.dll
-        /// </summary>
-        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net40.System.Data.Services");
-        private static byte[]? _SystemDataServices;
-
-        /// <summary>
-        /// The image bytes for System.Data.SqlXml.dll
-        /// </summary>
-        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net40.System.Data.SqlXml");
-        private static byte[]? _SystemDataSqlXml;
-
-        /// <summary>
-        /// The image bytes for System.Deployment.dll
-        /// </summary>
-        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net40.System.Deployment");
-        private static byte[]? _SystemDeployment;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net40.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.Device.dll
-        /// </summary>
-        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net40.System.Device");
-        private static byte[]? _SystemDevice;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.AccountManagement.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net40.System.DirectoryServices.AccountManagement");
-        private static byte[]? _SystemDirectoryServicesAccountManagement;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net40.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.Protocols.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net40.System.DirectoryServices.Protocols");
-        private static byte[]? _SystemDirectoryServicesProtocols;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net40.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net40.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net40.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.EnterpriseServices.dll
-        /// </summary>
-        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net40.System.EnterpriseServices");
-        private static byte[]? _SystemEnterpriseServices;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.dll
-        /// </summary>
-        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net40.System.IdentityModel");
-        private static byte[]? _SystemIdentityModel;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Selectors.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net40.System.IdentityModel.Selectors");
-        private static byte[]? _SystemIdentityModelSelectors;
-
-        /// <summary>
-        /// The image bytes for System.IO.Log.dll
-        /// </summary>
-        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net40.System.IO.Log");
-        private static byte[]? _SystemIOLog;
-
-        /// <summary>
-        /// The image bytes for System.Management.dll
-        /// </summary>
-        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net40.System.Management");
-        private static byte[]? _SystemManagement;
-
-        /// <summary>
-        /// The image bytes for System.Management.Instrumentation.dll
-        /// </summary>
-        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net40.System.Management.Instrumentation");
-        private static byte[]? _SystemManagementInstrumentation;
-
-        /// <summary>
-        /// The image bytes for System.Messaging.dll
-        /// </summary>
-        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net40.System.Messaging");
-        private static byte[]? _SystemMessaging;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net40.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net40.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Printing.dll
-        /// </summary>
-        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net40.System.Printing");
-        private static byte[]? _SystemPrinting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Caching.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net40.System.Runtime.Caching");
-        private static byte[]? _SystemRuntimeCaching;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net40.System.Runtime.DurableInstancing");
-        private static byte[]? _SystemRuntimeDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Remoting.dll
-        /// </summary>
-        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net40.System.Runtime.Remoting");
-        private static byte[]? _SystemRuntimeRemoting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net40.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net40.System.Runtime.Serialization.Formatters.Soap");
-        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net40.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activation.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net40.System.ServiceModel.Activation");
-        private static byte[]? _SystemServiceModelActivation;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activities.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net40.System.ServiceModel.Activities");
-        private static byte[]? _SystemServiceModelActivities;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Channels.dll
-        /// </summary>
-        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net40.System.ServiceModel.Channels");
-        private static byte[]? _SystemServiceModelChannels;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Discovery.dll
-        /// </summary>
-        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net40.System.ServiceModel.Discovery");
-        private static byte[]? _SystemServiceModelDiscovery;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.dll
-        /// </summary>
-        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net40.System.ServiceModel");
-        private static byte[]? _SystemServiceModel;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Routing.dll
-        /// </summary>
-        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net40.System.ServiceModel.Routing");
-        private static byte[]? _SystemServiceModelRouting;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net40.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net40.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Speech.dll
-        /// </summary>
-        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net40.System.Speech");
-        private static byte[]? _SystemSpeech;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net40.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Abstractions.dll
-        /// </summary>
-        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net40.System.Web.Abstractions");
-        private static byte[]? _SystemWebAbstractions;
-
-        /// <summary>
-        /// The image bytes for System.Web.ApplicationServices.dll
-        /// </summary>
-        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net40.System.Web.ApplicationServices");
-        private static byte[]? _SystemWebApplicationServices;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net40.System.Web.DataVisualization.Design");
-        private static byte[]? _SystemWebDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net40.System.Web.DataVisualization");
-        private static byte[]? _SystemWebDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net40.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net40.System.Web.DynamicData.Design");
-        private static byte[]? _SystemWebDynamicDataDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net40.System.Web.DynamicData");
-        private static byte[]? _SystemWebDynamicData;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net40.System.Web.Entity.Design");
-        private static byte[]? _SystemWebEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.dll
-        /// </summary>
-        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net40.System.Web.Entity");
-        private static byte[]? _SystemWebEntity;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.Design.dll
-        /// </summary>
-        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net40.System.Web.Extensions.Design");
-        private static byte[]? _SystemWebExtensionsDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.dll
-        /// </summary>
-        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net40.System.Web.Extensions");
-        private static byte[]? _SystemWebExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Mobile.dll
-        /// </summary>
-        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net40.System.Web.Mobile");
-        private static byte[]? _SystemWebMobile;
-
-        /// <summary>
-        /// The image bytes for System.Web.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net40.System.Web.RegularExpressions");
-        private static byte[]? _SystemWebRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Routing.dll
-        /// </summary>
-        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net40.System.Web.Routing");
-        private static byte[]? _SystemWebRouting;
-
-        /// <summary>
-        /// The image bytes for System.Web.Services.dll
-        /// </summary>
-        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net40.System.Web.Services");
-        private static byte[]? _SystemWebServices;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net40.System.Windows.Forms.DataVisualization.Design");
-        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net40.System.Windows.Forms.DataVisualization");
-        private static byte[]? _SystemWindowsFormsDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net40.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Input.Manipulations.dll
-        /// </summary>
-        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net40.System.Windows.Input.Manipulations");
-        private static byte[]? _SystemWindowsInputManipulations;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Presentation.dll
-        /// </summary>
-        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net40.System.Windows.Presentation");
-        private static byte[]? _SystemWindowsPresentation;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Activities.dll
-        /// </summary>
-        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net40.System.Workflow.Activities");
-        private static byte[]? _SystemWorkflowActivities;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net40.System.Workflow.ComponentModel");
-        private static byte[]? _SystemWorkflowComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Runtime.dll
-        /// </summary>
-        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net40.System.Workflow.Runtime");
-        private static byte[]? _SystemWorkflowRuntime;
-
-        /// <summary>
-        /// The image bytes for System.WorkflowServices.dll
-        /// </summary>
-        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net40.System.WorkflowServices");
-        private static byte[]? _SystemWorkflowServices;
-
-        /// <summary>
-        /// The image bytes for System.Xaml.dll
-        /// </summary>
-        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net40.System.Xaml");
-        private static byte[]? _SystemXaml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net40.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net40.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClient.dll
-        /// </summary>
-        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net40.UIAutomationClient");
-        private static byte[]? _UIAutomationClient;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClientsideProviders.dll
-        /// </summary>
-        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net40.UIAutomationClientsideProviders");
-        private static byte[]? _UIAutomationClientsideProviders;
-
-        /// <summary>
-        /// The image bytes for UIAutomationProvider.dll
-        /// </summary>
-        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net40.UIAutomationProvider");
-        private static byte[]? _UIAutomationProvider;
-
-        /// <summary>
-        /// The image bytes for UIAutomationTypes.dll
-        /// </summary>
-        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net40.UIAutomationTypes");
-        private static byte[]? _UIAutomationTypes;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net40.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for WindowsFormsIntegration.dll
-        /// </summary>
-        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net40.WindowsFormsIntegration");
-        private static byte[]? _WindowsFormsIntegration;
-
-        /// <summary>
-        /// The image bytes for XamlBuildTask.dll
-        /// </summary>
-        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net40.XamlBuildTask");
-        private static byte[]? _XamlBuildTask;
-
-
-    }
-}
-
-public static partial class Net40
-{
     public static class ReferenceInfos
     {
 
@@ -3536,6 +2832,710 @@ public static partial class Net40
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net40
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net40.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for CustomMarshalers.dll
+        /// </summary>
+        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net40.CustomMarshalers");
+        private static byte[]? _CustomMarshalers;
+
+        /// <summary>
+        /// The image bytes for ISymWrapper.dll
+        /// </summary>
+        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net40.ISymWrapper");
+        private static byte[]? _ISymWrapper;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net40.Microsoft.Build.Conversion.v4.0");
+        private static byte[]? _MicrosoftBuildConversionv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.dll
+        /// </summary>
+        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net40.Microsoft.Build");
+        private static byte[]? _MicrosoftBuild;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Engine.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net40.Microsoft.Build.Engine");
+        private static byte[]? _MicrosoftBuildEngine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Framework.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net40.Microsoft.Build.Framework");
+        private static byte[]? _MicrosoftBuildFramework;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net40.Microsoft.Build.Tasks.v4.0");
+        private static byte[]? _MicrosoftBuildTasksv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net40.Microsoft.Build.Utilities.v4.0");
+        private static byte[]? _MicrosoftBuildUtilitiesv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net40.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JScript.dll
+        /// </summary>
+        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net40.Microsoft.JScript");
+        private static byte[]? _MicrosoftJScript;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net40.Microsoft.VisualBasic.Compatibility.Data");
+        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net40.Microsoft.VisualBasic.Compatibility");
+        private static byte[]? _MicrosoftVisualBasicCompatibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net40.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net40.Microsoft.VisualC");
+        private static byte[]? _MicrosoftVisualC;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.STLCLR.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net40.Microsoft.VisualC.STLCLR");
+        private static byte[]? _MicrosoftVisualCSTLCLR;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net40.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for PresentationBuildTasks.dll
+        /// </summary>
+        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net40.PresentationBuildTasks");
+        private static byte[]? _PresentationBuildTasks;
+
+        /// <summary>
+        /// The image bytes for PresentationCore.dll
+        /// </summary>
+        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net40.PresentationCore");
+        private static byte[]? _PresentationCore;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net40.PresentationFramework.Aero");
+        private static byte[]? _PresentationFrameworkAero;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Classic.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net40.PresentationFramework.Classic");
+        private static byte[]? _PresentationFrameworkClassic;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.dll
+        /// </summary>
+        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net40.PresentationFramework");
+        private static byte[]? _PresentationFramework;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Luna.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net40.PresentationFramework.Luna");
+        private static byte[]? _PresentationFrameworkLuna;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Royale.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net40.PresentationFramework.Royale");
+        private static byte[]? _PresentationFrameworkRoyale;
+
+        /// <summary>
+        /// The image bytes for ReachFramework.dll
+        /// </summary>
+        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net40.ReachFramework");
+        private static byte[]? _ReachFramework;
+
+        /// <summary>
+        /// The image bytes for sysglobl.dll
+        /// </summary>
+        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net40.sysglobl");
+        private static byte[]? _sysglobl;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Core.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net40.System.Activities.Core.Presentation");
+        private static byte[]? _SystemActivitiesCorePresentation;
+
+        /// <summary>
+        /// The image bytes for System.Activities.dll
+        /// </summary>
+        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net40.System.Activities");
+        private static byte[]? _SystemActivities;
+
+        /// <summary>
+        /// The image bytes for System.Activities.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net40.System.Activities.DurableInstancing");
+        private static byte[]? _SystemActivitiesDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net40.System.Activities.Presentation");
+        private static byte[]? _SystemActivitiesPresentation;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.Contract.dll
+        /// </summary>
+        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net40.System.AddIn.Contract");
+        private static byte[]? _SystemAddInContract;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.dll
+        /// </summary>
+        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net40.System.AddIn");
+        private static byte[]? _SystemAddIn;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.dll
+        /// </summary>
+        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net40.System.ComponentModel.Composition");
+        private static byte[]? _SystemComponentModelComposition;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net40.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net40.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.Install.dll
+        /// </summary>
+        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net40.System.Configuration.Install");
+        private static byte[]? _SystemConfigurationInstall;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net40.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net40.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net40.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net40.System.Data.Entity.Design");
+        private static byte[]? _SystemDataEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.dll
+        /// </summary>
+        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net40.System.Data.Entity");
+        private static byte[]? _SystemDataEntity;
+
+        /// <summary>
+        /// The image bytes for System.Data.Linq.dll
+        /// </summary>
+        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net40.System.Data.Linq");
+        private static byte[]? _SystemDataLinq;
+
+        /// <summary>
+        /// The image bytes for System.Data.OracleClient.dll
+        /// </summary>
+        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net40.System.Data.OracleClient");
+        private static byte[]? _SystemDataOracleClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Client.dll
+        /// </summary>
+        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net40.System.Data.Services.Client");
+        private static byte[]? _SystemDataServicesClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Design.dll
+        /// </summary>
+        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net40.System.Data.Services.Design");
+        private static byte[]? _SystemDataServicesDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.dll
+        /// </summary>
+        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net40.System.Data.Services");
+        private static byte[]? _SystemDataServices;
+
+        /// <summary>
+        /// The image bytes for System.Data.SqlXml.dll
+        /// </summary>
+        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net40.System.Data.SqlXml");
+        private static byte[]? _SystemDataSqlXml;
+
+        /// <summary>
+        /// The image bytes for System.Deployment.dll
+        /// </summary>
+        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net40.System.Deployment");
+        private static byte[]? _SystemDeployment;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net40.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.Device.dll
+        /// </summary>
+        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net40.System.Device");
+        private static byte[]? _SystemDevice;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.AccountManagement.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net40.System.DirectoryServices.AccountManagement");
+        private static byte[]? _SystemDirectoryServicesAccountManagement;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net40.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.Protocols.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net40.System.DirectoryServices.Protocols");
+        private static byte[]? _SystemDirectoryServicesProtocols;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net40.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net40.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net40.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.EnterpriseServices.dll
+        /// </summary>
+        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net40.System.EnterpriseServices");
+        private static byte[]? _SystemEnterpriseServices;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.dll
+        /// </summary>
+        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net40.System.IdentityModel");
+        private static byte[]? _SystemIdentityModel;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Selectors.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net40.System.IdentityModel.Selectors");
+        private static byte[]? _SystemIdentityModelSelectors;
+
+        /// <summary>
+        /// The image bytes for System.IO.Log.dll
+        /// </summary>
+        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net40.System.IO.Log");
+        private static byte[]? _SystemIOLog;
+
+        /// <summary>
+        /// The image bytes for System.Management.dll
+        /// </summary>
+        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net40.System.Management");
+        private static byte[]? _SystemManagement;
+
+        /// <summary>
+        /// The image bytes for System.Management.Instrumentation.dll
+        /// </summary>
+        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net40.System.Management.Instrumentation");
+        private static byte[]? _SystemManagementInstrumentation;
+
+        /// <summary>
+        /// The image bytes for System.Messaging.dll
+        /// </summary>
+        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net40.System.Messaging");
+        private static byte[]? _SystemMessaging;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net40.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net40.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Printing.dll
+        /// </summary>
+        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net40.System.Printing");
+        private static byte[]? _SystemPrinting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Caching.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net40.System.Runtime.Caching");
+        private static byte[]? _SystemRuntimeCaching;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net40.System.Runtime.DurableInstancing");
+        private static byte[]? _SystemRuntimeDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Remoting.dll
+        /// </summary>
+        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net40.System.Runtime.Remoting");
+        private static byte[]? _SystemRuntimeRemoting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net40.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net40.System.Runtime.Serialization.Formatters.Soap");
+        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net40.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activation.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net40.System.ServiceModel.Activation");
+        private static byte[]? _SystemServiceModelActivation;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activities.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net40.System.ServiceModel.Activities");
+        private static byte[]? _SystemServiceModelActivities;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Channels.dll
+        /// </summary>
+        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net40.System.ServiceModel.Channels");
+        private static byte[]? _SystemServiceModelChannels;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Discovery.dll
+        /// </summary>
+        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net40.System.ServiceModel.Discovery");
+        private static byte[]? _SystemServiceModelDiscovery;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.dll
+        /// </summary>
+        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net40.System.ServiceModel");
+        private static byte[]? _SystemServiceModel;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Routing.dll
+        /// </summary>
+        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net40.System.ServiceModel.Routing");
+        private static byte[]? _SystemServiceModelRouting;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net40.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net40.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Speech.dll
+        /// </summary>
+        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net40.System.Speech");
+        private static byte[]? _SystemSpeech;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net40.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Abstractions.dll
+        /// </summary>
+        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net40.System.Web.Abstractions");
+        private static byte[]? _SystemWebAbstractions;
+
+        /// <summary>
+        /// The image bytes for System.Web.ApplicationServices.dll
+        /// </summary>
+        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net40.System.Web.ApplicationServices");
+        private static byte[]? _SystemWebApplicationServices;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net40.System.Web.DataVisualization.Design");
+        private static byte[]? _SystemWebDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net40.System.Web.DataVisualization");
+        private static byte[]? _SystemWebDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net40.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net40.System.Web.DynamicData.Design");
+        private static byte[]? _SystemWebDynamicDataDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net40.System.Web.DynamicData");
+        private static byte[]? _SystemWebDynamicData;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net40.System.Web.Entity.Design");
+        private static byte[]? _SystemWebEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.dll
+        /// </summary>
+        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net40.System.Web.Entity");
+        private static byte[]? _SystemWebEntity;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.Design.dll
+        /// </summary>
+        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net40.System.Web.Extensions.Design");
+        private static byte[]? _SystemWebExtensionsDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.dll
+        /// </summary>
+        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net40.System.Web.Extensions");
+        private static byte[]? _SystemWebExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Mobile.dll
+        /// </summary>
+        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net40.System.Web.Mobile");
+        private static byte[]? _SystemWebMobile;
+
+        /// <summary>
+        /// The image bytes for System.Web.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net40.System.Web.RegularExpressions");
+        private static byte[]? _SystemWebRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Routing.dll
+        /// </summary>
+        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net40.System.Web.Routing");
+        private static byte[]? _SystemWebRouting;
+
+        /// <summary>
+        /// The image bytes for System.Web.Services.dll
+        /// </summary>
+        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net40.System.Web.Services");
+        private static byte[]? _SystemWebServices;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net40.System.Windows.Forms.DataVisualization.Design");
+        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net40.System.Windows.Forms.DataVisualization");
+        private static byte[]? _SystemWindowsFormsDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net40.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Input.Manipulations.dll
+        /// </summary>
+        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net40.System.Windows.Input.Manipulations");
+        private static byte[]? _SystemWindowsInputManipulations;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Presentation.dll
+        /// </summary>
+        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net40.System.Windows.Presentation");
+        private static byte[]? _SystemWindowsPresentation;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Activities.dll
+        /// </summary>
+        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net40.System.Workflow.Activities");
+        private static byte[]? _SystemWorkflowActivities;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net40.System.Workflow.ComponentModel");
+        private static byte[]? _SystemWorkflowComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Runtime.dll
+        /// </summary>
+        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net40.System.Workflow.Runtime");
+        private static byte[]? _SystemWorkflowRuntime;
+
+        /// <summary>
+        /// The image bytes for System.WorkflowServices.dll
+        /// </summary>
+        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net40.System.WorkflowServices");
+        private static byte[]? _SystemWorkflowServices;
+
+        /// <summary>
+        /// The image bytes for System.Xaml.dll
+        /// </summary>
+        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net40.System.Xaml");
+        private static byte[]? _SystemXaml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net40.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net40.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClient.dll
+        /// </summary>
+        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net40.UIAutomationClient");
+        private static byte[]? _UIAutomationClient;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClientsideProviders.dll
+        /// </summary>
+        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net40.UIAutomationClientsideProviders");
+        private static byte[]? _UIAutomationClientsideProviders;
+
+        /// <summary>
+        /// The image bytes for UIAutomationProvider.dll
+        /// </summary>
+        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net40.UIAutomationProvider");
+        private static byte[]? _UIAutomationProvider;
+
+        /// <summary>
+        /// The image bytes for UIAutomationTypes.dll
+        /// </summary>
+        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net40.UIAutomationTypes");
+        private static byte[]? _UIAutomationTypes;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net40.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for WindowsFormsIntegration.dll
+        /// </summary>
+        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net40.WindowsFormsIntegration");
+        private static byte[]? _WindowsFormsIntegration;
+
+        /// <summary>
+        /// The image bytes for XamlBuildTask.dll
+        /// </summary>
+        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net40.XamlBuildTask");
+        private static byte[]? _XamlBuildTask;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net461/Basic.Reference.Assemblies.Net461.csproj
+++ b/Src/Basic.Reference.Assemblies.Net461/Basic.Reference.Assemblies.Net461.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Import Project="Generated.targets" />

--- a/Src/Basic.Reference.Assemblies.Net461/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net461/Generated.cs
@@ -9,1192 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net461
 {
-    public static class ExtraReferenceInfos
-    {
-
-        /// <summary>
-        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, Net461.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("bc890e4e-a34f-463c-8fd9-60f43c8beb88"));
-        private static ImmutableArray<ReferenceInfo> _all;
-        public static ImmutableArray<ReferenceInfo> All
-        {
-            get
-            {
-                if (_all.IsDefault)
-                {
-                    _all =
-                    [
-                        SystemThreadingTasksExtensions,
-                    ];
-                }
-                return _all;
-            }
-        }
-
-        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
-    }
-}
-
-public static partial class Net461
-{
-    public static class ExtraReferences
-    {
-        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static PortableExecutableReference SystemThreadingTasksExtensions
-        {
-            get
-            {
-                if (_SystemThreadingTasksExtensions is null)
-                {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net461)");
-                }
-                return _SystemThreadingTasksExtensions;
-            }
-        }
-
-        private static ImmutableArray<PortableExecutableReference> _all;
-        public static ImmutableArray<PortableExecutableReference> All
-        {
-            get
-            {
-                if (_all.IsDefault)
-                {
-                    _all =
-                    [
-                        SystemThreadingTasksExtensions,
-                    ];
-                }
-                return _all;
-            }
-        }
-    }
-}
-
-public static partial class Net461
-{
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net461.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for CustomMarshalers.dll
-        /// </summary>
-        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net461.CustomMarshalers");
-        private static byte[]? _CustomMarshalers;
-
-        /// <summary>
-        /// The image bytes for ISymWrapper.dll
-        /// </summary>
-        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net461.ISymWrapper");
-        private static byte[]? _ISymWrapper;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Activities.Build.dll
-        /// </summary>
-        public static byte[] MicrosoftActivitiesBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftActivitiesBuild, "net461.Microsoft.Activities.Build");
-        private static byte[]? _MicrosoftActivitiesBuild;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net461.Microsoft.Build.Conversion.v4.0");
-        private static byte[]? _MicrosoftBuildConversionv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.dll
-        /// </summary>
-        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net461.Microsoft.Build");
-        private static byte[]? _MicrosoftBuild;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Engine.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net461.Microsoft.Build.Engine");
-        private static byte[]? _MicrosoftBuildEngine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Framework.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net461.Microsoft.Build.Framework");
-        private static byte[]? _MicrosoftBuildFramework;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net461.Microsoft.Build.Tasks.v4.0");
-        private static byte[]? _MicrosoftBuildTasksv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net461.Microsoft.Build.Utilities.v4.0");
-        private static byte[]? _MicrosoftBuildUtilitiesv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net461.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JScript.dll
-        /// </summary>
-        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net461.Microsoft.JScript");
-        private static byte[]? _MicrosoftJScript;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net461.Microsoft.VisualBasic.Compatibility.Data");
-        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net461.Microsoft.VisualBasic.Compatibility");
-        private static byte[]? _MicrosoftVisualBasicCompatibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net461.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net461.Microsoft.VisualC");
-        private static byte[]? _MicrosoftVisualC;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.STLCLR.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net461.Microsoft.VisualC.STLCLR");
-        private static byte[]? _MicrosoftVisualCSTLCLR;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net461.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for PresentationBuildTasks.dll
-        /// </summary>
-        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net461.PresentationBuildTasks");
-        private static byte[]? _PresentationBuildTasks;
-
-        /// <summary>
-        /// The image bytes for PresentationCore.dll
-        /// </summary>
-        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net461.PresentationCore");
-        private static byte[]? _PresentationCore;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net461.PresentationFramework.Aero");
-        private static byte[]? _PresentationFrameworkAero;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero2.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net461.PresentationFramework.Aero2");
-        private static byte[]? _PresentationFrameworkAero2;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.AeroLite.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net461.PresentationFramework.AeroLite");
-        private static byte[]? _PresentationFrameworkAeroLite;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Classic.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net461.PresentationFramework.Classic");
-        private static byte[]? _PresentationFrameworkClassic;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.dll
-        /// </summary>
-        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net461.PresentationFramework");
-        private static byte[]? _PresentationFramework;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Luna.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net461.PresentationFramework.Luna");
-        private static byte[]? _PresentationFrameworkLuna;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Royale.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net461.PresentationFramework.Royale");
-        private static byte[]? _PresentationFrameworkRoyale;
-
-        /// <summary>
-        /// The image bytes for ReachFramework.dll
-        /// </summary>
-        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net461.ReachFramework");
-        private static byte[]? _ReachFramework;
-
-        /// <summary>
-        /// The image bytes for sysglobl.dll
-        /// </summary>
-        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net461.sysglobl");
-        private static byte[]? _sysglobl;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Core.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net461.System.Activities.Core.Presentation");
-        private static byte[]? _SystemActivitiesCorePresentation;
-
-        /// <summary>
-        /// The image bytes for System.Activities.dll
-        /// </summary>
-        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net461.System.Activities");
-        private static byte[]? _SystemActivities;
-
-        /// <summary>
-        /// The image bytes for System.Activities.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net461.System.Activities.DurableInstancing");
-        private static byte[]? _SystemActivitiesDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net461.System.Activities.Presentation");
-        private static byte[]? _SystemActivitiesPresentation;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.Contract.dll
-        /// </summary>
-        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net461.System.AddIn.Contract");
-        private static byte[]? _SystemAddInContract;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.dll
-        /// </summary>
-        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net461.System.AddIn");
-        private static byte[]? _SystemAddIn;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.dll
-        /// </summary>
-        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net461.System.ComponentModel.Composition");
-        private static byte[]? _SystemComponentModelComposition;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.Registration.dll
-        /// </summary>
-        public static byte[] SystemComponentModelCompositionRegistration => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelCompositionRegistration, "net461.System.ComponentModel.Composition.Registration");
-        private static byte[]? _SystemComponentModelCompositionRegistration;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net461.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net461.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.Install.dll
-        /// </summary>
-        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net461.System.Configuration.Install");
-        private static byte[]? _SystemConfigurationInstall;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net461.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net461.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net461.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net461.System.Data.Entity.Design");
-        private static byte[]? _SystemDataEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.dll
-        /// </summary>
-        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net461.System.Data.Entity");
-        private static byte[]? _SystemDataEntity;
-
-        /// <summary>
-        /// The image bytes for System.Data.Linq.dll
-        /// </summary>
-        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net461.System.Data.Linq");
-        private static byte[]? _SystemDataLinq;
-
-        /// <summary>
-        /// The image bytes for System.Data.OracleClient.dll
-        /// </summary>
-        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net461.System.Data.OracleClient");
-        private static byte[]? _SystemDataOracleClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Client.dll
-        /// </summary>
-        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net461.System.Data.Services.Client");
-        private static byte[]? _SystemDataServicesClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Design.dll
-        /// </summary>
-        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net461.System.Data.Services.Design");
-        private static byte[]? _SystemDataServicesDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.dll
-        /// </summary>
-        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net461.System.Data.Services");
-        private static byte[]? _SystemDataServices;
-
-        /// <summary>
-        /// The image bytes for System.Data.SqlXml.dll
-        /// </summary>
-        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net461.System.Data.SqlXml");
-        private static byte[]? _SystemDataSqlXml;
-
-        /// <summary>
-        /// The image bytes for System.Deployment.dll
-        /// </summary>
-        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net461.System.Deployment");
-        private static byte[]? _SystemDeployment;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net461.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.Device.dll
-        /// </summary>
-        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net461.System.Device");
-        private static byte[]? _SystemDevice;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.AccountManagement.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net461.System.DirectoryServices.AccountManagement");
-        private static byte[]? _SystemDirectoryServicesAccountManagement;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net461.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.Protocols.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net461.System.DirectoryServices.Protocols");
-        private static byte[]? _SystemDirectoryServicesProtocols;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net461.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net461.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net461.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.dll
-        /// </summary>
-        public static byte[] SystemDynamic => ResourceLoader.GetOrCreateResource(ref _SystemDynamic, "net461.System.Dynamic");
-        private static byte[]? _SystemDynamic;
-
-        /// <summary>
-        /// The image bytes for System.EnterpriseServices.dll
-        /// </summary>
-        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net461.System.EnterpriseServices");
-        private static byte[]? _SystemEnterpriseServices;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.dll
-        /// </summary>
-        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net461.System.IdentityModel");
-        private static byte[]? _SystemIdentityModel;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Selectors.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net461.System.IdentityModel.Selectors");
-        private static byte[]? _SystemIdentityModelSelectors;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Services.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelServices => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelServices, "net461.System.IdentityModel.Services");
-        private static byte[]? _SystemIdentityModelServices;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net461.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net461.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Log.dll
-        /// </summary>
-        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net461.System.IO.Log");
-        private static byte[]? _SystemIOLog;
-
-        /// <summary>
-        /// The image bytes for System.Management.dll
-        /// </summary>
-        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net461.System.Management");
-        private static byte[]? _SystemManagement;
-
-        /// <summary>
-        /// The image bytes for System.Management.Instrumentation.dll
-        /// </summary>
-        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net461.System.Management.Instrumentation");
-        private static byte[]? _SystemManagementInstrumentation;
-
-        /// <summary>
-        /// The image bytes for System.Messaging.dll
-        /// </summary>
-        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net461.System.Messaging");
-        private static byte[]? _SystemMessaging;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net461.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net461.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.WebRequest.dll
-        /// </summary>
-        public static byte[] SystemNetHttpWebRequest => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpWebRequest, "net461.System.Net.Http.WebRequest");
-        private static byte[]? _SystemNetHttpWebRequest;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net461.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net461.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.Printing.dll
-        /// </summary>
-        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net461.System.Printing");
-        private static byte[]? _SystemPrinting;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Context.dll
-        /// </summary>
-        public static byte[] SystemReflectionContext => ResourceLoader.GetOrCreateResource(ref _SystemReflectionContext, "net461.System.Reflection.Context");
-        private static byte[]? _SystemReflectionContext;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Caching.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net461.System.Runtime.Caching");
-        private static byte[]? _SystemRuntimeCaching;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net461.System.Runtime.DurableInstancing");
-        private static byte[]? _SystemRuntimeDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Remoting.dll
-        /// </summary>
-        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net461.System.Runtime.Remoting");
-        private static byte[]? _SystemRuntimeRemoting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net461.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net461.System.Runtime.Serialization.Formatters.Soap");
-        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net461.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activation.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net461.System.ServiceModel.Activation");
-        private static byte[]? _SystemServiceModelActivation;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activities.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net461.System.ServiceModel.Activities");
-        private static byte[]? _SystemServiceModelActivities;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Channels.dll
-        /// </summary>
-        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net461.System.ServiceModel.Channels");
-        private static byte[]? _SystemServiceModelChannels;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Discovery.dll
-        /// </summary>
-        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net461.System.ServiceModel.Discovery");
-        private static byte[]? _SystemServiceModelDiscovery;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.dll
-        /// </summary>
-        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net461.System.ServiceModel");
-        private static byte[]? _SystemServiceModel;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Routing.dll
-        /// </summary>
-        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net461.System.ServiceModel.Routing");
-        private static byte[]? _SystemServiceModelRouting;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net461.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net461.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Speech.dll
-        /// </summary>
-        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net461.System.Speech");
-        private static byte[]? _SystemSpeech;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net461.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Abstractions.dll
-        /// </summary>
-        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net461.System.Web.Abstractions");
-        private static byte[]? _SystemWebAbstractions;
-
-        /// <summary>
-        /// The image bytes for System.Web.ApplicationServices.dll
-        /// </summary>
-        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net461.System.Web.ApplicationServices");
-        private static byte[]? _SystemWebApplicationServices;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net461.System.Web.DataVisualization.Design");
-        private static byte[]? _SystemWebDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net461.System.Web.DataVisualization");
-        private static byte[]? _SystemWebDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net461.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net461.System.Web.DynamicData.Design");
-        private static byte[]? _SystemWebDynamicDataDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net461.System.Web.DynamicData");
-        private static byte[]? _SystemWebDynamicData;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net461.System.Web.Entity.Design");
-        private static byte[]? _SystemWebEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.dll
-        /// </summary>
-        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net461.System.Web.Entity");
-        private static byte[]? _SystemWebEntity;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.Design.dll
-        /// </summary>
-        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net461.System.Web.Extensions.Design");
-        private static byte[]? _SystemWebExtensionsDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.dll
-        /// </summary>
-        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net461.System.Web.Extensions");
-        private static byte[]? _SystemWebExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Mobile.dll
-        /// </summary>
-        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net461.System.Web.Mobile");
-        private static byte[]? _SystemWebMobile;
-
-        /// <summary>
-        /// The image bytes for System.Web.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net461.System.Web.RegularExpressions");
-        private static byte[]? _SystemWebRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Routing.dll
-        /// </summary>
-        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net461.System.Web.Routing");
-        private static byte[]? _SystemWebRouting;
-
-        /// <summary>
-        /// The image bytes for System.Web.Services.dll
-        /// </summary>
-        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net461.System.Web.Services");
-        private static byte[]? _SystemWebServices;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Controls.Ribbon.dll
-        /// </summary>
-        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net461.System.Windows.Controls.Ribbon");
-        private static byte[]? _SystemWindowsControlsRibbon;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net461.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net461.System.Windows.Forms.DataVisualization.Design");
-        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net461.System.Windows.Forms.DataVisualization");
-        private static byte[]? _SystemWindowsFormsDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net461.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Input.Manipulations.dll
-        /// </summary>
-        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net461.System.Windows.Input.Manipulations");
-        private static byte[]? _SystemWindowsInputManipulations;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Presentation.dll
-        /// </summary>
-        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net461.System.Windows.Presentation");
-        private static byte[]? _SystemWindowsPresentation;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Activities.dll
-        /// </summary>
-        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net461.System.Workflow.Activities");
-        private static byte[]? _SystemWorkflowActivities;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net461.System.Workflow.ComponentModel");
-        private static byte[]? _SystemWorkflowComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Runtime.dll
-        /// </summary>
-        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net461.System.Workflow.Runtime");
-        private static byte[]? _SystemWorkflowRuntime;
-
-        /// <summary>
-        /// The image bytes for System.WorkflowServices.dll
-        /// </summary>
-        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net461.System.WorkflowServices");
-        private static byte[]? _SystemWorkflowServices;
-
-        /// <summary>
-        /// The image bytes for System.Xaml.dll
-        /// </summary>
-        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net461.System.Xaml");
-        private static byte[]? _SystemXaml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net461.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net461.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net461.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClient.dll
-        /// </summary>
-        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net461.UIAutomationClient");
-        private static byte[]? _UIAutomationClient;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClientsideProviders.dll
-        /// </summary>
-        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net461.UIAutomationClientsideProviders");
-        private static byte[]? _UIAutomationClientsideProviders;
-
-        /// <summary>
-        /// The image bytes for UIAutomationProvider.dll
-        /// </summary>
-        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net461.UIAutomationProvider");
-        private static byte[]? _UIAutomationProvider;
-
-        /// <summary>
-        /// The image bytes for UIAutomationTypes.dll
-        /// </summary>
-        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net461.UIAutomationTypes");
-        private static byte[]? _UIAutomationTypes;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net461.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for WindowsFormsIntegration.dll
-        /// </summary>
-        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net461.WindowsFormsIntegration");
-        private static byte[]? _WindowsFormsIntegration;
-
-        /// <summary>
-        /// The image bytes for XamlBuildTask.dll
-        /// </summary>
-        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net461.XamlBuildTask");
-        private static byte[]? _XamlBuildTask;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net461.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net461.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net461.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net461.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net461.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net461.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net461.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net461.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net461.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net461.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net461.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net461.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net461.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net461.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net461.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net461.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net461.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net461.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net461.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net461.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net461.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net461.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net461.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net461.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net461.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net461.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net461.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net461.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net461.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net461.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net461.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net461.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "net461.System.Runtime.InteropServices.WindowsRuntime");
-        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net461.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net461.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net461.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net461.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net461.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Duplex.dll
-        /// </summary>
-        public static byte[] SystemServiceModelDuplex => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDuplex, "net461.System.ServiceModel.Duplex");
-        private static byte[]? _SystemServiceModelDuplex;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Http.dll
-        /// </summary>
-        public static byte[] SystemServiceModelHttp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelHttp, "net461.System.ServiceModel.Http");
-        private static byte[]? _SystemServiceModelHttp;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.NetTcp.dll
-        /// </summary>
-        public static byte[] SystemServiceModelNetTcp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelNetTcp, "net461.System.ServiceModel.NetTcp");
-        private static byte[]? _SystemServiceModelNetTcp;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemServiceModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelPrimitives, "net461.System.ServiceModel.Primitives");
-        private static byte[]? _SystemServiceModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Security.dll
-        /// </summary>
-        public static byte[] SystemServiceModelSecurity => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelSecurity, "net461.System.ServiceModel.Security");
-        private static byte[]? _SystemServiceModelSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net461.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net461.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net461.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net461.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net461.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net461.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net461.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net461.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net461.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net461.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net461.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-
-    }
-}
-
-public static partial class Net461
-{
     public static class ReferenceInfos
     {
 
@@ -5650,6 +4464,1192 @@ public static partial class Net461
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net461
+{
+    public static class ExtraReferenceInfos
+    {
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, Net461.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("bc890e4e-a34f-463c-8fd9-60f43c8beb88"));
+        private static ImmutableArray<ReferenceInfo> _all;
+        public static ImmutableArray<ReferenceInfo> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+
+        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
+    }
+}
+
+public static partial class Net461
+{
+    public static class ExtraReferences
+    {
+        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static PortableExecutableReference SystemThreadingTasksExtensions
+        {
+            get
+            {
+                if (_SystemThreadingTasksExtensions is null)
+                {
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net461)");
+                }
+                return _SystemThreadingTasksExtensions;
+            }
+        }
+
+        private static ImmutableArray<PortableExecutableReference> _all;
+        public static ImmutableArray<PortableExecutableReference> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+    }
+}
+
+public static partial class Net461
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net461.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for CustomMarshalers.dll
+        /// </summary>
+        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net461.CustomMarshalers");
+        private static byte[]? _CustomMarshalers;
+
+        /// <summary>
+        /// The image bytes for ISymWrapper.dll
+        /// </summary>
+        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net461.ISymWrapper");
+        private static byte[]? _ISymWrapper;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Activities.Build.dll
+        /// </summary>
+        public static byte[] MicrosoftActivitiesBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftActivitiesBuild, "net461.Microsoft.Activities.Build");
+        private static byte[]? _MicrosoftActivitiesBuild;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net461.Microsoft.Build.Conversion.v4.0");
+        private static byte[]? _MicrosoftBuildConversionv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.dll
+        /// </summary>
+        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net461.Microsoft.Build");
+        private static byte[]? _MicrosoftBuild;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Engine.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net461.Microsoft.Build.Engine");
+        private static byte[]? _MicrosoftBuildEngine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Framework.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net461.Microsoft.Build.Framework");
+        private static byte[]? _MicrosoftBuildFramework;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net461.Microsoft.Build.Tasks.v4.0");
+        private static byte[]? _MicrosoftBuildTasksv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net461.Microsoft.Build.Utilities.v4.0");
+        private static byte[]? _MicrosoftBuildUtilitiesv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net461.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JScript.dll
+        /// </summary>
+        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net461.Microsoft.JScript");
+        private static byte[]? _MicrosoftJScript;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net461.Microsoft.VisualBasic.Compatibility.Data");
+        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net461.Microsoft.VisualBasic.Compatibility");
+        private static byte[]? _MicrosoftVisualBasicCompatibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net461.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net461.Microsoft.VisualC");
+        private static byte[]? _MicrosoftVisualC;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.STLCLR.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net461.Microsoft.VisualC.STLCLR");
+        private static byte[]? _MicrosoftVisualCSTLCLR;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net461.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for PresentationBuildTasks.dll
+        /// </summary>
+        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net461.PresentationBuildTasks");
+        private static byte[]? _PresentationBuildTasks;
+
+        /// <summary>
+        /// The image bytes for PresentationCore.dll
+        /// </summary>
+        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net461.PresentationCore");
+        private static byte[]? _PresentationCore;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net461.PresentationFramework.Aero");
+        private static byte[]? _PresentationFrameworkAero;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero2.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net461.PresentationFramework.Aero2");
+        private static byte[]? _PresentationFrameworkAero2;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.AeroLite.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net461.PresentationFramework.AeroLite");
+        private static byte[]? _PresentationFrameworkAeroLite;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Classic.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net461.PresentationFramework.Classic");
+        private static byte[]? _PresentationFrameworkClassic;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.dll
+        /// </summary>
+        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net461.PresentationFramework");
+        private static byte[]? _PresentationFramework;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Luna.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net461.PresentationFramework.Luna");
+        private static byte[]? _PresentationFrameworkLuna;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Royale.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net461.PresentationFramework.Royale");
+        private static byte[]? _PresentationFrameworkRoyale;
+
+        /// <summary>
+        /// The image bytes for ReachFramework.dll
+        /// </summary>
+        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net461.ReachFramework");
+        private static byte[]? _ReachFramework;
+
+        /// <summary>
+        /// The image bytes for sysglobl.dll
+        /// </summary>
+        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net461.sysglobl");
+        private static byte[]? _sysglobl;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Core.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net461.System.Activities.Core.Presentation");
+        private static byte[]? _SystemActivitiesCorePresentation;
+
+        /// <summary>
+        /// The image bytes for System.Activities.dll
+        /// </summary>
+        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net461.System.Activities");
+        private static byte[]? _SystemActivities;
+
+        /// <summary>
+        /// The image bytes for System.Activities.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net461.System.Activities.DurableInstancing");
+        private static byte[]? _SystemActivitiesDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net461.System.Activities.Presentation");
+        private static byte[]? _SystemActivitiesPresentation;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.Contract.dll
+        /// </summary>
+        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net461.System.AddIn.Contract");
+        private static byte[]? _SystemAddInContract;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.dll
+        /// </summary>
+        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net461.System.AddIn");
+        private static byte[]? _SystemAddIn;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.dll
+        /// </summary>
+        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net461.System.ComponentModel.Composition");
+        private static byte[]? _SystemComponentModelComposition;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.Registration.dll
+        /// </summary>
+        public static byte[] SystemComponentModelCompositionRegistration => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelCompositionRegistration, "net461.System.ComponentModel.Composition.Registration");
+        private static byte[]? _SystemComponentModelCompositionRegistration;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net461.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net461.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.Install.dll
+        /// </summary>
+        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net461.System.Configuration.Install");
+        private static byte[]? _SystemConfigurationInstall;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net461.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net461.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net461.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net461.System.Data.Entity.Design");
+        private static byte[]? _SystemDataEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.dll
+        /// </summary>
+        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net461.System.Data.Entity");
+        private static byte[]? _SystemDataEntity;
+
+        /// <summary>
+        /// The image bytes for System.Data.Linq.dll
+        /// </summary>
+        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net461.System.Data.Linq");
+        private static byte[]? _SystemDataLinq;
+
+        /// <summary>
+        /// The image bytes for System.Data.OracleClient.dll
+        /// </summary>
+        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net461.System.Data.OracleClient");
+        private static byte[]? _SystemDataOracleClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Client.dll
+        /// </summary>
+        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net461.System.Data.Services.Client");
+        private static byte[]? _SystemDataServicesClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Design.dll
+        /// </summary>
+        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net461.System.Data.Services.Design");
+        private static byte[]? _SystemDataServicesDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.dll
+        /// </summary>
+        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net461.System.Data.Services");
+        private static byte[]? _SystemDataServices;
+
+        /// <summary>
+        /// The image bytes for System.Data.SqlXml.dll
+        /// </summary>
+        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net461.System.Data.SqlXml");
+        private static byte[]? _SystemDataSqlXml;
+
+        /// <summary>
+        /// The image bytes for System.Deployment.dll
+        /// </summary>
+        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net461.System.Deployment");
+        private static byte[]? _SystemDeployment;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net461.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.Device.dll
+        /// </summary>
+        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net461.System.Device");
+        private static byte[]? _SystemDevice;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.AccountManagement.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net461.System.DirectoryServices.AccountManagement");
+        private static byte[]? _SystemDirectoryServicesAccountManagement;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net461.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.Protocols.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net461.System.DirectoryServices.Protocols");
+        private static byte[]? _SystemDirectoryServicesProtocols;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net461.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net461.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net461.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.dll
+        /// </summary>
+        public static byte[] SystemDynamic => ResourceLoader.GetOrCreateResource(ref _SystemDynamic, "net461.System.Dynamic");
+        private static byte[]? _SystemDynamic;
+
+        /// <summary>
+        /// The image bytes for System.EnterpriseServices.dll
+        /// </summary>
+        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net461.System.EnterpriseServices");
+        private static byte[]? _SystemEnterpriseServices;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.dll
+        /// </summary>
+        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net461.System.IdentityModel");
+        private static byte[]? _SystemIdentityModel;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Selectors.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net461.System.IdentityModel.Selectors");
+        private static byte[]? _SystemIdentityModelSelectors;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Services.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelServices => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelServices, "net461.System.IdentityModel.Services");
+        private static byte[]? _SystemIdentityModelServices;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net461.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net461.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Log.dll
+        /// </summary>
+        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net461.System.IO.Log");
+        private static byte[]? _SystemIOLog;
+
+        /// <summary>
+        /// The image bytes for System.Management.dll
+        /// </summary>
+        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net461.System.Management");
+        private static byte[]? _SystemManagement;
+
+        /// <summary>
+        /// The image bytes for System.Management.Instrumentation.dll
+        /// </summary>
+        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net461.System.Management.Instrumentation");
+        private static byte[]? _SystemManagementInstrumentation;
+
+        /// <summary>
+        /// The image bytes for System.Messaging.dll
+        /// </summary>
+        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net461.System.Messaging");
+        private static byte[]? _SystemMessaging;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net461.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net461.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.WebRequest.dll
+        /// </summary>
+        public static byte[] SystemNetHttpWebRequest => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpWebRequest, "net461.System.Net.Http.WebRequest");
+        private static byte[]? _SystemNetHttpWebRequest;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net461.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net461.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.Printing.dll
+        /// </summary>
+        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net461.System.Printing");
+        private static byte[]? _SystemPrinting;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Context.dll
+        /// </summary>
+        public static byte[] SystemReflectionContext => ResourceLoader.GetOrCreateResource(ref _SystemReflectionContext, "net461.System.Reflection.Context");
+        private static byte[]? _SystemReflectionContext;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Caching.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net461.System.Runtime.Caching");
+        private static byte[]? _SystemRuntimeCaching;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net461.System.Runtime.DurableInstancing");
+        private static byte[]? _SystemRuntimeDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Remoting.dll
+        /// </summary>
+        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net461.System.Runtime.Remoting");
+        private static byte[]? _SystemRuntimeRemoting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net461.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net461.System.Runtime.Serialization.Formatters.Soap");
+        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net461.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activation.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net461.System.ServiceModel.Activation");
+        private static byte[]? _SystemServiceModelActivation;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activities.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net461.System.ServiceModel.Activities");
+        private static byte[]? _SystemServiceModelActivities;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Channels.dll
+        /// </summary>
+        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net461.System.ServiceModel.Channels");
+        private static byte[]? _SystemServiceModelChannels;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Discovery.dll
+        /// </summary>
+        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net461.System.ServiceModel.Discovery");
+        private static byte[]? _SystemServiceModelDiscovery;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.dll
+        /// </summary>
+        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net461.System.ServiceModel");
+        private static byte[]? _SystemServiceModel;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Routing.dll
+        /// </summary>
+        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net461.System.ServiceModel.Routing");
+        private static byte[]? _SystemServiceModelRouting;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net461.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net461.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Speech.dll
+        /// </summary>
+        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net461.System.Speech");
+        private static byte[]? _SystemSpeech;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net461.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Abstractions.dll
+        /// </summary>
+        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net461.System.Web.Abstractions");
+        private static byte[]? _SystemWebAbstractions;
+
+        /// <summary>
+        /// The image bytes for System.Web.ApplicationServices.dll
+        /// </summary>
+        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net461.System.Web.ApplicationServices");
+        private static byte[]? _SystemWebApplicationServices;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net461.System.Web.DataVisualization.Design");
+        private static byte[]? _SystemWebDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net461.System.Web.DataVisualization");
+        private static byte[]? _SystemWebDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net461.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net461.System.Web.DynamicData.Design");
+        private static byte[]? _SystemWebDynamicDataDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net461.System.Web.DynamicData");
+        private static byte[]? _SystemWebDynamicData;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net461.System.Web.Entity.Design");
+        private static byte[]? _SystemWebEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.dll
+        /// </summary>
+        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net461.System.Web.Entity");
+        private static byte[]? _SystemWebEntity;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.Design.dll
+        /// </summary>
+        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net461.System.Web.Extensions.Design");
+        private static byte[]? _SystemWebExtensionsDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.dll
+        /// </summary>
+        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net461.System.Web.Extensions");
+        private static byte[]? _SystemWebExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Mobile.dll
+        /// </summary>
+        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net461.System.Web.Mobile");
+        private static byte[]? _SystemWebMobile;
+
+        /// <summary>
+        /// The image bytes for System.Web.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net461.System.Web.RegularExpressions");
+        private static byte[]? _SystemWebRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Routing.dll
+        /// </summary>
+        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net461.System.Web.Routing");
+        private static byte[]? _SystemWebRouting;
+
+        /// <summary>
+        /// The image bytes for System.Web.Services.dll
+        /// </summary>
+        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net461.System.Web.Services");
+        private static byte[]? _SystemWebServices;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Controls.Ribbon.dll
+        /// </summary>
+        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net461.System.Windows.Controls.Ribbon");
+        private static byte[]? _SystemWindowsControlsRibbon;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net461.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net461.System.Windows.Forms.DataVisualization.Design");
+        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net461.System.Windows.Forms.DataVisualization");
+        private static byte[]? _SystemWindowsFormsDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net461.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Input.Manipulations.dll
+        /// </summary>
+        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net461.System.Windows.Input.Manipulations");
+        private static byte[]? _SystemWindowsInputManipulations;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Presentation.dll
+        /// </summary>
+        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net461.System.Windows.Presentation");
+        private static byte[]? _SystemWindowsPresentation;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Activities.dll
+        /// </summary>
+        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net461.System.Workflow.Activities");
+        private static byte[]? _SystemWorkflowActivities;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net461.System.Workflow.ComponentModel");
+        private static byte[]? _SystemWorkflowComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Runtime.dll
+        /// </summary>
+        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net461.System.Workflow.Runtime");
+        private static byte[]? _SystemWorkflowRuntime;
+
+        /// <summary>
+        /// The image bytes for System.WorkflowServices.dll
+        /// </summary>
+        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net461.System.WorkflowServices");
+        private static byte[]? _SystemWorkflowServices;
+
+        /// <summary>
+        /// The image bytes for System.Xaml.dll
+        /// </summary>
+        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net461.System.Xaml");
+        private static byte[]? _SystemXaml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net461.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net461.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net461.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClient.dll
+        /// </summary>
+        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net461.UIAutomationClient");
+        private static byte[]? _UIAutomationClient;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClientsideProviders.dll
+        /// </summary>
+        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net461.UIAutomationClientsideProviders");
+        private static byte[]? _UIAutomationClientsideProviders;
+
+        /// <summary>
+        /// The image bytes for UIAutomationProvider.dll
+        /// </summary>
+        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net461.UIAutomationProvider");
+        private static byte[]? _UIAutomationProvider;
+
+        /// <summary>
+        /// The image bytes for UIAutomationTypes.dll
+        /// </summary>
+        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net461.UIAutomationTypes");
+        private static byte[]? _UIAutomationTypes;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net461.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for WindowsFormsIntegration.dll
+        /// </summary>
+        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net461.WindowsFormsIntegration");
+        private static byte[]? _WindowsFormsIntegration;
+
+        /// <summary>
+        /// The image bytes for XamlBuildTask.dll
+        /// </summary>
+        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net461.XamlBuildTask");
+        private static byte[]? _XamlBuildTask;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net461.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net461.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net461.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net461.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net461.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net461.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net461.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net461.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net461.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net461.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net461.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net461.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net461.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net461.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net461.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net461.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net461.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net461.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net461.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net461.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net461.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net461.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net461.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net461.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net461.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net461.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net461.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net461.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net461.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net461.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net461.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net461.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "net461.System.Runtime.InteropServices.WindowsRuntime");
+        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net461.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net461.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net461.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net461.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net461.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Duplex.dll
+        /// </summary>
+        public static byte[] SystemServiceModelDuplex => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDuplex, "net461.System.ServiceModel.Duplex");
+        private static byte[]? _SystemServiceModelDuplex;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Http.dll
+        /// </summary>
+        public static byte[] SystemServiceModelHttp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelHttp, "net461.System.ServiceModel.Http");
+        private static byte[]? _SystemServiceModelHttp;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.NetTcp.dll
+        /// </summary>
+        public static byte[] SystemServiceModelNetTcp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelNetTcp, "net461.System.ServiceModel.NetTcp");
+        private static byte[]? _SystemServiceModelNetTcp;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemServiceModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelPrimitives, "net461.System.ServiceModel.Primitives");
+        private static byte[]? _SystemServiceModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Security.dll
+        /// </summary>
+        public static byte[] SystemServiceModelSecurity => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelSecurity, "net461.System.ServiceModel.Security");
+        private static byte[]? _SystemServiceModelSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net461.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net461.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net461.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net461.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net461.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net461.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net461.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net461.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net461.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net461.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net461.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net461/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net461/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -1118,6 +1118,7 @@ public static partial class Net461
 
     }
 }
+
 public static partial class Net461
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net461/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net461/Generated.cs
@@ -9,6 +9,74 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net461
 {
+    public static class ExtraReferenceInfos
+    {
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, Net461.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("bc890e4e-a34f-463c-8fd9-60f43c8beb88"));
+        private static ImmutableArray<ReferenceInfo> _all;
+        public static ImmutableArray<ReferenceInfo> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+
+        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
+    }
+}
+
+public static partial class Net461
+{
+    public static class ExtraReferences
+    {
+        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static PortableExecutableReference SystemThreadingTasksExtensions
+        {
+            get
+            {
+                if (_SystemThreadingTasksExtensions is null)
+                {
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net461)");
+                }
+                return _SystemThreadingTasksExtensions;
+            }
+        }
+
+        private static ImmutableArray<PortableExecutableReference> _all;
+        public static ImmutableArray<PortableExecutableReference> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+    }
+}
+
+public static partial class Net461
+{
     public static class Resources
     {
         /// <summary>
@@ -1114,6 +1182,12 @@ public static partial class Net461
         /// </summary>
         public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net461.System.Xml.XmlSerializer");
         private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net461.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
 
 
     }

--- a/Src/Basic.Reference.Assemblies.Net461/Generated.targets
+++ b/Src/Basic.Reference.Assemblies.Net461/Generated.targets
@@ -736,5 +736,9 @@
             <LogicalName>net461.System.Xml.XmlSerializer</LogicalName>
             <Link>Resources\net461\System.Xml.XmlSerializer.dll</Link>
         </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\system.threading.tasks.extensions\4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll" WithCulture="false">
+            <LogicalName>net461.System.Threading.Tasks.Extensions</LogicalName>
+            <Link>Resources\net461\System.Threading.Tasks.Extensions.dll</Link>
+        </EmbeddedResource>
     </ItemGroup>
 </Project>

--- a/Src/Basic.Reference.Assemblies.Net472/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net472/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -1424,6 +1424,7 @@ public static partial class Net472
 
     }
 }
+
 public static partial class Net472
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net472/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net472/Generated.cs
@@ -9,1424 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net472
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net472.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for CustomMarshalers.dll
-        /// </summary>
-        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net472.CustomMarshalers");
-        private static byte[]? _CustomMarshalers;
-
-        /// <summary>
-        /// The image bytes for ISymWrapper.dll
-        /// </summary>
-        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net472.ISymWrapper");
-        private static byte[]? _ISymWrapper;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Activities.Build.dll
-        /// </summary>
-        public static byte[] MicrosoftActivitiesBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftActivitiesBuild, "net472.Microsoft.Activities.Build");
-        private static byte[]? _MicrosoftActivitiesBuild;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net472.Microsoft.Build.Conversion.v4.0");
-        private static byte[]? _MicrosoftBuildConversionv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.dll
-        /// </summary>
-        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net472.Microsoft.Build");
-        private static byte[]? _MicrosoftBuild;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Engine.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net472.Microsoft.Build.Engine");
-        private static byte[]? _MicrosoftBuildEngine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Framework.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net472.Microsoft.Build.Framework");
-        private static byte[]? _MicrosoftBuildFramework;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net472.Microsoft.Build.Tasks.v4.0");
-        private static byte[]? _MicrosoftBuildTasksv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net472.Microsoft.Build.Utilities.v4.0");
-        private static byte[]? _MicrosoftBuildUtilitiesv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net472.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JScript.dll
-        /// </summary>
-        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net472.Microsoft.JScript");
-        private static byte[]? _MicrosoftJScript;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net472.Microsoft.VisualBasic.Compatibility.Data");
-        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net472.Microsoft.VisualBasic.Compatibility");
-        private static byte[]? _MicrosoftVisualBasicCompatibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net472.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net472.Microsoft.VisualC");
-        private static byte[]? _MicrosoftVisualC;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.STLCLR.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net472.Microsoft.VisualC.STLCLR");
-        private static byte[]? _MicrosoftVisualCSTLCLR;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net472.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for PresentationBuildTasks.dll
-        /// </summary>
-        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net472.PresentationBuildTasks");
-        private static byte[]? _PresentationBuildTasks;
-
-        /// <summary>
-        /// The image bytes for PresentationCore.dll
-        /// </summary>
-        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net472.PresentationCore");
-        private static byte[]? _PresentationCore;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net472.PresentationFramework.Aero");
-        private static byte[]? _PresentationFrameworkAero;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero2.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net472.PresentationFramework.Aero2");
-        private static byte[]? _PresentationFrameworkAero2;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.AeroLite.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net472.PresentationFramework.AeroLite");
-        private static byte[]? _PresentationFrameworkAeroLite;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Classic.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net472.PresentationFramework.Classic");
-        private static byte[]? _PresentationFrameworkClassic;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.dll
-        /// </summary>
-        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net472.PresentationFramework");
-        private static byte[]? _PresentationFramework;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Luna.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net472.PresentationFramework.Luna");
-        private static byte[]? _PresentationFrameworkLuna;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Royale.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net472.PresentationFramework.Royale");
-        private static byte[]? _PresentationFrameworkRoyale;
-
-        /// <summary>
-        /// The image bytes for ReachFramework.dll
-        /// </summary>
-        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net472.ReachFramework");
-        private static byte[]? _ReachFramework;
-
-        /// <summary>
-        /// The image bytes for sysglobl.dll
-        /// </summary>
-        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net472.sysglobl");
-        private static byte[]? _sysglobl;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Core.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net472.System.Activities.Core.Presentation");
-        private static byte[]? _SystemActivitiesCorePresentation;
-
-        /// <summary>
-        /// The image bytes for System.Activities.dll
-        /// </summary>
-        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net472.System.Activities");
-        private static byte[]? _SystemActivities;
-
-        /// <summary>
-        /// The image bytes for System.Activities.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net472.System.Activities.DurableInstancing");
-        private static byte[]? _SystemActivitiesDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net472.System.Activities.Presentation");
-        private static byte[]? _SystemActivitiesPresentation;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.Contract.dll
-        /// </summary>
-        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net472.System.AddIn.Contract");
-        private static byte[]? _SystemAddInContract;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.dll
-        /// </summary>
-        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net472.System.AddIn");
-        private static byte[]? _SystemAddIn;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.dll
-        /// </summary>
-        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net472.System.ComponentModel.Composition");
-        private static byte[]? _SystemComponentModelComposition;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.Registration.dll
-        /// </summary>
-        public static byte[] SystemComponentModelCompositionRegistration => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelCompositionRegistration, "net472.System.ComponentModel.Composition.Registration");
-        private static byte[]? _SystemComponentModelCompositionRegistration;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net472.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net472.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.Install.dll
-        /// </summary>
-        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net472.System.Configuration.Install");
-        private static byte[]? _SystemConfigurationInstall;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net472.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net472.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net472.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net472.System.Data.Entity.Design");
-        private static byte[]? _SystemDataEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.dll
-        /// </summary>
-        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net472.System.Data.Entity");
-        private static byte[]? _SystemDataEntity;
-
-        /// <summary>
-        /// The image bytes for System.Data.Linq.dll
-        /// </summary>
-        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net472.System.Data.Linq");
-        private static byte[]? _SystemDataLinq;
-
-        /// <summary>
-        /// The image bytes for System.Data.OracleClient.dll
-        /// </summary>
-        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net472.System.Data.OracleClient");
-        private static byte[]? _SystemDataOracleClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Client.dll
-        /// </summary>
-        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net472.System.Data.Services.Client");
-        private static byte[]? _SystemDataServicesClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Design.dll
-        /// </summary>
-        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net472.System.Data.Services.Design");
-        private static byte[]? _SystemDataServicesDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.dll
-        /// </summary>
-        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net472.System.Data.Services");
-        private static byte[]? _SystemDataServices;
-
-        /// <summary>
-        /// The image bytes for System.Data.SqlXml.dll
-        /// </summary>
-        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net472.System.Data.SqlXml");
-        private static byte[]? _SystemDataSqlXml;
-
-        /// <summary>
-        /// The image bytes for System.Deployment.dll
-        /// </summary>
-        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net472.System.Deployment");
-        private static byte[]? _SystemDeployment;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net472.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.Device.dll
-        /// </summary>
-        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net472.System.Device");
-        private static byte[]? _SystemDevice;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net472.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.AccountManagement.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net472.System.DirectoryServices.AccountManagement");
-        private static byte[]? _SystemDirectoryServicesAccountManagement;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net472.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.Protocols.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net472.System.DirectoryServices.Protocols");
-        private static byte[]? _SystemDirectoryServicesProtocols;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net472.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net472.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net472.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.dll
-        /// </summary>
-        public static byte[] SystemDynamic => ResourceLoader.GetOrCreateResource(ref _SystemDynamic, "net472.System.Dynamic");
-        private static byte[]? _SystemDynamic;
-
-        /// <summary>
-        /// The image bytes for System.EnterpriseServices.dll
-        /// </summary>
-        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net472.System.EnterpriseServices");
-        private static byte[]? _SystemEnterpriseServices;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.dll
-        /// </summary>
-        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net472.System.IdentityModel");
-        private static byte[]? _SystemIdentityModel;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Selectors.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net472.System.IdentityModel.Selectors");
-        private static byte[]? _SystemIdentityModelSelectors;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Services.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelServices => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelServices, "net472.System.IdentityModel.Services");
-        private static byte[]? _SystemIdentityModelServices;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net472.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net472.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Log.dll
-        /// </summary>
-        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net472.System.IO.Log");
-        private static byte[]? _SystemIOLog;
-
-        /// <summary>
-        /// The image bytes for System.Management.dll
-        /// </summary>
-        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net472.System.Management");
-        private static byte[]? _SystemManagement;
-
-        /// <summary>
-        /// The image bytes for System.Management.Instrumentation.dll
-        /// </summary>
-        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net472.System.Management.Instrumentation");
-        private static byte[]? _SystemManagementInstrumentation;
-
-        /// <summary>
-        /// The image bytes for System.Messaging.dll
-        /// </summary>
-        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net472.System.Messaging");
-        private static byte[]? _SystemMessaging;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net472.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net472.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.WebRequest.dll
-        /// </summary>
-        public static byte[] SystemNetHttpWebRequest => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpWebRequest, "net472.System.Net.Http.WebRequest");
-        private static byte[]? _SystemNetHttpWebRequest;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net472.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Printing.dll
-        /// </summary>
-        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net472.System.Printing");
-        private static byte[]? _SystemPrinting;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Context.dll
-        /// </summary>
-        public static byte[] SystemReflectionContext => ResourceLoader.GetOrCreateResource(ref _SystemReflectionContext, "net472.System.Reflection.Context");
-        private static byte[]? _SystemReflectionContext;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Caching.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net472.System.Runtime.Caching");
-        private static byte[]? _SystemRuntimeCaching;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net472.System.Runtime.DurableInstancing");
-        private static byte[]? _SystemRuntimeDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Remoting.dll
-        /// </summary>
-        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net472.System.Runtime.Remoting");
-        private static byte[]? _SystemRuntimeRemoting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net472.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net472.System.Runtime.Serialization.Formatters.Soap");
-        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net472.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activation.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net472.System.ServiceModel.Activation");
-        private static byte[]? _SystemServiceModelActivation;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activities.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net472.System.ServiceModel.Activities");
-        private static byte[]? _SystemServiceModelActivities;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Channels.dll
-        /// </summary>
-        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net472.System.ServiceModel.Channels");
-        private static byte[]? _SystemServiceModelChannels;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Discovery.dll
-        /// </summary>
-        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net472.System.ServiceModel.Discovery");
-        private static byte[]? _SystemServiceModelDiscovery;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.dll
-        /// </summary>
-        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net472.System.ServiceModel");
-        private static byte[]? _SystemServiceModel;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Routing.dll
-        /// </summary>
-        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net472.System.ServiceModel.Routing");
-        private static byte[]? _SystemServiceModelRouting;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net472.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net472.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Speech.dll
-        /// </summary>
-        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net472.System.Speech");
-        private static byte[]? _SystemSpeech;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net472.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Abstractions.dll
-        /// </summary>
-        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net472.System.Web.Abstractions");
-        private static byte[]? _SystemWebAbstractions;
-
-        /// <summary>
-        /// The image bytes for System.Web.ApplicationServices.dll
-        /// </summary>
-        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net472.System.Web.ApplicationServices");
-        private static byte[]? _SystemWebApplicationServices;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net472.System.Web.DataVisualization.Design");
-        private static byte[]? _SystemWebDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net472.System.Web.DataVisualization");
-        private static byte[]? _SystemWebDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net472.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net472.System.Web.DynamicData.Design");
-        private static byte[]? _SystemWebDynamicDataDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net472.System.Web.DynamicData");
-        private static byte[]? _SystemWebDynamicData;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net472.System.Web.Entity.Design");
-        private static byte[]? _SystemWebEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.dll
-        /// </summary>
-        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net472.System.Web.Entity");
-        private static byte[]? _SystemWebEntity;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.Design.dll
-        /// </summary>
-        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net472.System.Web.Extensions.Design");
-        private static byte[]? _SystemWebExtensionsDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.dll
-        /// </summary>
-        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net472.System.Web.Extensions");
-        private static byte[]? _SystemWebExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Mobile.dll
-        /// </summary>
-        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net472.System.Web.Mobile");
-        private static byte[]? _SystemWebMobile;
-
-        /// <summary>
-        /// The image bytes for System.Web.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net472.System.Web.RegularExpressions");
-        private static byte[]? _SystemWebRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Routing.dll
-        /// </summary>
-        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net472.System.Web.Routing");
-        private static byte[]? _SystemWebRouting;
-
-        /// <summary>
-        /// The image bytes for System.Web.Services.dll
-        /// </summary>
-        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net472.System.Web.Services");
-        private static byte[]? _SystemWebServices;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Controls.Ribbon.dll
-        /// </summary>
-        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net472.System.Windows.Controls.Ribbon");
-        private static byte[]? _SystemWindowsControlsRibbon;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net472.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net472.System.Windows.Forms.DataVisualization.Design");
-        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net472.System.Windows.Forms.DataVisualization");
-        private static byte[]? _SystemWindowsFormsDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net472.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Input.Manipulations.dll
-        /// </summary>
-        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net472.System.Windows.Input.Manipulations");
-        private static byte[]? _SystemWindowsInputManipulations;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Presentation.dll
-        /// </summary>
-        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net472.System.Windows.Presentation");
-        private static byte[]? _SystemWindowsPresentation;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Activities.dll
-        /// </summary>
-        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net472.System.Workflow.Activities");
-        private static byte[]? _SystemWorkflowActivities;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net472.System.Workflow.ComponentModel");
-        private static byte[]? _SystemWorkflowComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Runtime.dll
-        /// </summary>
-        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net472.System.Workflow.Runtime");
-        private static byte[]? _SystemWorkflowRuntime;
-
-        /// <summary>
-        /// The image bytes for System.WorkflowServices.dll
-        /// </summary>
-        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net472.System.WorkflowServices");
-        private static byte[]? _SystemWorkflowServices;
-
-        /// <summary>
-        /// The image bytes for System.Xaml.dll
-        /// </summary>
-        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net472.System.Xaml");
-        private static byte[]? _SystemXaml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net472.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net472.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net472.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClient.dll
-        /// </summary>
-        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net472.UIAutomationClient");
-        private static byte[]? _UIAutomationClient;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClientsideProviders.dll
-        /// </summary>
-        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net472.UIAutomationClientsideProviders");
-        private static byte[]? _UIAutomationClientsideProviders;
-
-        /// <summary>
-        /// The image bytes for UIAutomationProvider.dll
-        /// </summary>
-        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net472.UIAutomationProvider");
-        private static byte[]? _UIAutomationProvider;
-
-        /// <summary>
-        /// The image bytes for UIAutomationTypes.dll
-        /// </summary>
-        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net472.UIAutomationTypes");
-        private static byte[]? _UIAutomationTypes;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net472.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for WindowsFormsIntegration.dll
-        /// </summary>
-        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net472.WindowsFormsIntegration");
-        private static byte[]? _WindowsFormsIntegration;
-
-        /// <summary>
-        /// The image bytes for XamlBuildTask.dll
-        /// </summary>
-        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net472.XamlBuildTask");
-        private static byte[]? _XamlBuildTask;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net472.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net472.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net472.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net472.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net472.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net472.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net472.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net472.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net472.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net472.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net472.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net472.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net472.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net472.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net472.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net472.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net472.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net472.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net472.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net472.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net472.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net472.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net472.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net472.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net472.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net472.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net472.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net472.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net472.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net472.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net472.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net472.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net472.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net472.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net472.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net472.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net472.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net472.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net472.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net472.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net472.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Rtc.dll
-        /// </summary>
-        public static byte[] SystemNetHttpRtc => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpRtc, "net472.System.Net.Http.Rtc");
-        private static byte[]? _SystemNetHttpRtc;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net472.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net472.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net472.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net472.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net472.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net472.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net472.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net472.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net472.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net472.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net472.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net472.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net472.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net472.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net472.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net472.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net472.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net472.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net472.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net472.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net472.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net472.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net472.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net472.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net472.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net472.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "net472.System.Runtime.InteropServices.WindowsRuntime");
-        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net472.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net472.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net472.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net472.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net472.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net472.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net472.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net472.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net472.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net472.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net472.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net472.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net472.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Duplex.dll
-        /// </summary>
-        public static byte[] SystemServiceModelDuplex => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDuplex, "net472.System.ServiceModel.Duplex");
-        private static byte[]? _SystemServiceModelDuplex;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Http.dll
-        /// </summary>
-        public static byte[] SystemServiceModelHttp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelHttp, "net472.System.ServiceModel.Http");
-        private static byte[]? _SystemServiceModelHttp;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.NetTcp.dll
-        /// </summary>
-        public static byte[] SystemServiceModelNetTcp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelNetTcp, "net472.System.ServiceModel.NetTcp");
-        private static byte[]? _SystemServiceModelNetTcp;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemServiceModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelPrimitives, "net472.System.ServiceModel.Primitives");
-        private static byte[]? _SystemServiceModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Security.dll
-        /// </summary>
-        public static byte[] SystemServiceModelSecurity => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelSecurity, "net472.System.ServiceModel.Security");
-        private static byte[]? _SystemServiceModelSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net472.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net472.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net472.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net472.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net472.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net472.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net472.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net472.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net472.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net472.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net472.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net472.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net472.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net472.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net472.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net472.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net472.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-
-    }
-}
-
-public static partial class Net472
-{
     public static class ReferenceInfos
     {
 
@@ -7106,6 +5688,1424 @@ public static partial class Net472
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net472
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net472.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for CustomMarshalers.dll
+        /// </summary>
+        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net472.CustomMarshalers");
+        private static byte[]? _CustomMarshalers;
+
+        /// <summary>
+        /// The image bytes for ISymWrapper.dll
+        /// </summary>
+        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net472.ISymWrapper");
+        private static byte[]? _ISymWrapper;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Activities.Build.dll
+        /// </summary>
+        public static byte[] MicrosoftActivitiesBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftActivitiesBuild, "net472.Microsoft.Activities.Build");
+        private static byte[]? _MicrosoftActivitiesBuild;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net472.Microsoft.Build.Conversion.v4.0");
+        private static byte[]? _MicrosoftBuildConversionv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.dll
+        /// </summary>
+        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net472.Microsoft.Build");
+        private static byte[]? _MicrosoftBuild;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Engine.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net472.Microsoft.Build.Engine");
+        private static byte[]? _MicrosoftBuildEngine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Framework.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net472.Microsoft.Build.Framework");
+        private static byte[]? _MicrosoftBuildFramework;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net472.Microsoft.Build.Tasks.v4.0");
+        private static byte[]? _MicrosoftBuildTasksv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net472.Microsoft.Build.Utilities.v4.0");
+        private static byte[]? _MicrosoftBuildUtilitiesv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net472.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JScript.dll
+        /// </summary>
+        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net472.Microsoft.JScript");
+        private static byte[]? _MicrosoftJScript;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net472.Microsoft.VisualBasic.Compatibility.Data");
+        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net472.Microsoft.VisualBasic.Compatibility");
+        private static byte[]? _MicrosoftVisualBasicCompatibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net472.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net472.Microsoft.VisualC");
+        private static byte[]? _MicrosoftVisualC;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.STLCLR.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net472.Microsoft.VisualC.STLCLR");
+        private static byte[]? _MicrosoftVisualCSTLCLR;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net472.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for PresentationBuildTasks.dll
+        /// </summary>
+        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net472.PresentationBuildTasks");
+        private static byte[]? _PresentationBuildTasks;
+
+        /// <summary>
+        /// The image bytes for PresentationCore.dll
+        /// </summary>
+        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net472.PresentationCore");
+        private static byte[]? _PresentationCore;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net472.PresentationFramework.Aero");
+        private static byte[]? _PresentationFrameworkAero;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero2.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net472.PresentationFramework.Aero2");
+        private static byte[]? _PresentationFrameworkAero2;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.AeroLite.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net472.PresentationFramework.AeroLite");
+        private static byte[]? _PresentationFrameworkAeroLite;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Classic.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net472.PresentationFramework.Classic");
+        private static byte[]? _PresentationFrameworkClassic;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.dll
+        /// </summary>
+        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net472.PresentationFramework");
+        private static byte[]? _PresentationFramework;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Luna.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net472.PresentationFramework.Luna");
+        private static byte[]? _PresentationFrameworkLuna;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Royale.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net472.PresentationFramework.Royale");
+        private static byte[]? _PresentationFrameworkRoyale;
+
+        /// <summary>
+        /// The image bytes for ReachFramework.dll
+        /// </summary>
+        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net472.ReachFramework");
+        private static byte[]? _ReachFramework;
+
+        /// <summary>
+        /// The image bytes for sysglobl.dll
+        /// </summary>
+        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net472.sysglobl");
+        private static byte[]? _sysglobl;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Core.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net472.System.Activities.Core.Presentation");
+        private static byte[]? _SystemActivitiesCorePresentation;
+
+        /// <summary>
+        /// The image bytes for System.Activities.dll
+        /// </summary>
+        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net472.System.Activities");
+        private static byte[]? _SystemActivities;
+
+        /// <summary>
+        /// The image bytes for System.Activities.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net472.System.Activities.DurableInstancing");
+        private static byte[]? _SystemActivitiesDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net472.System.Activities.Presentation");
+        private static byte[]? _SystemActivitiesPresentation;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.Contract.dll
+        /// </summary>
+        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net472.System.AddIn.Contract");
+        private static byte[]? _SystemAddInContract;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.dll
+        /// </summary>
+        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net472.System.AddIn");
+        private static byte[]? _SystemAddIn;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.dll
+        /// </summary>
+        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net472.System.ComponentModel.Composition");
+        private static byte[]? _SystemComponentModelComposition;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.Registration.dll
+        /// </summary>
+        public static byte[] SystemComponentModelCompositionRegistration => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelCompositionRegistration, "net472.System.ComponentModel.Composition.Registration");
+        private static byte[]? _SystemComponentModelCompositionRegistration;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net472.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net472.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.Install.dll
+        /// </summary>
+        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net472.System.Configuration.Install");
+        private static byte[]? _SystemConfigurationInstall;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net472.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net472.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net472.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net472.System.Data.Entity.Design");
+        private static byte[]? _SystemDataEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.dll
+        /// </summary>
+        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net472.System.Data.Entity");
+        private static byte[]? _SystemDataEntity;
+
+        /// <summary>
+        /// The image bytes for System.Data.Linq.dll
+        /// </summary>
+        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net472.System.Data.Linq");
+        private static byte[]? _SystemDataLinq;
+
+        /// <summary>
+        /// The image bytes for System.Data.OracleClient.dll
+        /// </summary>
+        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net472.System.Data.OracleClient");
+        private static byte[]? _SystemDataOracleClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Client.dll
+        /// </summary>
+        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net472.System.Data.Services.Client");
+        private static byte[]? _SystemDataServicesClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Design.dll
+        /// </summary>
+        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net472.System.Data.Services.Design");
+        private static byte[]? _SystemDataServicesDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.dll
+        /// </summary>
+        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net472.System.Data.Services");
+        private static byte[]? _SystemDataServices;
+
+        /// <summary>
+        /// The image bytes for System.Data.SqlXml.dll
+        /// </summary>
+        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net472.System.Data.SqlXml");
+        private static byte[]? _SystemDataSqlXml;
+
+        /// <summary>
+        /// The image bytes for System.Deployment.dll
+        /// </summary>
+        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net472.System.Deployment");
+        private static byte[]? _SystemDeployment;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net472.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.Device.dll
+        /// </summary>
+        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net472.System.Device");
+        private static byte[]? _SystemDevice;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net472.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.AccountManagement.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net472.System.DirectoryServices.AccountManagement");
+        private static byte[]? _SystemDirectoryServicesAccountManagement;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net472.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.Protocols.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net472.System.DirectoryServices.Protocols");
+        private static byte[]? _SystemDirectoryServicesProtocols;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net472.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net472.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net472.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.dll
+        /// </summary>
+        public static byte[] SystemDynamic => ResourceLoader.GetOrCreateResource(ref _SystemDynamic, "net472.System.Dynamic");
+        private static byte[]? _SystemDynamic;
+
+        /// <summary>
+        /// The image bytes for System.EnterpriseServices.dll
+        /// </summary>
+        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net472.System.EnterpriseServices");
+        private static byte[]? _SystemEnterpriseServices;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.dll
+        /// </summary>
+        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net472.System.IdentityModel");
+        private static byte[]? _SystemIdentityModel;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Selectors.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net472.System.IdentityModel.Selectors");
+        private static byte[]? _SystemIdentityModelSelectors;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Services.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelServices => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelServices, "net472.System.IdentityModel.Services");
+        private static byte[]? _SystemIdentityModelServices;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net472.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net472.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Log.dll
+        /// </summary>
+        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net472.System.IO.Log");
+        private static byte[]? _SystemIOLog;
+
+        /// <summary>
+        /// The image bytes for System.Management.dll
+        /// </summary>
+        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net472.System.Management");
+        private static byte[]? _SystemManagement;
+
+        /// <summary>
+        /// The image bytes for System.Management.Instrumentation.dll
+        /// </summary>
+        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net472.System.Management.Instrumentation");
+        private static byte[]? _SystemManagementInstrumentation;
+
+        /// <summary>
+        /// The image bytes for System.Messaging.dll
+        /// </summary>
+        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net472.System.Messaging");
+        private static byte[]? _SystemMessaging;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net472.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net472.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.WebRequest.dll
+        /// </summary>
+        public static byte[] SystemNetHttpWebRequest => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpWebRequest, "net472.System.Net.Http.WebRequest");
+        private static byte[]? _SystemNetHttpWebRequest;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net472.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Printing.dll
+        /// </summary>
+        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net472.System.Printing");
+        private static byte[]? _SystemPrinting;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Context.dll
+        /// </summary>
+        public static byte[] SystemReflectionContext => ResourceLoader.GetOrCreateResource(ref _SystemReflectionContext, "net472.System.Reflection.Context");
+        private static byte[]? _SystemReflectionContext;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Caching.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net472.System.Runtime.Caching");
+        private static byte[]? _SystemRuntimeCaching;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net472.System.Runtime.DurableInstancing");
+        private static byte[]? _SystemRuntimeDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Remoting.dll
+        /// </summary>
+        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net472.System.Runtime.Remoting");
+        private static byte[]? _SystemRuntimeRemoting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net472.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net472.System.Runtime.Serialization.Formatters.Soap");
+        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net472.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activation.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net472.System.ServiceModel.Activation");
+        private static byte[]? _SystemServiceModelActivation;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activities.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net472.System.ServiceModel.Activities");
+        private static byte[]? _SystemServiceModelActivities;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Channels.dll
+        /// </summary>
+        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net472.System.ServiceModel.Channels");
+        private static byte[]? _SystemServiceModelChannels;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Discovery.dll
+        /// </summary>
+        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net472.System.ServiceModel.Discovery");
+        private static byte[]? _SystemServiceModelDiscovery;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.dll
+        /// </summary>
+        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net472.System.ServiceModel");
+        private static byte[]? _SystemServiceModel;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Routing.dll
+        /// </summary>
+        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net472.System.ServiceModel.Routing");
+        private static byte[]? _SystemServiceModelRouting;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net472.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net472.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Speech.dll
+        /// </summary>
+        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net472.System.Speech");
+        private static byte[]? _SystemSpeech;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net472.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Abstractions.dll
+        /// </summary>
+        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net472.System.Web.Abstractions");
+        private static byte[]? _SystemWebAbstractions;
+
+        /// <summary>
+        /// The image bytes for System.Web.ApplicationServices.dll
+        /// </summary>
+        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net472.System.Web.ApplicationServices");
+        private static byte[]? _SystemWebApplicationServices;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net472.System.Web.DataVisualization.Design");
+        private static byte[]? _SystemWebDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net472.System.Web.DataVisualization");
+        private static byte[]? _SystemWebDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net472.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net472.System.Web.DynamicData.Design");
+        private static byte[]? _SystemWebDynamicDataDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net472.System.Web.DynamicData");
+        private static byte[]? _SystemWebDynamicData;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net472.System.Web.Entity.Design");
+        private static byte[]? _SystemWebEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.dll
+        /// </summary>
+        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net472.System.Web.Entity");
+        private static byte[]? _SystemWebEntity;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.Design.dll
+        /// </summary>
+        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net472.System.Web.Extensions.Design");
+        private static byte[]? _SystemWebExtensionsDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.dll
+        /// </summary>
+        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net472.System.Web.Extensions");
+        private static byte[]? _SystemWebExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Mobile.dll
+        /// </summary>
+        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net472.System.Web.Mobile");
+        private static byte[]? _SystemWebMobile;
+
+        /// <summary>
+        /// The image bytes for System.Web.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net472.System.Web.RegularExpressions");
+        private static byte[]? _SystemWebRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Routing.dll
+        /// </summary>
+        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net472.System.Web.Routing");
+        private static byte[]? _SystemWebRouting;
+
+        /// <summary>
+        /// The image bytes for System.Web.Services.dll
+        /// </summary>
+        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net472.System.Web.Services");
+        private static byte[]? _SystemWebServices;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Controls.Ribbon.dll
+        /// </summary>
+        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net472.System.Windows.Controls.Ribbon");
+        private static byte[]? _SystemWindowsControlsRibbon;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net472.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net472.System.Windows.Forms.DataVisualization.Design");
+        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net472.System.Windows.Forms.DataVisualization");
+        private static byte[]? _SystemWindowsFormsDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net472.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Input.Manipulations.dll
+        /// </summary>
+        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net472.System.Windows.Input.Manipulations");
+        private static byte[]? _SystemWindowsInputManipulations;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Presentation.dll
+        /// </summary>
+        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net472.System.Windows.Presentation");
+        private static byte[]? _SystemWindowsPresentation;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Activities.dll
+        /// </summary>
+        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net472.System.Workflow.Activities");
+        private static byte[]? _SystemWorkflowActivities;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net472.System.Workflow.ComponentModel");
+        private static byte[]? _SystemWorkflowComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Runtime.dll
+        /// </summary>
+        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net472.System.Workflow.Runtime");
+        private static byte[]? _SystemWorkflowRuntime;
+
+        /// <summary>
+        /// The image bytes for System.WorkflowServices.dll
+        /// </summary>
+        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net472.System.WorkflowServices");
+        private static byte[]? _SystemWorkflowServices;
+
+        /// <summary>
+        /// The image bytes for System.Xaml.dll
+        /// </summary>
+        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net472.System.Xaml");
+        private static byte[]? _SystemXaml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net472.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net472.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net472.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClient.dll
+        /// </summary>
+        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net472.UIAutomationClient");
+        private static byte[]? _UIAutomationClient;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClientsideProviders.dll
+        /// </summary>
+        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net472.UIAutomationClientsideProviders");
+        private static byte[]? _UIAutomationClientsideProviders;
+
+        /// <summary>
+        /// The image bytes for UIAutomationProvider.dll
+        /// </summary>
+        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net472.UIAutomationProvider");
+        private static byte[]? _UIAutomationProvider;
+
+        /// <summary>
+        /// The image bytes for UIAutomationTypes.dll
+        /// </summary>
+        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net472.UIAutomationTypes");
+        private static byte[]? _UIAutomationTypes;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net472.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for WindowsFormsIntegration.dll
+        /// </summary>
+        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net472.WindowsFormsIntegration");
+        private static byte[]? _WindowsFormsIntegration;
+
+        /// <summary>
+        /// The image bytes for XamlBuildTask.dll
+        /// </summary>
+        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net472.XamlBuildTask");
+        private static byte[]? _XamlBuildTask;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net472.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net472.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net472.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net472.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net472.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net472.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net472.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net472.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net472.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net472.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net472.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net472.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net472.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net472.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net472.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net472.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net472.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net472.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net472.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net472.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net472.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net472.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net472.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net472.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net472.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net472.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net472.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net472.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net472.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net472.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net472.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net472.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net472.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net472.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net472.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net472.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net472.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net472.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net472.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net472.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net472.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Rtc.dll
+        /// </summary>
+        public static byte[] SystemNetHttpRtc => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpRtc, "net472.System.Net.Http.Rtc");
+        private static byte[]? _SystemNetHttpRtc;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net472.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net472.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net472.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net472.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net472.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net472.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net472.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net472.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net472.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net472.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net472.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net472.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net472.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net472.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net472.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net472.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net472.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net472.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net472.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net472.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net472.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net472.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net472.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net472.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net472.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net472.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "net472.System.Runtime.InteropServices.WindowsRuntime");
+        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net472.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net472.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net472.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net472.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net472.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net472.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net472.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net472.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net472.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net472.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net472.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net472.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net472.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Duplex.dll
+        /// </summary>
+        public static byte[] SystemServiceModelDuplex => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDuplex, "net472.System.ServiceModel.Duplex");
+        private static byte[]? _SystemServiceModelDuplex;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Http.dll
+        /// </summary>
+        public static byte[] SystemServiceModelHttp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelHttp, "net472.System.ServiceModel.Http");
+        private static byte[]? _SystemServiceModelHttp;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.NetTcp.dll
+        /// </summary>
+        public static byte[] SystemServiceModelNetTcp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelNetTcp, "net472.System.ServiceModel.NetTcp");
+        private static byte[]? _SystemServiceModelNetTcp;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemServiceModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelPrimitives, "net472.System.ServiceModel.Primitives");
+        private static byte[]? _SystemServiceModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Security.dll
+        /// </summary>
+        public static byte[] SystemServiceModelSecurity => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelSecurity, "net472.System.ServiceModel.Security");
+        private static byte[]? _SystemServiceModelSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net472.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net472.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net472.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net472.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net472.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net472.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net472.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net472.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net472.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net472.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net472.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net472.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net472.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net472.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net472.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net472.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net472.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net50/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net50/Generated.cs
@@ -9,926 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net50
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net50.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net50.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net50.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net50.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net50.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net50.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net50.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net50.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net50.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net50.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net50.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net50.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net50.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net50.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net50.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net50.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net50.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net50.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net50.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net50.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net50.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net50.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net50.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net50.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net50.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net50.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net50.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net50.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net50.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net50.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net50.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net50.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net50.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net50.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net50.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net50.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net50.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net50.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net50.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net50.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net50.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net50.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net50.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net50.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net50.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net50.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net50.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net50.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net50.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net50.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net50.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net50.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net50.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net50.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net50.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net50.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net50.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net50.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net50.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net50.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net50.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net50.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net50.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net50.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net50.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net50.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net50.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net50.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net50.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net50.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net50.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net50.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net50.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net50.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net50.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net50.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net50.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net50.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net50.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net50.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net50.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net50.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net50.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net50.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net50.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net50.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net50.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net50.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net50.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net50.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net50.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net50.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net50.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net50.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net50.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net50.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net50.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net50.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net50.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net50.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net50.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net50.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net50.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net50.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net50.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net50.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net50.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net50.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net50.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net50.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net50.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net50.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net50.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net50.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net50.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net50.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net50.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net50.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net50.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net50.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net50.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net50.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net50.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net50.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net50.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net50.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net50.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net50.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net50.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net50.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net50.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net50.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net50.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net50.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net50.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net50.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net50.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net50.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net50.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net50.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net50.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net50.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net50.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net50.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net50.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net50.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net50.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net50.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net50.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net50.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net50.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net50.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-
-    }
-}
-
-public static partial class Net50
-{
     public static class ReferenceInfos
     {
 
@@ -4616,6 +3696,926 @@ public static partial class Net50
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net50
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net50.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net50.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net50.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net50.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net50.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net50.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net50.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net50.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net50.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net50.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net50.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net50.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net50.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net50.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net50.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net50.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net50.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net50.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net50.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net50.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net50.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net50.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net50.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net50.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net50.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net50.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net50.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net50.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net50.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net50.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net50.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net50.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net50.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net50.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net50.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net50.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net50.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net50.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net50.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net50.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net50.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net50.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net50.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net50.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net50.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net50.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net50.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net50.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net50.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net50.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net50.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net50.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net50.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net50.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net50.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net50.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net50.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net50.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net50.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net50.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net50.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net50.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net50.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net50.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net50.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net50.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net50.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net50.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net50.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net50.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net50.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net50.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net50.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net50.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net50.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net50.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net50.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net50.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net50.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net50.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net50.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net50.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net50.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net50.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net50.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net50.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net50.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net50.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net50.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net50.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net50.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net50.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net50.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net50.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net50.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net50.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net50.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net50.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net50.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net50.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net50.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net50.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net50.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net50.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net50.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net50.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net50.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net50.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net50.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net50.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net50.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net50.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net50.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net50.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net50.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net50.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net50.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net50.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net50.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net50.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net50.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net50.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net50.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net50.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net50.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net50.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net50.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net50.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net50.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net50.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net50.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net50.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net50.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net50.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net50.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net50.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net50.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net50.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net50.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net50.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net50.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net50.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net50.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net50.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net50.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net50.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net50.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net50.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net50.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net50.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net50.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net50.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net50/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net50/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -926,6 +926,7 @@ public static partial class Net50
 
     }
 }
+
 public static partial class Net50
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net60/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net60/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -968,6 +968,7 @@ public static partial class Net60
 
     }
 }
+
 public static partial class Net60
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net60/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net60/Generated.cs
@@ -9,968 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net60
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net60.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net60.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net60.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net60.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net60.Microsoft.Win32.Registry");
-        private static byte[]? _MicrosoftWin32Registry;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net60.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net60.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net60.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net60.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net60.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net60.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net60.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net60.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net60.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net60.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net60.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net60.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net60.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net60.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net60.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net60.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net60.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net60.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net60.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net60.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net60.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net60.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net60.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net60.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net60.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net60.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net60.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net60.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net60.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net60.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net60.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net60.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net60.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net60.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net60.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net60.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net60.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net60.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net60.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net60.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net60.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net60.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net60.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net60.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net60.System.IO.FileSystem.AccessControl");
-        private static byte[]? _SystemIOFileSystemAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net60.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net60.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net60.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net60.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net60.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net60.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net60.System.IO.Pipes.AccessControl");
-        private static byte[]? _SystemIOPipesAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net60.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net60.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net60.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net60.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net60.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net60.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net60.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net60.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net60.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net60.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net60.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net60.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net60.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net60.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net60.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net60.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net60.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net60.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net60.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net60.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net60.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net60.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net60.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net60.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net60.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net60.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net60.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net60.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net60.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net60.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net60.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net60.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net60.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net60.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net60.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net60.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net60.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net60.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net60.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net60.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net60.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net60.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net60.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net60.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net60.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net60.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net60.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net60.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net60.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net60.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net60.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net60.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net60.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net60.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net60.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net60.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net60.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net60.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Cng.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net60.System.Security.Cryptography.Cng");
-        private static byte[]? _SystemSecurityCryptographyCng;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net60.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net60.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net60.System.Security.Cryptography.OpenSsl");
-        private static byte[]? _SystemSecurityCryptographyOpenSsl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net60.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net60.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net60.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net60.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net60.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net60.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net60.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net60.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net60.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net60.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net60.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net60.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net60.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net60.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net60.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net60.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net60.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net60.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net60.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net60.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net60.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net60.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net60.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net60.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net60.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net60.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net60.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net60.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net60.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net60.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net60.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net60.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net60.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net60.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net60.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net60.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net60.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net60.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net60.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net60.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-
-    }
-}
-
-public static partial class Net60
-{
     public static class ReferenceInfos
     {
 
@@ -4826,6 +3864,968 @@ public static partial class Net60
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net60
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net60.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net60.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net60.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net60.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net60.Microsoft.Win32.Registry");
+        private static byte[]? _MicrosoftWin32Registry;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net60.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net60.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net60.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net60.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net60.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net60.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net60.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net60.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net60.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net60.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net60.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net60.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net60.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net60.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net60.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net60.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net60.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net60.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net60.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net60.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net60.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net60.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net60.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net60.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net60.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net60.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net60.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net60.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net60.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net60.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net60.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net60.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net60.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net60.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net60.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net60.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net60.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net60.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net60.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net60.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net60.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net60.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net60.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net60.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net60.System.IO.FileSystem.AccessControl");
+        private static byte[]? _SystemIOFileSystemAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net60.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net60.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net60.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net60.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net60.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net60.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net60.System.IO.Pipes.AccessControl");
+        private static byte[]? _SystemIOPipesAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net60.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net60.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net60.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net60.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net60.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net60.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net60.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net60.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net60.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net60.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net60.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net60.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net60.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net60.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net60.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net60.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net60.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net60.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net60.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net60.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net60.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net60.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net60.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net60.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net60.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net60.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net60.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net60.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net60.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net60.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net60.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net60.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net60.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net60.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net60.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net60.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net60.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net60.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net60.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net60.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net60.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net60.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net60.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net60.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net60.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net60.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net60.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net60.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net60.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net60.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net60.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net60.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net60.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net60.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net60.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net60.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net60.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net60.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Cng.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net60.System.Security.Cryptography.Cng");
+        private static byte[]? _SystemSecurityCryptographyCng;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net60.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net60.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net60.System.Security.Cryptography.OpenSsl");
+        private static byte[]? _SystemSecurityCryptographyOpenSsl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net60.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net60.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net60.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net60.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net60.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net60.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net60.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net60.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net60.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net60.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net60.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net60.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net60.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net60.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net60.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net60.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net60.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net60.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net60.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net60.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net60.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net60.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net60.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net60.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net60.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net60.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net60.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net60.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net60.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net60.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net60.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net60.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net60.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net60.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net60.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net60.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net60.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net60.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net60.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net60.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net60Windows/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net60Windows/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -296,6 +296,7 @@ public static partial class Net60Windows
 
     }
 }
+
 public static partial class Net60Windows
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net60Windows/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net60Windows/Generated.cs
@@ -9,296 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net60Windows
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net60windows.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net60windows.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Forms.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicForms, "net60windows.Microsoft.VisualBasic.Forms");
-        private static byte[]? _MicrosoftVisualBasicForms;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.AccessControl.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32RegistryAccessControl => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32RegistryAccessControl, "net60windows.Microsoft.Win32.Registry.AccessControl");
-        private static byte[]? _MicrosoftWin32RegistryAccessControl;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.SystemEvents.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32SystemEvents => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32SystemEvents, "net60windows.Microsoft.Win32.SystemEvents");
-        private static byte[]? _MicrosoftWin32SystemEvents;
-
-        /// <summary>
-        /// The image bytes for PresentationCore.dll
-        /// </summary>
-        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net60windows.PresentationCore");
-        private static byte[]? _PresentationCore;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net60windows.PresentationFramework.Aero");
-        private static byte[]? _PresentationFrameworkAero;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero2.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net60windows.PresentationFramework.Aero2");
-        private static byte[]? _PresentationFrameworkAero2;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.AeroLite.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net60windows.PresentationFramework.AeroLite");
-        private static byte[]? _PresentationFrameworkAeroLite;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Classic.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net60windows.PresentationFramework.Classic");
-        private static byte[]? _PresentationFrameworkClassic;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.dll
-        /// </summary>
-        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net60windows.PresentationFramework");
-        private static byte[]? _PresentationFramework;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Luna.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net60windows.PresentationFramework.Luna");
-        private static byte[]? _PresentationFrameworkLuna;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Royale.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net60windows.PresentationFramework.Royale");
-        private static byte[]? _PresentationFrameworkRoyale;
-
-        /// <summary>
-        /// The image bytes for PresentationUI.dll
-        /// </summary>
-        public static byte[] PresentationUI => ResourceLoader.GetOrCreateResource(ref _PresentationUI, "net60windows.PresentationUI");
-        private static byte[]? _PresentationUI;
-
-        /// <summary>
-        /// The image bytes for ReachFramework.dll
-        /// </summary>
-        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net60windows.ReachFramework");
-        private static byte[]? _ReachFramework;
-
-        /// <summary>
-        /// The image bytes for System.CodeDom.dll
-        /// </summary>
-        public static byte[] SystemCodeDom => ResourceLoader.GetOrCreateResource(ref _SystemCodeDom, "net60windows.System.CodeDom");
-        private static byte[]? _SystemCodeDom;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.ConfigurationManager.dll
-        /// </summary>
-        public static byte[] SystemConfigurationConfigurationManager => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationConfigurationManager, "net60windows.System.Configuration.ConfigurationManager");
-        private static byte[]? _SystemConfigurationConfigurationManager;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net60windows.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.EventLog.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "net60windows.System.Diagnostics.EventLog");
-        private static byte[]? _SystemDiagnosticsEventLog;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.PerformanceCounter.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsPerformanceCounter => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsPerformanceCounter, "net60windows.System.Diagnostics.PerformanceCounter");
-        private static byte[]? _SystemDiagnosticsPerformanceCounter;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net60windows.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Common.dll
-        /// </summary>
-        public static byte[] SystemDrawingCommon => ResourceLoader.GetOrCreateResource(ref _SystemDrawingCommon, "net60windows.System.Drawing.Common");
-        private static byte[]? _SystemDrawingCommon;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net60windows.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net60windows.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.IO.Packaging.dll
-        /// </summary>
-        public static byte[] SystemIOPackaging => ResourceLoader.GetOrCreateResource(ref _SystemIOPackaging, "net60windows.System.IO.Packaging");
-        private static byte[]? _SystemIOPackaging;
-
-        /// <summary>
-        /// The image bytes for System.Printing.dll
-        /// </summary>
-        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net60windows.System.Printing");
-        private static byte[]? _SystemPrinting;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Extensions.dll
-        /// </summary>
-        public static byte[] SystemResourcesExtensions => ResourceLoader.GetOrCreateResource(ref _SystemResourcesExtensions, "net60windows.System.Resources.Extensions");
-        private static byte[]? _SystemResourcesExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Pkcs.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPkcs => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPkcs, "net60windows.System.Security.Cryptography.Pkcs");
-        private static byte[]? _SystemSecurityCryptographyPkcs;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.ProtectedData.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyProtectedData => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyProtectedData, "net60windows.System.Security.Cryptography.ProtectedData");
-        private static byte[]? _SystemSecurityCryptographyProtectedData;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Xml.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "net60windows.System.Security.Cryptography.Xml");
-        private static byte[]? _SystemSecurityCryptographyXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Permissions.dll
-        /// </summary>
-        public static byte[] SystemSecurityPermissions => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPermissions, "net60windows.System.Security.Permissions");
-        private static byte[]? _SystemSecurityPermissions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemThreadingAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemThreadingAccessControl, "net60windows.System.Threading.AccessControl");
-        private static byte[]? _SystemThreadingAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Controls.Ribbon.dll
-        /// </summary>
-        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net60windows.System.Windows.Controls.Ribbon");
-        private static byte[]? _SystemWindowsControlsRibbon;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Extensions.dll
-        /// </summary>
-        public static byte[] SystemWindowsExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWindowsExtensions, "net60windows.System.Windows.Extensions");
-        private static byte[]? _SystemWindowsExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.Design.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesign, "net60windows.System.Windows.Forms.Design");
-        private static byte[]? _SystemWindowsFormsDesign;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.Design.Editors.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDesignEditors => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesignEditors, "net60windows.System.Windows.Forms.Design.Editors");
-        private static byte[]? _SystemWindowsFormsDesignEditors;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net60windows.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.Primitives.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsPrimitives, "net60windows.System.Windows.Forms.Primitives");
-        private static byte[]? _SystemWindowsFormsPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Input.Manipulations.dll
-        /// </summary>
-        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net60windows.System.Windows.Input.Manipulations");
-        private static byte[]? _SystemWindowsInputManipulations;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Presentation.dll
-        /// </summary>
-        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net60windows.System.Windows.Presentation");
-        private static byte[]? _SystemWindowsPresentation;
-
-        /// <summary>
-        /// The image bytes for System.Xaml.dll
-        /// </summary>
-        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net60windows.System.Xaml");
-        private static byte[]? _SystemXaml;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClient.dll
-        /// </summary>
-        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net60windows.UIAutomationClient");
-        private static byte[]? _UIAutomationClient;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClientSideProviders.dll
-        /// </summary>
-        public static byte[] UIAutomationClientSideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientSideProviders, "net60windows.UIAutomationClientSideProviders");
-        private static byte[]? _UIAutomationClientSideProviders;
-
-        /// <summary>
-        /// The image bytes for UIAutomationProvider.dll
-        /// </summary>
-        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net60windows.UIAutomationProvider");
-        private static byte[]? _UIAutomationProvider;
-
-        /// <summary>
-        /// The image bytes for UIAutomationTypes.dll
-        /// </summary>
-        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net60windows.UIAutomationTypes");
-        private static byte[]? _UIAutomationTypes;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net60windows.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for WindowsFormsIntegration.dll
-        /// </summary>
-        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net60windows.WindowsFormsIntegration");
-        private static byte[]? _WindowsFormsIntegration;
-
-
-    }
-}
-
-public static partial class Net60Windows
-{
     public static class ReferenceInfos
     {
 
@@ -1466,6 +1176,296 @@ public static partial class Net60Windows
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net60Windows
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net60windows.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net60windows.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Forms.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicForms, "net60windows.Microsoft.VisualBasic.Forms");
+        private static byte[]? _MicrosoftVisualBasicForms;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.AccessControl.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32RegistryAccessControl => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32RegistryAccessControl, "net60windows.Microsoft.Win32.Registry.AccessControl");
+        private static byte[]? _MicrosoftWin32RegistryAccessControl;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.SystemEvents.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32SystemEvents => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32SystemEvents, "net60windows.Microsoft.Win32.SystemEvents");
+        private static byte[]? _MicrosoftWin32SystemEvents;
+
+        /// <summary>
+        /// The image bytes for PresentationCore.dll
+        /// </summary>
+        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net60windows.PresentationCore");
+        private static byte[]? _PresentationCore;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net60windows.PresentationFramework.Aero");
+        private static byte[]? _PresentationFrameworkAero;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero2.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net60windows.PresentationFramework.Aero2");
+        private static byte[]? _PresentationFrameworkAero2;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.AeroLite.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net60windows.PresentationFramework.AeroLite");
+        private static byte[]? _PresentationFrameworkAeroLite;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Classic.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net60windows.PresentationFramework.Classic");
+        private static byte[]? _PresentationFrameworkClassic;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.dll
+        /// </summary>
+        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net60windows.PresentationFramework");
+        private static byte[]? _PresentationFramework;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Luna.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net60windows.PresentationFramework.Luna");
+        private static byte[]? _PresentationFrameworkLuna;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Royale.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net60windows.PresentationFramework.Royale");
+        private static byte[]? _PresentationFrameworkRoyale;
+
+        /// <summary>
+        /// The image bytes for PresentationUI.dll
+        /// </summary>
+        public static byte[] PresentationUI => ResourceLoader.GetOrCreateResource(ref _PresentationUI, "net60windows.PresentationUI");
+        private static byte[]? _PresentationUI;
+
+        /// <summary>
+        /// The image bytes for ReachFramework.dll
+        /// </summary>
+        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net60windows.ReachFramework");
+        private static byte[]? _ReachFramework;
+
+        /// <summary>
+        /// The image bytes for System.CodeDom.dll
+        /// </summary>
+        public static byte[] SystemCodeDom => ResourceLoader.GetOrCreateResource(ref _SystemCodeDom, "net60windows.System.CodeDom");
+        private static byte[]? _SystemCodeDom;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.ConfigurationManager.dll
+        /// </summary>
+        public static byte[] SystemConfigurationConfigurationManager => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationConfigurationManager, "net60windows.System.Configuration.ConfigurationManager");
+        private static byte[]? _SystemConfigurationConfigurationManager;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net60windows.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.EventLog.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "net60windows.System.Diagnostics.EventLog");
+        private static byte[]? _SystemDiagnosticsEventLog;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.PerformanceCounter.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsPerformanceCounter => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsPerformanceCounter, "net60windows.System.Diagnostics.PerformanceCounter");
+        private static byte[]? _SystemDiagnosticsPerformanceCounter;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net60windows.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Common.dll
+        /// </summary>
+        public static byte[] SystemDrawingCommon => ResourceLoader.GetOrCreateResource(ref _SystemDrawingCommon, "net60windows.System.Drawing.Common");
+        private static byte[]? _SystemDrawingCommon;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net60windows.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net60windows.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.IO.Packaging.dll
+        /// </summary>
+        public static byte[] SystemIOPackaging => ResourceLoader.GetOrCreateResource(ref _SystemIOPackaging, "net60windows.System.IO.Packaging");
+        private static byte[]? _SystemIOPackaging;
+
+        /// <summary>
+        /// The image bytes for System.Printing.dll
+        /// </summary>
+        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net60windows.System.Printing");
+        private static byte[]? _SystemPrinting;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Extensions.dll
+        /// </summary>
+        public static byte[] SystemResourcesExtensions => ResourceLoader.GetOrCreateResource(ref _SystemResourcesExtensions, "net60windows.System.Resources.Extensions");
+        private static byte[]? _SystemResourcesExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Pkcs.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPkcs => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPkcs, "net60windows.System.Security.Cryptography.Pkcs");
+        private static byte[]? _SystemSecurityCryptographyPkcs;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.ProtectedData.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyProtectedData => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyProtectedData, "net60windows.System.Security.Cryptography.ProtectedData");
+        private static byte[]? _SystemSecurityCryptographyProtectedData;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Xml.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "net60windows.System.Security.Cryptography.Xml");
+        private static byte[]? _SystemSecurityCryptographyXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Permissions.dll
+        /// </summary>
+        public static byte[] SystemSecurityPermissions => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPermissions, "net60windows.System.Security.Permissions");
+        private static byte[]? _SystemSecurityPermissions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemThreadingAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemThreadingAccessControl, "net60windows.System.Threading.AccessControl");
+        private static byte[]? _SystemThreadingAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Controls.Ribbon.dll
+        /// </summary>
+        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net60windows.System.Windows.Controls.Ribbon");
+        private static byte[]? _SystemWindowsControlsRibbon;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Extensions.dll
+        /// </summary>
+        public static byte[] SystemWindowsExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWindowsExtensions, "net60windows.System.Windows.Extensions");
+        private static byte[]? _SystemWindowsExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.Design.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesign, "net60windows.System.Windows.Forms.Design");
+        private static byte[]? _SystemWindowsFormsDesign;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.Design.Editors.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDesignEditors => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesignEditors, "net60windows.System.Windows.Forms.Design.Editors");
+        private static byte[]? _SystemWindowsFormsDesignEditors;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net60windows.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.Primitives.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsPrimitives, "net60windows.System.Windows.Forms.Primitives");
+        private static byte[]? _SystemWindowsFormsPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Input.Manipulations.dll
+        /// </summary>
+        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net60windows.System.Windows.Input.Manipulations");
+        private static byte[]? _SystemWindowsInputManipulations;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Presentation.dll
+        /// </summary>
+        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net60windows.System.Windows.Presentation");
+        private static byte[]? _SystemWindowsPresentation;
+
+        /// <summary>
+        /// The image bytes for System.Xaml.dll
+        /// </summary>
+        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net60windows.System.Xaml");
+        private static byte[]? _SystemXaml;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClient.dll
+        /// </summary>
+        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net60windows.UIAutomationClient");
+        private static byte[]? _UIAutomationClient;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClientSideProviders.dll
+        /// </summary>
+        public static byte[] UIAutomationClientSideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientSideProviders, "net60windows.UIAutomationClientSideProviders");
+        private static byte[]? _UIAutomationClientSideProviders;
+
+        /// <summary>
+        /// The image bytes for UIAutomationProvider.dll
+        /// </summary>
+        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net60windows.UIAutomationProvider");
+        private static byte[]? _UIAutomationProvider;
+
+        /// <summary>
+        /// The image bytes for UIAutomationTypes.dll
+        /// </summary>
+        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net60windows.UIAutomationTypes");
+        private static byte[]? _UIAutomationTypes;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net60windows.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for WindowsFormsIntegration.dll
+        /// </summary>
+        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net60windows.WindowsFormsIntegration");
+        private static byte[]? _WindowsFormsIntegration;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net70/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net70/Generated.cs
@@ -9,992 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net70
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net70.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net70.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net70.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net70.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net70.Microsoft.Win32.Registry");
-        private static byte[]? _MicrosoftWin32Registry;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net70.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net70.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net70.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net70.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net70.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net70.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net70.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net70.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net70.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net70.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net70.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net70.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net70.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net70.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net70.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net70.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net70.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net70.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net70.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net70.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net70.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net70.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net70.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net70.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net70.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net70.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net70.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net70.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net70.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net70.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net70.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net70.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net70.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net70.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net70.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net70.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Tar.dll
-        /// </summary>
-        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net70.System.Formats.Tar");
-        private static byte[]? _SystemFormatsTar;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net70.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net70.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net70.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net70.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net70.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net70.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net70.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net70.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net70.System.IO.FileSystem.AccessControl");
-        private static byte[]? _SystemIOFileSystemAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net70.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net70.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net70.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net70.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net70.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net70.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net70.System.IO.Pipes.AccessControl");
-        private static byte[]? _SystemIOPipesAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net70.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net70.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net70.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net70.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net70.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net70.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net70.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net70.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net70.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net70.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net70.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net70.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net70.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net70.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net70.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net70.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Quic.dll
-        /// </summary>
-        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net70.System.Net.Quic");
-        private static byte[]? _SystemNetQuic;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net70.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net70.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net70.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net70.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net70.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net70.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net70.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net70.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net70.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net70.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net70.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net70.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net70.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net70.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net70.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net70.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net70.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net70.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net70.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net70.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net70.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net70.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net70.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net70.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net70.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net70.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net70.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net70.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net70.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net70.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net70.System.Runtime.InteropServices.JavaScript");
-        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net70.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net70.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net70.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net70.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net70.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net70.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net70.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net70.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net70.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net70.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net70.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net70.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Cng.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net70.System.Security.Cryptography.Cng");
-        private static byte[]? _SystemSecurityCryptographyCng;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net70.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net70.System.Security.Cryptography");
-        private static byte[]? _SystemSecurityCryptography;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net70.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net70.System.Security.Cryptography.OpenSsl");
-        private static byte[]? _SystemSecurityCryptographyOpenSsl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net70.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net70.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net70.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net70.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net70.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net70.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net70.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net70.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net70.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net70.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net70.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net70.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net70.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net70.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net70.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net70.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net70.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net70.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net70.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net70.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net70.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net70.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net70.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net70.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net70.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net70.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net70.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net70.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net70.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net70.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net70.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net70.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net70.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net70.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net70.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net70.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net70.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net70.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net70.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net70.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-
-    }
-}
-
-public static partial class Net70
-{
     public static class ReferenceInfos
     {
 
@@ -4946,6 +3960,992 @@ public static partial class Net70
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net70
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net70.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net70.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net70.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net70.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net70.Microsoft.Win32.Registry");
+        private static byte[]? _MicrosoftWin32Registry;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net70.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net70.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net70.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net70.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net70.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net70.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net70.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net70.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net70.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net70.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net70.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net70.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net70.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net70.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net70.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net70.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net70.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net70.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net70.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net70.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net70.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net70.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net70.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net70.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net70.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net70.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net70.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net70.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net70.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net70.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net70.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net70.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net70.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net70.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net70.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net70.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Tar.dll
+        /// </summary>
+        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net70.System.Formats.Tar");
+        private static byte[]? _SystemFormatsTar;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net70.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net70.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net70.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net70.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net70.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net70.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net70.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net70.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net70.System.IO.FileSystem.AccessControl");
+        private static byte[]? _SystemIOFileSystemAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net70.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net70.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net70.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net70.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net70.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net70.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net70.System.IO.Pipes.AccessControl");
+        private static byte[]? _SystemIOPipesAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net70.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net70.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net70.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net70.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net70.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net70.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net70.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net70.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net70.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net70.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net70.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net70.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net70.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net70.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net70.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net70.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Quic.dll
+        /// </summary>
+        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net70.System.Net.Quic");
+        private static byte[]? _SystemNetQuic;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net70.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net70.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net70.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net70.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net70.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net70.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net70.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net70.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net70.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net70.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net70.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net70.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net70.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net70.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net70.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net70.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net70.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net70.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net70.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net70.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net70.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net70.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net70.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net70.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net70.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net70.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net70.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net70.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net70.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net70.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net70.System.Runtime.InteropServices.JavaScript");
+        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net70.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net70.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net70.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net70.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net70.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net70.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net70.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net70.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net70.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net70.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net70.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net70.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Cng.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net70.System.Security.Cryptography.Cng");
+        private static byte[]? _SystemSecurityCryptographyCng;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net70.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net70.System.Security.Cryptography");
+        private static byte[]? _SystemSecurityCryptography;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net70.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net70.System.Security.Cryptography.OpenSsl");
+        private static byte[]? _SystemSecurityCryptographyOpenSsl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net70.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net70.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net70.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net70.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net70.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net70.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net70.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net70.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net70.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net70.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net70.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net70.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net70.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net70.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net70.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net70.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net70.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net70.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net70.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net70.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net70.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net70.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net70.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net70.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net70.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net70.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net70.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net70.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net70.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net70.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net70.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net70.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net70.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net70.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net70.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net70.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net70.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net70.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net70.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net70.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net70/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net70/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -992,6 +992,7 @@ public static partial class Net70
 
     }
 }
+
 public static partial class Net70
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net80/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net80/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -992,6 +992,7 @@ public static partial class Net80
 
     }
 }
+
 public static partial class Net80
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net80/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net80/Generated.cs
@@ -9,992 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net80
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net80.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net80.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net80.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net80.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net80.Microsoft.Win32.Registry");
-        private static byte[]? _MicrosoftWin32Registry;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net80.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net80.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net80.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net80.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net80.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net80.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net80.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net80.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net80.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net80.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net80.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net80.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net80.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net80.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net80.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net80.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net80.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net80.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net80.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net80.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net80.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net80.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net80.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net80.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net80.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net80.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net80.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net80.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net80.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net80.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net80.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net80.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net80.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net80.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net80.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net80.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Tar.dll
-        /// </summary>
-        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net80.System.Formats.Tar");
-        private static byte[]? _SystemFormatsTar;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net80.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net80.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net80.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net80.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net80.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net80.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net80.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net80.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net80.System.IO.FileSystem.AccessControl");
-        private static byte[]? _SystemIOFileSystemAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net80.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net80.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net80.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net80.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net80.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net80.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net80.System.IO.Pipes.AccessControl");
-        private static byte[]? _SystemIOPipesAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net80.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net80.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net80.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net80.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net80.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net80.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net80.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net80.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net80.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net80.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net80.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net80.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net80.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net80.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net80.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net80.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Quic.dll
-        /// </summary>
-        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net80.System.Net.Quic");
-        private static byte[]? _SystemNetQuic;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net80.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net80.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net80.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net80.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net80.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net80.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net80.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net80.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net80.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net80.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net80.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net80.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net80.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net80.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net80.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net80.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net80.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net80.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net80.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net80.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net80.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net80.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net80.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net80.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net80.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net80.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net80.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net80.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net80.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net80.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net80.System.Runtime.InteropServices.JavaScript");
-        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net80.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net80.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net80.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net80.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net80.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net80.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net80.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net80.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net80.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net80.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net80.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net80.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Cng.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net80.System.Security.Cryptography.Cng");
-        private static byte[]? _SystemSecurityCryptographyCng;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net80.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net80.System.Security.Cryptography");
-        private static byte[]? _SystemSecurityCryptography;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net80.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net80.System.Security.Cryptography.OpenSsl");
-        private static byte[]? _SystemSecurityCryptographyOpenSsl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net80.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net80.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net80.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net80.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net80.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net80.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net80.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net80.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net80.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net80.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net80.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net80.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net80.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net80.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net80.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net80.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net80.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net80.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net80.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net80.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net80.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net80.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net80.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net80.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net80.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net80.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net80.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net80.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net80.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net80.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net80.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net80.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net80.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net80.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net80.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net80.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net80.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net80.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net80.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net80.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-
-    }
-}
-
-public static partial class Net80
-{
     public static class ReferenceInfos
     {
 
@@ -4946,6 +3960,992 @@ public static partial class Net80
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net80
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net80.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net80.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net80.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net80.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net80.Microsoft.Win32.Registry");
+        private static byte[]? _MicrosoftWin32Registry;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net80.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net80.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net80.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net80.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net80.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net80.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net80.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net80.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net80.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net80.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net80.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net80.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net80.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net80.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net80.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net80.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net80.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net80.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net80.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net80.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net80.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net80.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net80.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net80.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net80.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net80.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net80.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net80.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net80.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net80.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net80.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net80.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net80.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net80.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net80.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net80.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Tar.dll
+        /// </summary>
+        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net80.System.Formats.Tar");
+        private static byte[]? _SystemFormatsTar;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net80.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net80.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net80.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net80.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net80.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net80.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net80.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net80.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net80.System.IO.FileSystem.AccessControl");
+        private static byte[]? _SystemIOFileSystemAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net80.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net80.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net80.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net80.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net80.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net80.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net80.System.IO.Pipes.AccessControl");
+        private static byte[]? _SystemIOPipesAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net80.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net80.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net80.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net80.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net80.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net80.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net80.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net80.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net80.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net80.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net80.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net80.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net80.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net80.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net80.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net80.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Quic.dll
+        /// </summary>
+        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net80.System.Net.Quic");
+        private static byte[]? _SystemNetQuic;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net80.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net80.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net80.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net80.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net80.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net80.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net80.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net80.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net80.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net80.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net80.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net80.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net80.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net80.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net80.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net80.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net80.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net80.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net80.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net80.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net80.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net80.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net80.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net80.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net80.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net80.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net80.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net80.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net80.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net80.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net80.System.Runtime.InteropServices.JavaScript");
+        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net80.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net80.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net80.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net80.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net80.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net80.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net80.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net80.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net80.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net80.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net80.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net80.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Cng.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net80.System.Security.Cryptography.Cng");
+        private static byte[]? _SystemSecurityCryptographyCng;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net80.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net80.System.Security.Cryptography");
+        private static byte[]? _SystemSecurityCryptography;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net80.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net80.System.Security.Cryptography.OpenSsl");
+        private static byte[]? _SystemSecurityCryptographyOpenSsl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net80.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net80.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net80.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net80.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net80.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net80.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net80.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net80.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net80.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net80.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net80.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net80.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net80.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net80.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net80.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net80.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net80.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net80.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net80.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net80.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net80.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net80.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net80.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net80.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net80.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net80.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net80.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net80.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net80.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net80.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net80.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net80.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net80.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net80.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net80.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net80.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net80.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net80.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net80.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net80.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net80Windows/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net80Windows/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -296,6 +296,7 @@ public static partial class Net80Windows
 
     }
 }
+
 public static partial class Net80Windows
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.Net80Windows/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net80Windows/Generated.cs
@@ -9,296 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net80Windows
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net80windows.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net80windows.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Forms.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicForms, "net80windows.Microsoft.VisualBasic.Forms");
-        private static byte[]? _MicrosoftVisualBasicForms;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.AccessControl.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32RegistryAccessControl => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32RegistryAccessControl, "net80windows.Microsoft.Win32.Registry.AccessControl");
-        private static byte[]? _MicrosoftWin32RegistryAccessControl;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.SystemEvents.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32SystemEvents => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32SystemEvents, "net80windows.Microsoft.Win32.SystemEvents");
-        private static byte[]? _MicrosoftWin32SystemEvents;
-
-        /// <summary>
-        /// The image bytes for PresentationCore.dll
-        /// </summary>
-        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net80windows.PresentationCore");
-        private static byte[]? _PresentationCore;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net80windows.PresentationFramework.Aero");
-        private static byte[]? _PresentationFrameworkAero;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero2.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net80windows.PresentationFramework.Aero2");
-        private static byte[]? _PresentationFrameworkAero2;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.AeroLite.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net80windows.PresentationFramework.AeroLite");
-        private static byte[]? _PresentationFrameworkAeroLite;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Classic.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net80windows.PresentationFramework.Classic");
-        private static byte[]? _PresentationFrameworkClassic;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.dll
-        /// </summary>
-        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net80windows.PresentationFramework");
-        private static byte[]? _PresentationFramework;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Luna.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net80windows.PresentationFramework.Luna");
-        private static byte[]? _PresentationFrameworkLuna;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Royale.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net80windows.PresentationFramework.Royale");
-        private static byte[]? _PresentationFrameworkRoyale;
-
-        /// <summary>
-        /// The image bytes for PresentationUI.dll
-        /// </summary>
-        public static byte[] PresentationUI => ResourceLoader.GetOrCreateResource(ref _PresentationUI, "net80windows.PresentationUI");
-        private static byte[]? _PresentationUI;
-
-        /// <summary>
-        /// The image bytes for ReachFramework.dll
-        /// </summary>
-        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net80windows.ReachFramework");
-        private static byte[]? _ReachFramework;
-
-        /// <summary>
-        /// The image bytes for System.CodeDom.dll
-        /// </summary>
-        public static byte[] SystemCodeDom => ResourceLoader.GetOrCreateResource(ref _SystemCodeDom, "net80windows.System.CodeDom");
-        private static byte[]? _SystemCodeDom;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.ConfigurationManager.dll
-        /// </summary>
-        public static byte[] SystemConfigurationConfigurationManager => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationConfigurationManager, "net80windows.System.Configuration.ConfigurationManager");
-        private static byte[]? _SystemConfigurationConfigurationManager;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net80windows.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.EventLog.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "net80windows.System.Diagnostics.EventLog");
-        private static byte[]? _SystemDiagnosticsEventLog;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.PerformanceCounter.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsPerformanceCounter => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsPerformanceCounter, "net80windows.System.Diagnostics.PerformanceCounter");
-        private static byte[]? _SystemDiagnosticsPerformanceCounter;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net80windows.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Common.dll
-        /// </summary>
-        public static byte[] SystemDrawingCommon => ResourceLoader.GetOrCreateResource(ref _SystemDrawingCommon, "net80windows.System.Drawing.Common");
-        private static byte[]? _SystemDrawingCommon;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net80windows.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net80windows.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.IO.Packaging.dll
-        /// </summary>
-        public static byte[] SystemIOPackaging => ResourceLoader.GetOrCreateResource(ref _SystemIOPackaging, "net80windows.System.IO.Packaging");
-        private static byte[]? _SystemIOPackaging;
-
-        /// <summary>
-        /// The image bytes for System.Printing.dll
-        /// </summary>
-        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net80windows.System.Printing");
-        private static byte[]? _SystemPrinting;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Extensions.dll
-        /// </summary>
-        public static byte[] SystemResourcesExtensions => ResourceLoader.GetOrCreateResource(ref _SystemResourcesExtensions, "net80windows.System.Resources.Extensions");
-        private static byte[]? _SystemResourcesExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Pkcs.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPkcs => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPkcs, "net80windows.System.Security.Cryptography.Pkcs");
-        private static byte[]? _SystemSecurityCryptographyPkcs;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.ProtectedData.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyProtectedData => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyProtectedData, "net80windows.System.Security.Cryptography.ProtectedData");
-        private static byte[]? _SystemSecurityCryptographyProtectedData;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Xml.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "net80windows.System.Security.Cryptography.Xml");
-        private static byte[]? _SystemSecurityCryptographyXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Permissions.dll
-        /// </summary>
-        public static byte[] SystemSecurityPermissions => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPermissions, "net80windows.System.Security.Permissions");
-        private static byte[]? _SystemSecurityPermissions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemThreadingAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemThreadingAccessControl, "net80windows.System.Threading.AccessControl");
-        private static byte[]? _SystemThreadingAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Controls.Ribbon.dll
-        /// </summary>
-        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net80windows.System.Windows.Controls.Ribbon");
-        private static byte[]? _SystemWindowsControlsRibbon;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Extensions.dll
-        /// </summary>
-        public static byte[] SystemWindowsExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWindowsExtensions, "net80windows.System.Windows.Extensions");
-        private static byte[]? _SystemWindowsExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.Design.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesign, "net80windows.System.Windows.Forms.Design");
-        private static byte[]? _SystemWindowsFormsDesign;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.Design.Editors.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDesignEditors => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesignEditors, "net80windows.System.Windows.Forms.Design.Editors");
-        private static byte[]? _SystemWindowsFormsDesignEditors;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net80windows.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.Primitives.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsPrimitives, "net80windows.System.Windows.Forms.Primitives");
-        private static byte[]? _SystemWindowsFormsPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Input.Manipulations.dll
-        /// </summary>
-        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net80windows.System.Windows.Input.Manipulations");
-        private static byte[]? _SystemWindowsInputManipulations;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Presentation.dll
-        /// </summary>
-        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net80windows.System.Windows.Presentation");
-        private static byte[]? _SystemWindowsPresentation;
-
-        /// <summary>
-        /// The image bytes for System.Xaml.dll
-        /// </summary>
-        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net80windows.System.Xaml");
-        private static byte[]? _SystemXaml;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClient.dll
-        /// </summary>
-        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net80windows.UIAutomationClient");
-        private static byte[]? _UIAutomationClient;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClientSideProviders.dll
-        /// </summary>
-        public static byte[] UIAutomationClientSideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientSideProviders, "net80windows.UIAutomationClientSideProviders");
-        private static byte[]? _UIAutomationClientSideProviders;
-
-        /// <summary>
-        /// The image bytes for UIAutomationProvider.dll
-        /// </summary>
-        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net80windows.UIAutomationProvider");
-        private static byte[]? _UIAutomationProvider;
-
-        /// <summary>
-        /// The image bytes for UIAutomationTypes.dll
-        /// </summary>
-        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net80windows.UIAutomationTypes");
-        private static byte[]? _UIAutomationTypes;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net80windows.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for WindowsFormsIntegration.dll
-        /// </summary>
-        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net80windows.WindowsFormsIntegration");
-        private static byte[]? _WindowsFormsIntegration;
-
-
-    }
-}
-
-public static partial class Net80Windows
-{
     public static class ReferenceInfos
     {
 
@@ -1466,6 +1176,296 @@ public static partial class Net80Windows
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net80Windows
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net80windows.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net80windows.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Forms.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicForms => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicForms, "net80windows.Microsoft.VisualBasic.Forms");
+        private static byte[]? _MicrosoftVisualBasicForms;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.AccessControl.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32RegistryAccessControl => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32RegistryAccessControl, "net80windows.Microsoft.Win32.Registry.AccessControl");
+        private static byte[]? _MicrosoftWin32RegistryAccessControl;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.SystemEvents.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32SystemEvents => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32SystemEvents, "net80windows.Microsoft.Win32.SystemEvents");
+        private static byte[]? _MicrosoftWin32SystemEvents;
+
+        /// <summary>
+        /// The image bytes for PresentationCore.dll
+        /// </summary>
+        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net80windows.PresentationCore");
+        private static byte[]? _PresentationCore;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net80windows.PresentationFramework.Aero");
+        private static byte[]? _PresentationFrameworkAero;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero2.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net80windows.PresentationFramework.Aero2");
+        private static byte[]? _PresentationFrameworkAero2;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.AeroLite.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net80windows.PresentationFramework.AeroLite");
+        private static byte[]? _PresentationFrameworkAeroLite;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Classic.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net80windows.PresentationFramework.Classic");
+        private static byte[]? _PresentationFrameworkClassic;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.dll
+        /// </summary>
+        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net80windows.PresentationFramework");
+        private static byte[]? _PresentationFramework;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Luna.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net80windows.PresentationFramework.Luna");
+        private static byte[]? _PresentationFrameworkLuna;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Royale.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net80windows.PresentationFramework.Royale");
+        private static byte[]? _PresentationFrameworkRoyale;
+
+        /// <summary>
+        /// The image bytes for PresentationUI.dll
+        /// </summary>
+        public static byte[] PresentationUI => ResourceLoader.GetOrCreateResource(ref _PresentationUI, "net80windows.PresentationUI");
+        private static byte[]? _PresentationUI;
+
+        /// <summary>
+        /// The image bytes for ReachFramework.dll
+        /// </summary>
+        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net80windows.ReachFramework");
+        private static byte[]? _ReachFramework;
+
+        /// <summary>
+        /// The image bytes for System.CodeDom.dll
+        /// </summary>
+        public static byte[] SystemCodeDom => ResourceLoader.GetOrCreateResource(ref _SystemCodeDom, "net80windows.System.CodeDom");
+        private static byte[]? _SystemCodeDom;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.ConfigurationManager.dll
+        /// </summary>
+        public static byte[] SystemConfigurationConfigurationManager => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationConfigurationManager, "net80windows.System.Configuration.ConfigurationManager");
+        private static byte[]? _SystemConfigurationConfigurationManager;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net80windows.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.EventLog.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsEventLog => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsEventLog, "net80windows.System.Diagnostics.EventLog");
+        private static byte[]? _SystemDiagnosticsEventLog;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.PerformanceCounter.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsPerformanceCounter => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsPerformanceCounter, "net80windows.System.Diagnostics.PerformanceCounter");
+        private static byte[]? _SystemDiagnosticsPerformanceCounter;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net80windows.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Common.dll
+        /// </summary>
+        public static byte[] SystemDrawingCommon => ResourceLoader.GetOrCreateResource(ref _SystemDrawingCommon, "net80windows.System.Drawing.Common");
+        private static byte[]? _SystemDrawingCommon;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net80windows.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net80windows.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.IO.Packaging.dll
+        /// </summary>
+        public static byte[] SystemIOPackaging => ResourceLoader.GetOrCreateResource(ref _SystemIOPackaging, "net80windows.System.IO.Packaging");
+        private static byte[]? _SystemIOPackaging;
+
+        /// <summary>
+        /// The image bytes for System.Printing.dll
+        /// </summary>
+        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net80windows.System.Printing");
+        private static byte[]? _SystemPrinting;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Extensions.dll
+        /// </summary>
+        public static byte[] SystemResourcesExtensions => ResourceLoader.GetOrCreateResource(ref _SystemResourcesExtensions, "net80windows.System.Resources.Extensions");
+        private static byte[]? _SystemResourcesExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Pkcs.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPkcs => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPkcs, "net80windows.System.Security.Cryptography.Pkcs");
+        private static byte[]? _SystemSecurityCryptographyPkcs;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.ProtectedData.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyProtectedData => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyProtectedData, "net80windows.System.Security.Cryptography.ProtectedData");
+        private static byte[]? _SystemSecurityCryptographyProtectedData;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Xml.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyXml => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyXml, "net80windows.System.Security.Cryptography.Xml");
+        private static byte[]? _SystemSecurityCryptographyXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Permissions.dll
+        /// </summary>
+        public static byte[] SystemSecurityPermissions => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPermissions, "net80windows.System.Security.Permissions");
+        private static byte[]? _SystemSecurityPermissions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemThreadingAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemThreadingAccessControl, "net80windows.System.Threading.AccessControl");
+        private static byte[]? _SystemThreadingAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Controls.Ribbon.dll
+        /// </summary>
+        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net80windows.System.Windows.Controls.Ribbon");
+        private static byte[]? _SystemWindowsControlsRibbon;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Extensions.dll
+        /// </summary>
+        public static byte[] SystemWindowsExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWindowsExtensions, "net80windows.System.Windows.Extensions");
+        private static byte[]? _SystemWindowsExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.Design.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesign, "net80windows.System.Windows.Forms.Design");
+        private static byte[]? _SystemWindowsFormsDesign;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.Design.Editors.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDesignEditors => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDesignEditors, "net80windows.System.Windows.Forms.Design.Editors");
+        private static byte[]? _SystemWindowsFormsDesignEditors;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net80windows.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.Primitives.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsPrimitives, "net80windows.System.Windows.Forms.Primitives");
+        private static byte[]? _SystemWindowsFormsPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Input.Manipulations.dll
+        /// </summary>
+        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net80windows.System.Windows.Input.Manipulations");
+        private static byte[]? _SystemWindowsInputManipulations;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Presentation.dll
+        /// </summary>
+        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net80windows.System.Windows.Presentation");
+        private static byte[]? _SystemWindowsPresentation;
+
+        /// <summary>
+        /// The image bytes for System.Xaml.dll
+        /// </summary>
+        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net80windows.System.Xaml");
+        private static byte[]? _SystemXaml;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClient.dll
+        /// </summary>
+        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net80windows.UIAutomationClient");
+        private static byte[]? _UIAutomationClient;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClientSideProviders.dll
+        /// </summary>
+        public static byte[] UIAutomationClientSideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientSideProviders, "net80windows.UIAutomationClientSideProviders");
+        private static byte[]? _UIAutomationClientSideProviders;
+
+        /// <summary>
+        /// The image bytes for UIAutomationProvider.dll
+        /// </summary>
+        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net80windows.UIAutomationProvider");
+        private static byte[]? _UIAutomationProvider;
+
+        /// <summary>
+        /// The image bytes for UIAutomationTypes.dll
+        /// </summary>
+        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net80windows.UIAutomationTypes");
+        private static byte[]? _UIAutomationTypes;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net80windows.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for WindowsFormsIntegration.dll
+        /// </summary>
+        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net80windows.WindowsFormsIntegration");
+        private static byte[]? _WindowsFormsIntegration;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net90/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net90/Generated.cs
@@ -9,998 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net90
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net90.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net90.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net90.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net90.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net90.Microsoft.Win32.Registry");
-        private static byte[]? _MicrosoftWin32Registry;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net90.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net90.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net90.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net90.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net90.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net90.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net90.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net90.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net90.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net90.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net90.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net90.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net90.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net90.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net90.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net90.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net90.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net90.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net90.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net90.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net90.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net90.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net90.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net90.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net90.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net90.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net90.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net90.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net90.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net90.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net90.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net90.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net90.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net90.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net90.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net90.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Tar.dll
-        /// </summary>
-        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net90.System.Formats.Tar");
-        private static byte[]? _SystemFormatsTar;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net90.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net90.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net90.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net90.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net90.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net90.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net90.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net90.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net90.System.IO.FileSystem.AccessControl");
-        private static byte[]? _SystemIOFileSystemAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net90.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net90.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net90.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net90.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net90.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net90.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipelines.dll
-        /// </summary>
-        public static byte[] SystemIOPipelines => ResourceLoader.GetOrCreateResource(ref _SystemIOPipelines, "net90.System.IO.Pipelines");
-        private static byte[]? _SystemIOPipelines;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net90.System.IO.Pipes.AccessControl");
-        private static byte[]? _SystemIOPipesAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net90.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net90.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net90.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net90.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net90.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net90.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net90.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net90.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net90.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net90.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net90.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net90.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net90.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net90.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net90.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net90.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Quic.dll
-        /// </summary>
-        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net90.System.Net.Quic");
-        private static byte[]? _SystemNetQuic;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net90.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net90.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net90.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net90.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net90.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net90.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net90.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net90.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net90.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net90.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net90.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net90.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net90.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net90.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net90.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net90.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net90.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net90.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net90.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net90.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net90.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net90.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net90.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net90.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net90.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net90.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net90.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net90.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net90.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net90.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net90.System.Runtime.InteropServices.JavaScript");
-        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net90.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net90.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net90.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net90.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net90.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net90.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net90.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net90.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net90.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net90.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net90.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net90.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Cng.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net90.System.Security.Cryptography.Cng");
-        private static byte[]? _SystemSecurityCryptographyCng;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net90.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net90.System.Security.Cryptography");
-        private static byte[]? _SystemSecurityCryptography;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net90.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net90.System.Security.Cryptography.OpenSsl");
-        private static byte[]? _SystemSecurityCryptographyOpenSsl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net90.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net90.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net90.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net90.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net90.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net90.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net90.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net90.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net90.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net90.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net90.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net90.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net90.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net90.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net90.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net90.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net90.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net90.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net90.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net90.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net90.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net90.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net90.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net90.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net90.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net90.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net90.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net90.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net90.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net90.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net90.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net90.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net90.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net90.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net90.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net90.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net90.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net90.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net90.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net90.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-
-    }
-}
-
-public static partial class Net90
-{
     public static class ReferenceInfos
     {
 
@@ -4976,6 +3984,998 @@ public static partial class Net90
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net90
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net90.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net90.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net90.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net90.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net90.Microsoft.Win32.Registry");
+        private static byte[]? _MicrosoftWin32Registry;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net90.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net90.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net90.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net90.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net90.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net90.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net90.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net90.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net90.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net90.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net90.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net90.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net90.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net90.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net90.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net90.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net90.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net90.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net90.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net90.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net90.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net90.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net90.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net90.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net90.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net90.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net90.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net90.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net90.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net90.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net90.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net90.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net90.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net90.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net90.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net90.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Tar.dll
+        /// </summary>
+        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net90.System.Formats.Tar");
+        private static byte[]? _SystemFormatsTar;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net90.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net90.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net90.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net90.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net90.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net90.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net90.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net90.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net90.System.IO.FileSystem.AccessControl");
+        private static byte[]? _SystemIOFileSystemAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net90.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net90.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net90.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net90.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net90.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net90.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipelines.dll
+        /// </summary>
+        public static byte[] SystemIOPipelines => ResourceLoader.GetOrCreateResource(ref _SystemIOPipelines, "net90.System.IO.Pipelines");
+        private static byte[]? _SystemIOPipelines;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net90.System.IO.Pipes.AccessControl");
+        private static byte[]? _SystemIOPipesAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net90.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net90.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net90.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net90.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net90.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net90.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net90.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net90.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net90.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net90.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net90.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net90.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net90.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net90.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net90.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net90.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Quic.dll
+        /// </summary>
+        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net90.System.Net.Quic");
+        private static byte[]? _SystemNetQuic;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net90.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net90.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net90.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net90.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net90.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net90.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net90.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net90.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net90.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net90.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net90.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net90.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net90.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net90.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net90.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net90.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net90.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net90.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net90.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net90.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net90.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net90.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net90.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net90.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net90.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net90.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net90.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net90.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net90.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net90.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net90.System.Runtime.InteropServices.JavaScript");
+        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net90.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net90.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net90.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net90.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net90.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net90.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net90.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net90.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net90.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net90.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net90.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net90.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Cng.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net90.System.Security.Cryptography.Cng");
+        private static byte[]? _SystemSecurityCryptographyCng;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net90.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net90.System.Security.Cryptography");
+        private static byte[]? _SystemSecurityCryptography;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net90.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net90.System.Security.Cryptography.OpenSsl");
+        private static byte[]? _SystemSecurityCryptographyOpenSsl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net90.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net90.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net90.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net90.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net90.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net90.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net90.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net90.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net90.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net90.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net90.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net90.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net90.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net90.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net90.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net90.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net90.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net90.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net90.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net90.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net90.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net90.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net90.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net90.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net90.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net90.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net90.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net90.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net90.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net90.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net90.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net90.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net90.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net90.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net90.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net90.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net90.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net90.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net90.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net90.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.Net90/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net90/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -998,6 +998,7 @@ public static partial class Net90
 
     }
 }
+
 public static partial class Net90
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.NetCoreApp31/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetCoreApp31/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -920,6 +920,7 @@ public static partial class NetCoreApp31
 
     }
 }
+
 public static partial class NetCoreApp31
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.NetCoreApp31/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetCoreApp31/Generated.cs
@@ -9,920 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class NetCoreApp31
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netcoreapp31.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "netcoreapp31.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netcoreapp31.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netcoreapp31.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netcoreapp31.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netcoreapp31.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netcoreapp31.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "netcoreapp31.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netcoreapp31.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netcoreapp31.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "netcoreapp31.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "netcoreapp31.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "netcoreapp31.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "netcoreapp31.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "netcoreapp31.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "netcoreapp31.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "netcoreapp31.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "netcoreapp31.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "netcoreapp31.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "netcoreapp31.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netcoreapp31.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netcoreapp31.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "netcoreapp31.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "netcoreapp31.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "netcoreapp31.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "netcoreapp31.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netcoreapp31.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "netcoreapp31.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netcoreapp31.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netcoreapp31.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "netcoreapp31.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "netcoreapp31.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netcoreapp31.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "netcoreapp31.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netcoreapp31.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netcoreapp31.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "netcoreapp31.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "netcoreapp31.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "netcoreapp31.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netcoreapp31.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netcoreapp31.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "netcoreapp31.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "netcoreapp31.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netcoreapp31.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "netcoreapp31.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netcoreapp31.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netcoreapp31.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netcoreapp31.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "netcoreapp31.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netcoreapp31.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "netcoreapp31.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "netcoreapp31.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "netcoreapp31.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "netcoreapp31.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "netcoreapp31.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netcoreapp31.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netcoreapp31.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "netcoreapp31.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "netcoreapp31.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "netcoreapp31.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "netcoreapp31.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netcoreapp31.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "netcoreapp31.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "netcoreapp31.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "netcoreapp31.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "netcoreapp31.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "netcoreapp31.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netcoreapp31.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "netcoreapp31.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netcoreapp31.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "netcoreapp31.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netcoreapp31.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "netcoreapp31.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "netcoreapp31.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "netcoreapp31.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "netcoreapp31.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "netcoreapp31.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "netcoreapp31.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "netcoreapp31.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netcoreapp31.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "netcoreapp31.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netcoreapp31.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "netcoreapp31.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "netcoreapp31.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "netcoreapp31.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netcoreapp31.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "netcoreapp31.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netcoreapp31.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "netcoreapp31.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "netcoreapp31.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netcoreapp31.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "netcoreapp31.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "netcoreapp31.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "netcoreapp31.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netcoreapp31.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netcoreapp31.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netcoreapp31.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netcoreapp31.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netcoreapp31.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "netcoreapp31.System.Runtime.InteropServices.WindowsRuntime");
-        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "netcoreapp31.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "netcoreapp31.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netcoreapp31.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "netcoreapp31.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "netcoreapp31.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "netcoreapp31.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netcoreapp31.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "netcoreapp31.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netcoreapp31.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netcoreapp31.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netcoreapp31.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netcoreapp31.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netcoreapp31.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netcoreapp31.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "netcoreapp31.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netcoreapp31.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "netcoreapp31.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "netcoreapp31.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "netcoreapp31.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "netcoreapp31.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netcoreapp31.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netcoreapp31.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "netcoreapp31.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "netcoreapp31.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netcoreapp31.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "netcoreapp31.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netcoreapp31.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "netcoreapp31.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "netcoreapp31.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netcoreapp31.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netcoreapp31.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "netcoreapp31.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "netcoreapp31.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "netcoreapp31.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netcoreapp31.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "netcoreapp31.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "netcoreapp31.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netcoreapp31.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "netcoreapp31.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "netcoreapp31.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "netcoreapp31.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "netcoreapp31.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "netcoreapp31.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netcoreapp31.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "netcoreapp31.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netcoreapp31.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netcoreapp31.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "netcoreapp31.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netcoreapp31.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netcoreapp31.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "netcoreapp31.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-
-    }
-}
-
-public static partial class NetCoreApp31
-{
     public static class ReferenceInfos
     {
 
@@ -4586,6 +3672,920 @@ public static partial class NetCoreApp31
                 return _all;
             }
         }
+    }
+}
+
+public static partial class NetCoreApp31
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netcoreapp31.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "netcoreapp31.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netcoreapp31.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netcoreapp31.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netcoreapp31.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netcoreapp31.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netcoreapp31.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "netcoreapp31.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netcoreapp31.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netcoreapp31.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "netcoreapp31.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "netcoreapp31.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "netcoreapp31.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "netcoreapp31.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "netcoreapp31.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "netcoreapp31.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "netcoreapp31.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "netcoreapp31.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "netcoreapp31.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "netcoreapp31.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netcoreapp31.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netcoreapp31.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "netcoreapp31.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "netcoreapp31.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "netcoreapp31.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "netcoreapp31.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netcoreapp31.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "netcoreapp31.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netcoreapp31.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netcoreapp31.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "netcoreapp31.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "netcoreapp31.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netcoreapp31.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "netcoreapp31.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netcoreapp31.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netcoreapp31.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "netcoreapp31.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "netcoreapp31.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "netcoreapp31.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netcoreapp31.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netcoreapp31.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "netcoreapp31.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "netcoreapp31.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netcoreapp31.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "netcoreapp31.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netcoreapp31.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netcoreapp31.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netcoreapp31.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "netcoreapp31.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netcoreapp31.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "netcoreapp31.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "netcoreapp31.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "netcoreapp31.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "netcoreapp31.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "netcoreapp31.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netcoreapp31.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netcoreapp31.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "netcoreapp31.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "netcoreapp31.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "netcoreapp31.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "netcoreapp31.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netcoreapp31.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "netcoreapp31.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "netcoreapp31.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "netcoreapp31.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "netcoreapp31.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "netcoreapp31.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netcoreapp31.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "netcoreapp31.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netcoreapp31.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "netcoreapp31.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netcoreapp31.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "netcoreapp31.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "netcoreapp31.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "netcoreapp31.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "netcoreapp31.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "netcoreapp31.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "netcoreapp31.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "netcoreapp31.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netcoreapp31.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "netcoreapp31.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netcoreapp31.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "netcoreapp31.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "netcoreapp31.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "netcoreapp31.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netcoreapp31.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "netcoreapp31.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netcoreapp31.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "netcoreapp31.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "netcoreapp31.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netcoreapp31.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "netcoreapp31.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "netcoreapp31.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "netcoreapp31.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netcoreapp31.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netcoreapp31.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netcoreapp31.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netcoreapp31.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netcoreapp31.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "netcoreapp31.System.Runtime.InteropServices.WindowsRuntime");
+        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "netcoreapp31.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "netcoreapp31.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netcoreapp31.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "netcoreapp31.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "netcoreapp31.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "netcoreapp31.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netcoreapp31.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "netcoreapp31.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netcoreapp31.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netcoreapp31.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netcoreapp31.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netcoreapp31.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netcoreapp31.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netcoreapp31.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "netcoreapp31.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netcoreapp31.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "netcoreapp31.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "netcoreapp31.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "netcoreapp31.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "netcoreapp31.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netcoreapp31.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netcoreapp31.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "netcoreapp31.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "netcoreapp31.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netcoreapp31.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "netcoreapp31.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netcoreapp31.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "netcoreapp31.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "netcoreapp31.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netcoreapp31.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netcoreapp31.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "netcoreapp31.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "netcoreapp31.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "netcoreapp31.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netcoreapp31.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "netcoreapp31.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "netcoreapp31.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netcoreapp31.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "netcoreapp31.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "netcoreapp31.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "netcoreapp31.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "netcoreapp31.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "netcoreapp31.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netcoreapp31.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "netcoreapp31.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netcoreapp31.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netcoreapp31.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "netcoreapp31.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netcoreapp31.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netcoreapp31.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "netcoreapp31.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.NetStandard13/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard13/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -362,6 +362,7 @@ public static partial class NetStandard13
 
     }
 }
+
 public static partial class NetStandard13
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.NetStandard13/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard13/Generated.cs
@@ -9,362 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class NetStandard13
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netstandard13.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netstandard13.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netstandard13.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netstandard13.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netstandard13.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netstandard13.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netstandard13.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netstandard13.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netstandard13.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netstandard13.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netstandard13.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netstandard13.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netstandard13.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netstandard13.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netstandard13.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netstandard13.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netstandard13.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netstandard13.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netstandard13.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netstandard13.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netstandard13.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netstandard13.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netstandard13.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netstandard13.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netstandard13.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netstandard13.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netstandard13.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netstandard13.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netstandard13.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netstandard13.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netstandard13.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netstandard13.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netstandard13.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netstandard13.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netstandard13.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "netstandard13.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netstandard13.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netstandard13.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netstandard13.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netstandard13.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netstandard13.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netstandard13.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netstandard13.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "netstandard13.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "netstandard13.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netstandard13.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netstandard13.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netstandard13.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netstandard13.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netstandard13.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard13.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netstandard13.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netstandard13.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netstandard13.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netstandard13.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netstandard13.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netstandard13.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard13.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-
-    }
-}
-
-public static partial class NetStandard13
-{
     public static class ReferenceInfos
     {
 
@@ -1796,6 +1440,362 @@ public static partial class NetStandard13
                 return _all;
             }
         }
+    }
+}
+
+public static partial class NetStandard13
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netstandard13.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netstandard13.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netstandard13.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netstandard13.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netstandard13.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netstandard13.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netstandard13.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netstandard13.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netstandard13.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netstandard13.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netstandard13.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netstandard13.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netstandard13.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netstandard13.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netstandard13.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netstandard13.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netstandard13.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netstandard13.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netstandard13.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netstandard13.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netstandard13.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netstandard13.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netstandard13.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netstandard13.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netstandard13.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netstandard13.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netstandard13.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netstandard13.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netstandard13.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netstandard13.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netstandard13.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netstandard13.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netstandard13.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netstandard13.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netstandard13.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "netstandard13.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netstandard13.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netstandard13.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netstandard13.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netstandard13.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netstandard13.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netstandard13.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netstandard13.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "netstandard13.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "netstandard13.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netstandard13.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netstandard13.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netstandard13.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netstandard13.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netstandard13.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard13.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netstandard13.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netstandard13.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netstandard13.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netstandard13.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netstandard13.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netstandard13.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard13.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Basic.Reference.Assemblies.NetStandard20.csproj
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Basic.Reference.Assemblies.NetStandard20.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Import Project="Generated.targets" />

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Basic.Reference.Assemblies.NetStandard20.csproj
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Basic.Reference.Assemblies.NetStandard20.csproj
@@ -5,6 +5,10 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" IncludeAssets="none" PrivateAssets="all" GeneratePathProperty="true" />
+  </ItemGroup>
+
   <Import Project="Generated.targets" />
 
 </Project>

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
@@ -9,826 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class NetStandard20
 {
-    public static class ExtraReferenceInfos
-    {
-
-        /// <summary>
-        /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
-        /// </summary>
-        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
-
-        /// <summary>
-        /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
-
-        /// <summary>
-        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, NetStandard20.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("619062a8-972f-4ae5-bbee-e36ac541d14f"));
-        private static ImmutableArray<ReferenceInfo> _all;
-        public static ImmutableArray<ReferenceInfo> All
-        {
-            get
-            {
-                if (_all.IsDefault)
-                {
-                    _all =
-                    [
-                        MicrosoftCSharp,
-                        MicrosoftVisualBasic,
-                        SystemThreadingTasksExtensions,
-                    ];
-                }
-                return _all;
-            }
-        }
-
-        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
-    }
-}
-
-public static partial class NetStandard20
-{
-    public static class ExtraReferences
-    {
-        private static PortableExecutableReference? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The <see cref="PortableExecutableReference"/> for Microsoft.CSharp.dll
-        /// </summary>
-        public static PortableExecutableReference MicrosoftCSharp
-        {
-            get
-            {
-                if (_MicrosoftCSharp is null)
-                {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
-                }
-                return _MicrosoftCSharp;
-            }
-        }
-
-        private static PortableExecutableReference? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The <see cref="PortableExecutableReference"/> for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static PortableExecutableReference MicrosoftVisualBasic
-        {
-            get
-            {
-                if (_MicrosoftVisualBasic is null)
-                {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
-                }
-                return _MicrosoftVisualBasic;
-            }
-        }
-
-        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static PortableExecutableReference SystemThreadingTasksExtensions
-        {
-            get
-            {
-                if (_SystemThreadingTasksExtensions is null)
-                {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
-                }
-                return _SystemThreadingTasksExtensions;
-            }
-        }
-
-        private static ImmutableArray<PortableExecutableReference> _all;
-        public static ImmutableArray<PortableExecutableReference> All
-        {
-            get
-            {
-                if (_all.IsDefault)
-                {
-                    _all =
-                    [
-                        MicrosoftCSharp,
-                        MicrosoftVisualBasic,
-                        SystemThreadingTasksExtensions,
-                    ];
-                }
-                return _all;
-            }
-        }
-    }
-}
-
-public static partial class NetStandard20
-{
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netstandard20.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netstandard20.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netstandard20.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netstandard20.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netstandard20.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netstandard20.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "netstandard20.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "netstandard20.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.dll
-        /// </summary>
-        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "netstandard20.System.ComponentModel.Composition");
-        private static byte[]? _SystemComponentModelComposition;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "netstandard20.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "netstandard20.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "netstandard20.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "netstandard20.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netstandard20.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netstandard20.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "netstandard20.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "netstandard20.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "netstandard20.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netstandard20.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netstandard20.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netstandard20.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "netstandard20.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "netstandard20.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netstandard20.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "netstandard20.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netstandard20.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netstandard20.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "netstandard20.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "netstandard20.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "netstandard20.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netstandard20.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netstandard20.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "netstandard20.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netstandard20.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "netstandard20.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netstandard20.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netstandard20.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netstandard20.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "netstandard20.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netstandard20.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "netstandard20.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "netstandard20.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "netstandard20.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "netstandard20.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "netstandard20.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netstandard20.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netstandard20.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "netstandard20.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "netstandard20.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "netstandard20.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netstandard20.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "netstandard20.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "netstandard20.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "netstandard20.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netstandard20.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "netstandard20.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netstandard20.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netstandard20.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "netstandard20.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "netstandard20.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "netstandard20.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "netstandard20.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netstandard20.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netstandard20.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netstandard20.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netstandard20.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "netstandard20.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netstandard20.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "netstandard20.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "netstandard20.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netstandard20.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netstandard20.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netstandard20.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netstandard20.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netstandard20.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netstandard20.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "netstandard20.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "netstandard20.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "netstandard20.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netstandard20.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "netstandard20.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netstandard20.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netstandard20.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netstandard20.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netstandard20.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netstandard20.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netstandard20.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netstandard20.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "netstandard20.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "netstandard20.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netstandard20.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netstandard20.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netstandard20.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netstandard20.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "netstandard20.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netstandard20.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "netstandard20.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "netstandard20.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "netstandard20.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netstandard20.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "netstandard20.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netstandard20.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "netstandard20.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "netstandard20.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "netstandard20.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "netstandard20.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netstandard20.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "netstandard20.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netstandard20.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netstandard20.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "netstandard20.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netstandard20.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard20.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netstandard20.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netstandard20.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard20.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-
-    }
-}
-
-public static partial class NetStandard20
-{
     public static class ReferenceInfos
     {
 
@@ -3580,6 +2760,826 @@ public static partial class NetStandard20
                 return _all;
             }
         }
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class ExtraReferenceInfos
+    {
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, NetStandard20.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("619062a8-972f-4ae5-bbee-e36ac541d14f"));
+        private static ImmutableArray<ReferenceInfo> _all;
+        public static ImmutableArray<ReferenceInfo> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+
+        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class ExtraReferences
+    {
+        private static PortableExecutableReference? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftCSharp
+        {
+            get
+            {
+                if (_MicrosoftCSharp is null)
+                {
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
+                }
+                return _MicrosoftCSharp;
+            }
+        }
+
+        private static PortableExecutableReference? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftVisualBasic
+        {
+            get
+            {
+                if (_MicrosoftVisualBasic is null)
+                {
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
+                }
+                return _MicrosoftVisualBasic;
+            }
+        }
+
+        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static PortableExecutableReference SystemThreadingTasksExtensions
+        {
+            get
+            {
+                if (_SystemThreadingTasksExtensions is null)
+                {
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
+                }
+                return _SystemThreadingTasksExtensions;
+            }
+        }
+
+        private static ImmutableArray<PortableExecutableReference> _all;
+        public static ImmutableArray<PortableExecutableReference> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netstandard20.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netstandard20.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netstandard20.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netstandard20.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netstandard20.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netstandard20.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "netstandard20.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "netstandard20.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.dll
+        /// </summary>
+        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "netstandard20.System.ComponentModel.Composition");
+        private static byte[]? _SystemComponentModelComposition;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "netstandard20.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "netstandard20.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "netstandard20.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "netstandard20.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netstandard20.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netstandard20.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "netstandard20.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "netstandard20.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "netstandard20.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netstandard20.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netstandard20.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netstandard20.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "netstandard20.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "netstandard20.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netstandard20.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "netstandard20.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netstandard20.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netstandard20.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "netstandard20.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "netstandard20.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "netstandard20.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netstandard20.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netstandard20.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "netstandard20.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netstandard20.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "netstandard20.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netstandard20.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netstandard20.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netstandard20.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "netstandard20.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netstandard20.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "netstandard20.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "netstandard20.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "netstandard20.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "netstandard20.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "netstandard20.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netstandard20.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netstandard20.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "netstandard20.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "netstandard20.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "netstandard20.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netstandard20.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "netstandard20.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "netstandard20.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "netstandard20.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netstandard20.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "netstandard20.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netstandard20.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netstandard20.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "netstandard20.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "netstandard20.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "netstandard20.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "netstandard20.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netstandard20.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netstandard20.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netstandard20.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netstandard20.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "netstandard20.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netstandard20.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "netstandard20.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "netstandard20.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netstandard20.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netstandard20.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netstandard20.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netstandard20.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netstandard20.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netstandard20.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "netstandard20.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "netstandard20.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "netstandard20.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netstandard20.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "netstandard20.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netstandard20.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netstandard20.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netstandard20.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netstandard20.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netstandard20.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netstandard20.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netstandard20.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "netstandard20.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "netstandard20.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netstandard20.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netstandard20.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netstandard20.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netstandard20.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "netstandard20.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netstandard20.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "netstandard20.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "netstandard20.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "netstandard20.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netstandard20.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "netstandard20.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netstandard20.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "netstandard20.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "netstandard20.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "netstandard20.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "netstandard20.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netstandard20.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "netstandard20.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netstandard20.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netstandard20.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "netstandard20.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netstandard20.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard20.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netstandard20.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netstandard20.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard20.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
@@ -9,6 +9,122 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class NetStandard20
 {
+    public static class ExtraReferenceInfos
+    {
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, NetStandard20.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("619062a8-972f-4ae5-bbee-e36ac541d14f"));
+        private static ImmutableArray<ReferenceInfo> _all;
+        public static ImmutableArray<ReferenceInfo> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+
+        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class ExtraReferences
+    {
+        private static PortableExecutableReference? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftCSharp
+        {
+            get
+            {
+                if (_MicrosoftCSharp is null)
+                {
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
+                }
+                return _MicrosoftCSharp;
+            }
+        }
+
+        private static PortableExecutableReference? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftVisualBasic
+        {
+            get
+            {
+                if (_MicrosoftVisualBasic is null)
+                {
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
+                }
+                return _MicrosoftVisualBasic;
+            }
+        }
+
+        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static PortableExecutableReference SystemThreadingTasksExtensions
+        {
+            get
+            {
+                if (_SystemThreadingTasksExtensions is null)
+                {
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
+                }
+                return _SystemThreadingTasksExtensions;
+            }
+        }
+
+        private static ImmutableArray<PortableExecutableReference> _all;
+        public static ImmutableArray<PortableExecutableReference> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+    }
+}
+
+public static partial class NetStandard20
+{
     public static class Resources
     {
         /// <summary>
@@ -688,6 +804,24 @@ public static partial class NetStandard20
         /// </summary>
         public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard20.System.Xml.XPath.XDocument");
         private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netstandard20.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netstandard20.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard20.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
 
 
     }

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -692,6 +692,7 @@ public static partial class NetStandard20
 
     }
 }
+
 public static partial class NetStandard20
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Generated.targets
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Generated.targets
@@ -452,5 +452,17 @@
             <LogicalName>netstandard20.System.Xml.XPath.XDocument</LogicalName>
             <Link>Resources\netstandard20\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\4.7.0\lib\netstandard2.0\Microsoft.CSharp.dll" WithCulture="false">
+            <LogicalName>netstandard20.Microsoft.CSharp</LogicalName>
+            <Link>Resources\netstandard20\Microsoft.CSharp.dll</Link>
+        </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.visualbasic\10.3.0\lib\netstandard2.0\Microsoft.VisualBasic.dll" WithCulture="false">
+            <LogicalName>netstandard20.Microsoft.VisualBasic</LogicalName>
+            <Link>Resources\netstandard20\Microsoft.VisualBasic.dll</Link>
+        </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\system.threading.tasks.extensions\4.5.4\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
+            <LogicalName>netstandard20.System.Threading.Tasks.Extensions</LogicalName>
+            <Link>Resources\netstandard20\System.Threading.Tasks.Extensions.dll</Link>
+        </EmbeddedResource>
     </ItemGroup>
 </Project>

--- a/Src/Basic.Reference.Assemblies.UnitTests/SanityUnitTests.cs
+++ b/Src/Basic.Reference.Assemblies.UnitTests/SanityUnitTests.cs
@@ -116,4 +116,64 @@ static void Main()
         Assert.NotEmpty(Net461.References.All);
         Assert.NotEmpty(Net472.References.All);
     }
+
+    [Fact]
+    public void ExtraNetStandard20()
+    {
+        var source = """
+            using System;
+
+            public class C
+            {
+                public System.Threading.Tasks.ValueTask Field1;
+                public dynamic Field2;
+                public Microsoft.VisualBasic.CompilerServices.NewLateBinding Field3;
+
+                static void Main() 
+                {
+                    Console.WriteLine("");
+                }
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            "Example",
+            [CSharpSyntaxTree.ParseText(source)],
+            [.. NetStandard20.References.All, .. NetStandard20.ExtraReferences.All]);
+
+        Assert.Empty(compilation.GetDiagnostics());
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        Assert.True(emitResult.Success);
+        Assert.Empty(emitResult.Diagnostics);
+    }
+
+    [Fact]
+    public void ExtraNetStandardNet461()
+    {
+        var source = """
+            using System;
+
+            public class C
+            {
+                public System.Threading.Tasks.ValueTask Field1;
+
+                static void Main() 
+                {
+                    Console.WriteLine("");
+                }
+            }
+            """;
+
+        var compilation = CSharpCompilation.Create(
+            "Example",
+            [CSharpSyntaxTree.ParseText(source)],
+            [.. Net461.References.All, .. Net461.ExtraReferences.All]);
+
+        Assert.Empty(compilation.GetDiagnostics());
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        Assert.True(emitResult.Success);
+        Assert.Empty(emitResult.Diagnostics);
+    }
 }

--- a/Src/Basic.Reference.Assemblies/Generated.Net472.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.Net472.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -1424,6 +1424,7 @@ public static partial class Net472
 
     }
 }
+
 public static partial class Net472
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies/Generated.Net472.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.Net472.cs
@@ -9,1424 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net472
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Accessibility.dll
-        /// </summary>
-        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net472.Accessibility");
-        private static byte[]? _Accessibility;
-
-        /// <summary>
-        /// The image bytes for CustomMarshalers.dll
-        /// </summary>
-        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net472.CustomMarshalers");
-        private static byte[]? _CustomMarshalers;
-
-        /// <summary>
-        /// The image bytes for ISymWrapper.dll
-        /// </summary>
-        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net472.ISymWrapper");
-        private static byte[]? _ISymWrapper;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Activities.Build.dll
-        /// </summary>
-        public static byte[] MicrosoftActivitiesBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftActivitiesBuild, "net472.Microsoft.Activities.Build");
-        private static byte[]? _MicrosoftActivitiesBuild;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net472.Microsoft.Build.Conversion.v4.0");
-        private static byte[]? _MicrosoftBuildConversionv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.dll
-        /// </summary>
-        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net472.Microsoft.Build");
-        private static byte[]? _MicrosoftBuild;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Engine.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net472.Microsoft.Build.Engine");
-        private static byte[]? _MicrosoftBuildEngine;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Framework.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net472.Microsoft.Build.Framework");
-        private static byte[]? _MicrosoftBuildFramework;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net472.Microsoft.Build.Tasks.v4.0");
-        private static byte[]? _MicrosoftBuildTasksv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
-        /// </summary>
-        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net472.Microsoft.Build.Utilities.v4.0");
-        private static byte[]? _MicrosoftBuildUtilitiesv40;
-
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net472.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.JScript.dll
-        /// </summary>
-        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net472.Microsoft.JScript");
-        private static byte[]? _MicrosoftJScript;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net472.Microsoft.VisualBasic.Compatibility.Data");
-        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net472.Microsoft.VisualBasic.Compatibility");
-        private static byte[]? _MicrosoftVisualBasicCompatibility;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net472.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net472.Microsoft.VisualC");
-        private static byte[]? _MicrosoftVisualC;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualC.STLCLR.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net472.Microsoft.VisualC.STLCLR");
-        private static byte[]? _MicrosoftVisualCSTLCLR;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net472.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for PresentationBuildTasks.dll
-        /// </summary>
-        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net472.PresentationBuildTasks");
-        private static byte[]? _PresentationBuildTasks;
-
-        /// <summary>
-        /// The image bytes for PresentationCore.dll
-        /// </summary>
-        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net472.PresentationCore");
-        private static byte[]? _PresentationCore;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net472.PresentationFramework.Aero");
-        private static byte[]? _PresentationFrameworkAero;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Aero2.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net472.PresentationFramework.Aero2");
-        private static byte[]? _PresentationFrameworkAero2;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.AeroLite.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net472.PresentationFramework.AeroLite");
-        private static byte[]? _PresentationFrameworkAeroLite;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Classic.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net472.PresentationFramework.Classic");
-        private static byte[]? _PresentationFrameworkClassic;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.dll
-        /// </summary>
-        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net472.PresentationFramework");
-        private static byte[]? _PresentationFramework;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Luna.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net472.PresentationFramework.Luna");
-        private static byte[]? _PresentationFrameworkLuna;
-
-        /// <summary>
-        /// The image bytes for PresentationFramework.Royale.dll
-        /// </summary>
-        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net472.PresentationFramework.Royale");
-        private static byte[]? _PresentationFrameworkRoyale;
-
-        /// <summary>
-        /// The image bytes for ReachFramework.dll
-        /// </summary>
-        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net472.ReachFramework");
-        private static byte[]? _ReachFramework;
-
-        /// <summary>
-        /// The image bytes for sysglobl.dll
-        /// </summary>
-        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net472.sysglobl");
-        private static byte[]? _sysglobl;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Core.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net472.System.Activities.Core.Presentation");
-        private static byte[]? _SystemActivitiesCorePresentation;
-
-        /// <summary>
-        /// The image bytes for System.Activities.dll
-        /// </summary>
-        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net472.System.Activities");
-        private static byte[]? _SystemActivities;
-
-        /// <summary>
-        /// The image bytes for System.Activities.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net472.System.Activities.DurableInstancing");
-        private static byte[]? _SystemActivitiesDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Activities.Presentation.dll
-        /// </summary>
-        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net472.System.Activities.Presentation");
-        private static byte[]? _SystemActivitiesPresentation;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.Contract.dll
-        /// </summary>
-        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net472.System.AddIn.Contract");
-        private static byte[]? _SystemAddInContract;
-
-        /// <summary>
-        /// The image bytes for System.AddIn.dll
-        /// </summary>
-        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net472.System.AddIn");
-        private static byte[]? _SystemAddIn;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.dll
-        /// </summary>
-        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net472.System.ComponentModel.Composition");
-        private static byte[]? _SystemComponentModelComposition;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.Registration.dll
-        /// </summary>
-        public static byte[] SystemComponentModelCompositionRegistration => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelCompositionRegistration, "net472.System.ComponentModel.Composition.Registration");
-        private static byte[]? _SystemComponentModelCompositionRegistration;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net472.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net472.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.Install.dll
-        /// </summary>
-        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net472.System.Configuration.Install");
-        private static byte[]? _SystemConfigurationInstall;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net472.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net472.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net472.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net472.System.Data.Entity.Design");
-        private static byte[]? _SystemDataEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Entity.dll
-        /// </summary>
-        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net472.System.Data.Entity");
-        private static byte[]? _SystemDataEntity;
-
-        /// <summary>
-        /// The image bytes for System.Data.Linq.dll
-        /// </summary>
-        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net472.System.Data.Linq");
-        private static byte[]? _SystemDataLinq;
-
-        /// <summary>
-        /// The image bytes for System.Data.OracleClient.dll
-        /// </summary>
-        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net472.System.Data.OracleClient");
-        private static byte[]? _SystemDataOracleClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Client.dll
-        /// </summary>
-        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net472.System.Data.Services.Client");
-        private static byte[]? _SystemDataServicesClient;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.Design.dll
-        /// </summary>
-        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net472.System.Data.Services.Design");
-        private static byte[]? _SystemDataServicesDesign;
-
-        /// <summary>
-        /// The image bytes for System.Data.Services.dll
-        /// </summary>
-        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net472.System.Data.Services");
-        private static byte[]? _SystemDataServices;
-
-        /// <summary>
-        /// The image bytes for System.Data.SqlXml.dll
-        /// </summary>
-        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net472.System.Data.SqlXml");
-        private static byte[]? _SystemDataSqlXml;
-
-        /// <summary>
-        /// The image bytes for System.Deployment.dll
-        /// </summary>
-        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net472.System.Deployment");
-        private static byte[]? _SystemDeployment;
-
-        /// <summary>
-        /// The image bytes for System.Design.dll
-        /// </summary>
-        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net472.System.Design");
-        private static byte[]? _SystemDesign;
-
-        /// <summary>
-        /// The image bytes for System.Device.dll
-        /// </summary>
-        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net472.System.Device");
-        private static byte[]? _SystemDevice;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net472.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.AccountManagement.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net472.System.DirectoryServices.AccountManagement");
-        private static byte[]? _SystemDirectoryServicesAccountManagement;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net472.System.DirectoryServices");
-        private static byte[]? _SystemDirectoryServices;
-
-        /// <summary>
-        /// The image bytes for System.DirectoryServices.Protocols.dll
-        /// </summary>
-        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net472.System.DirectoryServices.Protocols");
-        private static byte[]? _SystemDirectoryServicesProtocols;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net472.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Design.dll
-        /// </summary>
-        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net472.System.Drawing.Design");
-        private static byte[]? _SystemDrawingDesign;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net472.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.dll
-        /// </summary>
-        public static byte[] SystemDynamic => ResourceLoader.GetOrCreateResource(ref _SystemDynamic, "net472.System.Dynamic");
-        private static byte[]? _SystemDynamic;
-
-        /// <summary>
-        /// The image bytes for System.EnterpriseServices.dll
-        /// </summary>
-        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net472.System.EnterpriseServices");
-        private static byte[]? _SystemEnterpriseServices;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.dll
-        /// </summary>
-        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net472.System.IdentityModel");
-        private static byte[]? _SystemIdentityModel;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Selectors.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net472.System.IdentityModel.Selectors");
-        private static byte[]? _SystemIdentityModelSelectors;
-
-        /// <summary>
-        /// The image bytes for System.IdentityModel.Services.dll
-        /// </summary>
-        public static byte[] SystemIdentityModelServices => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelServices, "net472.System.IdentityModel.Services");
-        private static byte[]? _SystemIdentityModelServices;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net472.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net472.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Log.dll
-        /// </summary>
-        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net472.System.IO.Log");
-        private static byte[]? _SystemIOLog;
-
-        /// <summary>
-        /// The image bytes for System.Management.dll
-        /// </summary>
-        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net472.System.Management");
-        private static byte[]? _SystemManagement;
-
-        /// <summary>
-        /// The image bytes for System.Management.Instrumentation.dll
-        /// </summary>
-        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net472.System.Management.Instrumentation");
-        private static byte[]? _SystemManagementInstrumentation;
-
-        /// <summary>
-        /// The image bytes for System.Messaging.dll
-        /// </summary>
-        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net472.System.Messaging");
-        private static byte[]? _SystemMessaging;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net472.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net472.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.WebRequest.dll
-        /// </summary>
-        public static byte[] SystemNetHttpWebRequest => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpWebRequest, "net472.System.Net.Http.WebRequest");
-        private static byte[]? _SystemNetHttpWebRequest;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net472.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Printing.dll
-        /// </summary>
-        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net472.System.Printing");
-        private static byte[]? _SystemPrinting;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Context.dll
-        /// </summary>
-        public static byte[] SystemReflectionContext => ResourceLoader.GetOrCreateResource(ref _SystemReflectionContext, "net472.System.Reflection.Context");
-        private static byte[]? _SystemReflectionContext;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Caching.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net472.System.Runtime.Caching");
-        private static byte[]? _SystemRuntimeCaching;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.DurableInstancing.dll
-        /// </summary>
-        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net472.System.Runtime.DurableInstancing");
-        private static byte[]? _SystemRuntimeDurableInstancing;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Remoting.dll
-        /// </summary>
-        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net472.System.Runtime.Remoting");
-        private static byte[]? _SystemRuntimeRemoting;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net472.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net472.System.Runtime.Serialization.Formatters.Soap");
-        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net472.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activation.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net472.System.ServiceModel.Activation");
-        private static byte[]? _SystemServiceModelActivation;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Activities.dll
-        /// </summary>
-        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net472.System.ServiceModel.Activities");
-        private static byte[]? _SystemServiceModelActivities;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Channels.dll
-        /// </summary>
-        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net472.System.ServiceModel.Channels");
-        private static byte[]? _SystemServiceModelChannels;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Discovery.dll
-        /// </summary>
-        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net472.System.ServiceModel.Discovery");
-        private static byte[]? _SystemServiceModelDiscovery;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.dll
-        /// </summary>
-        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net472.System.ServiceModel");
-        private static byte[]? _SystemServiceModel;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Routing.dll
-        /// </summary>
-        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net472.System.ServiceModel.Routing");
-        private static byte[]? _SystemServiceModelRouting;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net472.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net472.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Speech.dll
-        /// </summary>
-        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net472.System.Speech");
-        private static byte[]? _SystemSpeech;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net472.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Abstractions.dll
-        /// </summary>
-        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net472.System.Web.Abstractions");
-        private static byte[]? _SystemWebAbstractions;
-
-        /// <summary>
-        /// The image bytes for System.Web.ApplicationServices.dll
-        /// </summary>
-        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net472.System.Web.ApplicationServices");
-        private static byte[]? _SystemWebApplicationServices;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net472.System.Web.DataVisualization.Design");
-        private static byte[]? _SystemWebDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net472.System.Web.DataVisualization");
-        private static byte[]? _SystemWebDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net472.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.Design.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net472.System.Web.DynamicData.Design");
-        private static byte[]? _SystemWebDynamicDataDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.DynamicData.dll
-        /// </summary>
-        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net472.System.Web.DynamicData");
-        private static byte[]? _SystemWebDynamicData;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.Design.dll
-        /// </summary>
-        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net472.System.Web.Entity.Design");
-        private static byte[]? _SystemWebEntityDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Entity.dll
-        /// </summary>
-        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net472.System.Web.Entity");
-        private static byte[]? _SystemWebEntity;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.Design.dll
-        /// </summary>
-        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net472.System.Web.Extensions.Design");
-        private static byte[]? _SystemWebExtensionsDesign;
-
-        /// <summary>
-        /// The image bytes for System.Web.Extensions.dll
-        /// </summary>
-        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net472.System.Web.Extensions");
-        private static byte[]? _SystemWebExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Mobile.dll
-        /// </summary>
-        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net472.System.Web.Mobile");
-        private static byte[]? _SystemWebMobile;
-
-        /// <summary>
-        /// The image bytes for System.Web.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net472.System.Web.RegularExpressions");
-        private static byte[]? _SystemWebRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Web.Routing.dll
-        /// </summary>
-        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net472.System.Web.Routing");
-        private static byte[]? _SystemWebRouting;
-
-        /// <summary>
-        /// The image bytes for System.Web.Services.dll
-        /// </summary>
-        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net472.System.Web.Services");
-        private static byte[]? _SystemWebServices;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Controls.Ribbon.dll
-        /// </summary>
-        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net472.System.Windows.Controls.Ribbon");
-        private static byte[]? _SystemWindowsControlsRibbon;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net472.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net472.System.Windows.Forms.DataVisualization.Design");
-        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.DataVisualization.dll
-        /// </summary>
-        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net472.System.Windows.Forms.DataVisualization");
-        private static byte[]? _SystemWindowsFormsDataVisualization;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Forms.dll
-        /// </summary>
-        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net472.System.Windows.Forms");
-        private static byte[]? _SystemWindowsForms;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Input.Manipulations.dll
-        /// </summary>
-        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net472.System.Windows.Input.Manipulations");
-        private static byte[]? _SystemWindowsInputManipulations;
-
-        /// <summary>
-        /// The image bytes for System.Windows.Presentation.dll
-        /// </summary>
-        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net472.System.Windows.Presentation");
-        private static byte[]? _SystemWindowsPresentation;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Activities.dll
-        /// </summary>
-        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net472.System.Workflow.Activities");
-        private static byte[]? _SystemWorkflowActivities;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net472.System.Workflow.ComponentModel");
-        private static byte[]? _SystemWorkflowComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.Workflow.Runtime.dll
-        /// </summary>
-        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net472.System.Workflow.Runtime");
-        private static byte[]? _SystemWorkflowRuntime;
-
-        /// <summary>
-        /// The image bytes for System.WorkflowServices.dll
-        /// </summary>
-        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net472.System.WorkflowServices");
-        private static byte[]? _SystemWorkflowServices;
-
-        /// <summary>
-        /// The image bytes for System.Xaml.dll
-        /// </summary>
-        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net472.System.Xaml");
-        private static byte[]? _SystemXaml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net472.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net472.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net472.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClient.dll
-        /// </summary>
-        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net472.UIAutomationClient");
-        private static byte[]? _UIAutomationClient;
-
-        /// <summary>
-        /// The image bytes for UIAutomationClientsideProviders.dll
-        /// </summary>
-        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net472.UIAutomationClientsideProviders");
-        private static byte[]? _UIAutomationClientsideProviders;
-
-        /// <summary>
-        /// The image bytes for UIAutomationProvider.dll
-        /// </summary>
-        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net472.UIAutomationProvider");
-        private static byte[]? _UIAutomationProvider;
-
-        /// <summary>
-        /// The image bytes for UIAutomationTypes.dll
-        /// </summary>
-        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net472.UIAutomationTypes");
-        private static byte[]? _UIAutomationTypes;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net472.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-        /// <summary>
-        /// The image bytes for WindowsFormsIntegration.dll
-        /// </summary>
-        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net472.WindowsFormsIntegration");
-        private static byte[]? _WindowsFormsIntegration;
-
-        /// <summary>
-        /// The image bytes for XamlBuildTask.dll
-        /// </summary>
-        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net472.XamlBuildTask");
-        private static byte[]? _XamlBuildTask;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net472.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net472.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net472.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net472.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net472.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net472.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net472.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net472.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net472.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net472.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net472.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net472.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net472.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net472.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net472.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net472.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net472.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net472.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net472.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net472.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net472.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net472.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net472.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net472.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net472.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net472.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net472.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net472.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net472.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net472.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net472.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net472.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net472.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net472.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net472.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net472.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net472.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net472.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net472.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net472.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net472.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Rtc.dll
-        /// </summary>
-        public static byte[] SystemNetHttpRtc => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpRtc, "net472.System.Net.Http.Rtc");
-        private static byte[]? _SystemNetHttpRtc;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net472.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net472.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net472.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net472.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net472.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net472.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net472.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net472.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net472.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net472.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net472.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net472.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net472.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net472.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net472.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net472.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net472.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net472.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net472.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net472.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net472.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net472.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net472.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net472.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net472.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net472.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "net472.System.Runtime.InteropServices.WindowsRuntime");
-        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net472.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net472.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net472.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net472.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net472.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net472.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net472.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net472.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net472.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net472.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net472.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net472.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net472.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Duplex.dll
-        /// </summary>
-        public static byte[] SystemServiceModelDuplex => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDuplex, "net472.System.ServiceModel.Duplex");
-        private static byte[]? _SystemServiceModelDuplex;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Http.dll
-        /// </summary>
-        public static byte[] SystemServiceModelHttp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelHttp, "net472.System.ServiceModel.Http");
-        private static byte[]? _SystemServiceModelHttp;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.NetTcp.dll
-        /// </summary>
-        public static byte[] SystemServiceModelNetTcp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelNetTcp, "net472.System.ServiceModel.NetTcp");
-        private static byte[]? _SystemServiceModelNetTcp;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemServiceModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelPrimitives, "net472.System.ServiceModel.Primitives");
-        private static byte[]? _SystemServiceModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Security.dll
-        /// </summary>
-        public static byte[] SystemServiceModelSecurity => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelSecurity, "net472.System.ServiceModel.Security");
-        private static byte[]? _SystemServiceModelSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net472.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net472.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net472.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net472.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net472.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net472.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net472.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net472.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net472.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net472.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net472.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net472.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net472.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net472.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net472.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net472.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net472.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-
-    }
-}
-
-public static partial class Net472
-{
     public static class ReferenceInfos
     {
 
@@ -7106,6 +5688,1424 @@ public static partial class Net472
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net472
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Accessibility.dll
+        /// </summary>
+        public static byte[] Accessibility => ResourceLoader.GetOrCreateResource(ref _Accessibility, "net472.Accessibility");
+        private static byte[]? _Accessibility;
+
+        /// <summary>
+        /// The image bytes for CustomMarshalers.dll
+        /// </summary>
+        public static byte[] CustomMarshalers => ResourceLoader.GetOrCreateResource(ref _CustomMarshalers, "net472.CustomMarshalers");
+        private static byte[]? _CustomMarshalers;
+
+        /// <summary>
+        /// The image bytes for ISymWrapper.dll
+        /// </summary>
+        public static byte[] ISymWrapper => ResourceLoader.GetOrCreateResource(ref _ISymWrapper, "net472.ISymWrapper");
+        private static byte[]? _ISymWrapper;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Activities.Build.dll
+        /// </summary>
+        public static byte[] MicrosoftActivitiesBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftActivitiesBuild, "net472.Microsoft.Activities.Build");
+        private static byte[]? _MicrosoftActivitiesBuild;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Conversion.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildConversionv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildConversionv40, "net472.Microsoft.Build.Conversion.v4.0");
+        private static byte[]? _MicrosoftBuildConversionv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.dll
+        /// </summary>
+        public static byte[] MicrosoftBuild => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuild, "net472.Microsoft.Build");
+        private static byte[]? _MicrosoftBuild;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Engine.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildEngine => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildEngine, "net472.Microsoft.Build.Engine");
+        private static byte[]? _MicrosoftBuildEngine;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Framework.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildFramework => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildFramework, "net472.Microsoft.Build.Framework");
+        private static byte[]? _MicrosoftBuildFramework;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Tasks.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildTasksv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildTasksv40, "net472.Microsoft.Build.Tasks.v4.0");
+        private static byte[]? _MicrosoftBuildTasksv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Build.Utilities.v4.0.dll
+        /// </summary>
+        public static byte[] MicrosoftBuildUtilitiesv40 => ResourceLoader.GetOrCreateResource(ref _MicrosoftBuildUtilitiesv40, "net472.Microsoft.Build.Utilities.v4.0");
+        private static byte[]? _MicrosoftBuildUtilitiesv40;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net472.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.JScript.dll
+        /// </summary>
+        public static byte[] MicrosoftJScript => ResourceLoader.GetOrCreateResource(ref _MicrosoftJScript, "net472.Microsoft.JScript");
+        private static byte[]? _MicrosoftJScript;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.Data.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibilityData => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibilityData, "net472.Microsoft.VisualBasic.Compatibility.Data");
+        private static byte[]? _MicrosoftVisualBasicCompatibilityData;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Compatibility.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCompatibility => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCompatibility, "net472.Microsoft.VisualBasic.Compatibility");
+        private static byte[]? _MicrosoftVisualBasicCompatibility;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net472.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualC => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualC, "net472.Microsoft.VisualC");
+        private static byte[]? _MicrosoftVisualC;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualC.STLCLR.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualCSTLCLR => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualCSTLCLR, "net472.Microsoft.VisualC.STLCLR");
+        private static byte[]? _MicrosoftVisualCSTLCLR;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net472.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for PresentationBuildTasks.dll
+        /// </summary>
+        public static byte[] PresentationBuildTasks => ResourceLoader.GetOrCreateResource(ref _PresentationBuildTasks, "net472.PresentationBuildTasks");
+        private static byte[]? _PresentationBuildTasks;
+
+        /// <summary>
+        /// The image bytes for PresentationCore.dll
+        /// </summary>
+        public static byte[] PresentationCore => ResourceLoader.GetOrCreateResource(ref _PresentationCore, "net472.PresentationCore");
+        private static byte[]? _PresentationCore;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero, "net472.PresentationFramework.Aero");
+        private static byte[]? _PresentationFrameworkAero;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Aero2.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAero2 => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAero2, "net472.PresentationFramework.Aero2");
+        private static byte[]? _PresentationFrameworkAero2;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.AeroLite.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkAeroLite => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkAeroLite, "net472.PresentationFramework.AeroLite");
+        private static byte[]? _PresentationFrameworkAeroLite;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Classic.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkClassic => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkClassic, "net472.PresentationFramework.Classic");
+        private static byte[]? _PresentationFrameworkClassic;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.dll
+        /// </summary>
+        public static byte[] PresentationFramework => ResourceLoader.GetOrCreateResource(ref _PresentationFramework, "net472.PresentationFramework");
+        private static byte[]? _PresentationFramework;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Luna.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkLuna => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkLuna, "net472.PresentationFramework.Luna");
+        private static byte[]? _PresentationFrameworkLuna;
+
+        /// <summary>
+        /// The image bytes for PresentationFramework.Royale.dll
+        /// </summary>
+        public static byte[] PresentationFrameworkRoyale => ResourceLoader.GetOrCreateResource(ref _PresentationFrameworkRoyale, "net472.PresentationFramework.Royale");
+        private static byte[]? _PresentationFrameworkRoyale;
+
+        /// <summary>
+        /// The image bytes for ReachFramework.dll
+        /// </summary>
+        public static byte[] ReachFramework => ResourceLoader.GetOrCreateResource(ref _ReachFramework, "net472.ReachFramework");
+        private static byte[]? _ReachFramework;
+
+        /// <summary>
+        /// The image bytes for sysglobl.dll
+        /// </summary>
+        public static byte[] sysglobl => ResourceLoader.GetOrCreateResource(ref _sysglobl, "net472.sysglobl");
+        private static byte[]? _sysglobl;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Core.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesCorePresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesCorePresentation, "net472.System.Activities.Core.Presentation");
+        private static byte[]? _SystemActivitiesCorePresentation;
+
+        /// <summary>
+        /// The image bytes for System.Activities.dll
+        /// </summary>
+        public static byte[] SystemActivities => ResourceLoader.GetOrCreateResource(ref _SystemActivities, "net472.System.Activities");
+        private static byte[]? _SystemActivities;
+
+        /// <summary>
+        /// The image bytes for System.Activities.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemActivitiesDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesDurableInstancing, "net472.System.Activities.DurableInstancing");
+        private static byte[]? _SystemActivitiesDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Activities.Presentation.dll
+        /// </summary>
+        public static byte[] SystemActivitiesPresentation => ResourceLoader.GetOrCreateResource(ref _SystemActivitiesPresentation, "net472.System.Activities.Presentation");
+        private static byte[]? _SystemActivitiesPresentation;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.Contract.dll
+        /// </summary>
+        public static byte[] SystemAddInContract => ResourceLoader.GetOrCreateResource(ref _SystemAddInContract, "net472.System.AddIn.Contract");
+        private static byte[]? _SystemAddInContract;
+
+        /// <summary>
+        /// The image bytes for System.AddIn.dll
+        /// </summary>
+        public static byte[] SystemAddIn => ResourceLoader.GetOrCreateResource(ref _SystemAddIn, "net472.System.AddIn");
+        private static byte[]? _SystemAddIn;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.dll
+        /// </summary>
+        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "net472.System.ComponentModel.Composition");
+        private static byte[]? _SystemComponentModelComposition;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.Registration.dll
+        /// </summary>
+        public static byte[] SystemComponentModelCompositionRegistration => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelCompositionRegistration, "net472.System.ComponentModel.Composition.Registration");
+        private static byte[]? _SystemComponentModelCompositionRegistration;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net472.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net472.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.Install.dll
+        /// </summary>
+        public static byte[] SystemConfigurationInstall => ResourceLoader.GetOrCreateResource(ref _SystemConfigurationInstall, "net472.System.Configuration.Install");
+        private static byte[]? _SystemConfigurationInstall;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net472.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net472.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net472.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemDataEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataEntityDesign, "net472.System.Data.Entity.Design");
+        private static byte[]? _SystemDataEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Entity.dll
+        /// </summary>
+        public static byte[] SystemDataEntity => ResourceLoader.GetOrCreateResource(ref _SystemDataEntity, "net472.System.Data.Entity");
+        private static byte[]? _SystemDataEntity;
+
+        /// <summary>
+        /// The image bytes for System.Data.Linq.dll
+        /// </summary>
+        public static byte[] SystemDataLinq => ResourceLoader.GetOrCreateResource(ref _SystemDataLinq, "net472.System.Data.Linq");
+        private static byte[]? _SystemDataLinq;
+
+        /// <summary>
+        /// The image bytes for System.Data.OracleClient.dll
+        /// </summary>
+        public static byte[] SystemDataOracleClient => ResourceLoader.GetOrCreateResource(ref _SystemDataOracleClient, "net472.System.Data.OracleClient");
+        private static byte[]? _SystemDataOracleClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Client.dll
+        /// </summary>
+        public static byte[] SystemDataServicesClient => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesClient, "net472.System.Data.Services.Client");
+        private static byte[]? _SystemDataServicesClient;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.Design.dll
+        /// </summary>
+        public static byte[] SystemDataServicesDesign => ResourceLoader.GetOrCreateResource(ref _SystemDataServicesDesign, "net472.System.Data.Services.Design");
+        private static byte[]? _SystemDataServicesDesign;
+
+        /// <summary>
+        /// The image bytes for System.Data.Services.dll
+        /// </summary>
+        public static byte[] SystemDataServices => ResourceLoader.GetOrCreateResource(ref _SystemDataServices, "net472.System.Data.Services");
+        private static byte[]? _SystemDataServices;
+
+        /// <summary>
+        /// The image bytes for System.Data.SqlXml.dll
+        /// </summary>
+        public static byte[] SystemDataSqlXml => ResourceLoader.GetOrCreateResource(ref _SystemDataSqlXml, "net472.System.Data.SqlXml");
+        private static byte[]? _SystemDataSqlXml;
+
+        /// <summary>
+        /// The image bytes for System.Deployment.dll
+        /// </summary>
+        public static byte[] SystemDeployment => ResourceLoader.GetOrCreateResource(ref _SystemDeployment, "net472.System.Deployment");
+        private static byte[]? _SystemDeployment;
+
+        /// <summary>
+        /// The image bytes for System.Design.dll
+        /// </summary>
+        public static byte[] SystemDesign => ResourceLoader.GetOrCreateResource(ref _SystemDesign, "net472.System.Design");
+        private static byte[]? _SystemDesign;
+
+        /// <summary>
+        /// The image bytes for System.Device.dll
+        /// </summary>
+        public static byte[] SystemDevice => ResourceLoader.GetOrCreateResource(ref _SystemDevice, "net472.System.Device");
+        private static byte[]? _SystemDevice;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net472.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.AccountManagement.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesAccountManagement => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesAccountManagement, "net472.System.DirectoryServices.AccountManagement");
+        private static byte[]? _SystemDirectoryServicesAccountManagement;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServices => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServices, "net472.System.DirectoryServices");
+        private static byte[]? _SystemDirectoryServices;
+
+        /// <summary>
+        /// The image bytes for System.DirectoryServices.Protocols.dll
+        /// </summary>
+        public static byte[] SystemDirectoryServicesProtocols => ResourceLoader.GetOrCreateResource(ref _SystemDirectoryServicesProtocols, "net472.System.DirectoryServices.Protocols");
+        private static byte[]? _SystemDirectoryServicesProtocols;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net472.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Design.dll
+        /// </summary>
+        public static byte[] SystemDrawingDesign => ResourceLoader.GetOrCreateResource(ref _SystemDrawingDesign, "net472.System.Drawing.Design");
+        private static byte[]? _SystemDrawingDesign;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net472.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.dll
+        /// </summary>
+        public static byte[] SystemDynamic => ResourceLoader.GetOrCreateResource(ref _SystemDynamic, "net472.System.Dynamic");
+        private static byte[]? _SystemDynamic;
+
+        /// <summary>
+        /// The image bytes for System.EnterpriseServices.dll
+        /// </summary>
+        public static byte[] SystemEnterpriseServices => ResourceLoader.GetOrCreateResource(ref _SystemEnterpriseServices, "net472.System.EnterpriseServices");
+        private static byte[]? _SystemEnterpriseServices;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.dll
+        /// </summary>
+        public static byte[] SystemIdentityModel => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModel, "net472.System.IdentityModel");
+        private static byte[]? _SystemIdentityModel;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Selectors.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelSelectors => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelSelectors, "net472.System.IdentityModel.Selectors");
+        private static byte[]? _SystemIdentityModelSelectors;
+
+        /// <summary>
+        /// The image bytes for System.IdentityModel.Services.dll
+        /// </summary>
+        public static byte[] SystemIdentityModelServices => ResourceLoader.GetOrCreateResource(ref _SystemIdentityModelServices, "net472.System.IdentityModel.Services");
+        private static byte[]? _SystemIdentityModelServices;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net472.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net472.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Log.dll
+        /// </summary>
+        public static byte[] SystemIOLog => ResourceLoader.GetOrCreateResource(ref _SystemIOLog, "net472.System.IO.Log");
+        private static byte[]? _SystemIOLog;
+
+        /// <summary>
+        /// The image bytes for System.Management.dll
+        /// </summary>
+        public static byte[] SystemManagement => ResourceLoader.GetOrCreateResource(ref _SystemManagement, "net472.System.Management");
+        private static byte[]? _SystemManagement;
+
+        /// <summary>
+        /// The image bytes for System.Management.Instrumentation.dll
+        /// </summary>
+        public static byte[] SystemManagementInstrumentation => ResourceLoader.GetOrCreateResource(ref _SystemManagementInstrumentation, "net472.System.Management.Instrumentation");
+        private static byte[]? _SystemManagementInstrumentation;
+
+        /// <summary>
+        /// The image bytes for System.Messaging.dll
+        /// </summary>
+        public static byte[] SystemMessaging => ResourceLoader.GetOrCreateResource(ref _SystemMessaging, "net472.System.Messaging");
+        private static byte[]? _SystemMessaging;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net472.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net472.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.WebRequest.dll
+        /// </summary>
+        public static byte[] SystemNetHttpWebRequest => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpWebRequest, "net472.System.Net.Http.WebRequest");
+        private static byte[]? _SystemNetHttpWebRequest;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net472.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Printing.dll
+        /// </summary>
+        public static byte[] SystemPrinting => ResourceLoader.GetOrCreateResource(ref _SystemPrinting, "net472.System.Printing");
+        private static byte[]? _SystemPrinting;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Context.dll
+        /// </summary>
+        public static byte[] SystemReflectionContext => ResourceLoader.GetOrCreateResource(ref _SystemReflectionContext, "net472.System.Reflection.Context");
+        private static byte[]? _SystemReflectionContext;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Caching.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCaching => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCaching, "net472.System.Runtime.Caching");
+        private static byte[]? _SystemRuntimeCaching;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.DurableInstancing.dll
+        /// </summary>
+        public static byte[] SystemRuntimeDurableInstancing => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeDurableInstancing, "net472.System.Runtime.DurableInstancing");
+        private static byte[]? _SystemRuntimeDurableInstancing;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Remoting.dll
+        /// </summary>
+        public static byte[] SystemRuntimeRemoting => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeRemoting, "net472.System.Runtime.Remoting");
+        private static byte[]? _SystemRuntimeRemoting;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net472.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.Soap.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormattersSoap => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormattersSoap, "net472.System.Runtime.Serialization.Formatters.Soap");
+        private static byte[]? _SystemRuntimeSerializationFormattersSoap;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net472.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activation.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivation => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivation, "net472.System.ServiceModel.Activation");
+        private static byte[]? _SystemServiceModelActivation;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Activities.dll
+        /// </summary>
+        public static byte[] SystemServiceModelActivities => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelActivities, "net472.System.ServiceModel.Activities");
+        private static byte[]? _SystemServiceModelActivities;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Channels.dll
+        /// </summary>
+        public static byte[] SystemServiceModelChannels => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelChannels, "net472.System.ServiceModel.Channels");
+        private static byte[]? _SystemServiceModelChannels;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Discovery.dll
+        /// </summary>
+        public static byte[] SystemServiceModelDiscovery => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDiscovery, "net472.System.ServiceModel.Discovery");
+        private static byte[]? _SystemServiceModelDiscovery;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.dll
+        /// </summary>
+        public static byte[] SystemServiceModel => ResourceLoader.GetOrCreateResource(ref _SystemServiceModel, "net472.System.ServiceModel");
+        private static byte[]? _SystemServiceModel;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Routing.dll
+        /// </summary>
+        public static byte[] SystemServiceModelRouting => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelRouting, "net472.System.ServiceModel.Routing");
+        private static byte[]? _SystemServiceModelRouting;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net472.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net472.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Speech.dll
+        /// </summary>
+        public static byte[] SystemSpeech => ResourceLoader.GetOrCreateResource(ref _SystemSpeech, "net472.System.Speech");
+        private static byte[]? _SystemSpeech;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net472.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Abstractions.dll
+        /// </summary>
+        public static byte[] SystemWebAbstractions => ResourceLoader.GetOrCreateResource(ref _SystemWebAbstractions, "net472.System.Web.Abstractions");
+        private static byte[]? _SystemWebAbstractions;
+
+        /// <summary>
+        /// The image bytes for System.Web.ApplicationServices.dll
+        /// </summary>
+        public static byte[] SystemWebApplicationServices => ResourceLoader.GetOrCreateResource(ref _SystemWebApplicationServices, "net472.System.Web.ApplicationServices");
+        private static byte[]? _SystemWebApplicationServices;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualizationDesign, "net472.System.Web.DataVisualization.Design");
+        private static byte[]? _SystemWebDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWebDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWebDataVisualization, "net472.System.Web.DataVisualization");
+        private static byte[]? _SystemWebDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net472.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.Design.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicDataDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicDataDesign, "net472.System.Web.DynamicData.Design");
+        private static byte[]? _SystemWebDynamicDataDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.DynamicData.dll
+        /// </summary>
+        public static byte[] SystemWebDynamicData => ResourceLoader.GetOrCreateResource(ref _SystemWebDynamicData, "net472.System.Web.DynamicData");
+        private static byte[]? _SystemWebDynamicData;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.Design.dll
+        /// </summary>
+        public static byte[] SystemWebEntityDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebEntityDesign, "net472.System.Web.Entity.Design");
+        private static byte[]? _SystemWebEntityDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Entity.dll
+        /// </summary>
+        public static byte[] SystemWebEntity => ResourceLoader.GetOrCreateResource(ref _SystemWebEntity, "net472.System.Web.Entity");
+        private static byte[]? _SystemWebEntity;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.Design.dll
+        /// </summary>
+        public static byte[] SystemWebExtensionsDesign => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensionsDesign, "net472.System.Web.Extensions.Design");
+        private static byte[]? _SystemWebExtensionsDesign;
+
+        /// <summary>
+        /// The image bytes for System.Web.Extensions.dll
+        /// </summary>
+        public static byte[] SystemWebExtensions => ResourceLoader.GetOrCreateResource(ref _SystemWebExtensions, "net472.System.Web.Extensions");
+        private static byte[]? _SystemWebExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Mobile.dll
+        /// </summary>
+        public static byte[] SystemWebMobile => ResourceLoader.GetOrCreateResource(ref _SystemWebMobile, "net472.System.Web.Mobile");
+        private static byte[]? _SystemWebMobile;
+
+        /// <summary>
+        /// The image bytes for System.Web.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemWebRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemWebRegularExpressions, "net472.System.Web.RegularExpressions");
+        private static byte[]? _SystemWebRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Web.Routing.dll
+        /// </summary>
+        public static byte[] SystemWebRouting => ResourceLoader.GetOrCreateResource(ref _SystemWebRouting, "net472.System.Web.Routing");
+        private static byte[]? _SystemWebRouting;
+
+        /// <summary>
+        /// The image bytes for System.Web.Services.dll
+        /// </summary>
+        public static byte[] SystemWebServices => ResourceLoader.GetOrCreateResource(ref _SystemWebServices, "net472.System.Web.Services");
+        private static byte[]? _SystemWebServices;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Controls.Ribbon.dll
+        /// </summary>
+        public static byte[] SystemWindowsControlsRibbon => ResourceLoader.GetOrCreateResource(ref _SystemWindowsControlsRibbon, "net472.System.Windows.Controls.Ribbon");
+        private static byte[]? _SystemWindowsControlsRibbon;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net472.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.Design.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualizationDesign => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualizationDesign, "net472.System.Windows.Forms.DataVisualization.Design");
+        private static byte[]? _SystemWindowsFormsDataVisualizationDesign;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.DataVisualization.dll
+        /// </summary>
+        public static byte[] SystemWindowsFormsDataVisualization => ResourceLoader.GetOrCreateResource(ref _SystemWindowsFormsDataVisualization, "net472.System.Windows.Forms.DataVisualization");
+        private static byte[]? _SystemWindowsFormsDataVisualization;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Forms.dll
+        /// </summary>
+        public static byte[] SystemWindowsForms => ResourceLoader.GetOrCreateResource(ref _SystemWindowsForms, "net472.System.Windows.Forms");
+        private static byte[]? _SystemWindowsForms;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Input.Manipulations.dll
+        /// </summary>
+        public static byte[] SystemWindowsInputManipulations => ResourceLoader.GetOrCreateResource(ref _SystemWindowsInputManipulations, "net472.System.Windows.Input.Manipulations");
+        private static byte[]? _SystemWindowsInputManipulations;
+
+        /// <summary>
+        /// The image bytes for System.Windows.Presentation.dll
+        /// </summary>
+        public static byte[] SystemWindowsPresentation => ResourceLoader.GetOrCreateResource(ref _SystemWindowsPresentation, "net472.System.Windows.Presentation");
+        private static byte[]? _SystemWindowsPresentation;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Activities.dll
+        /// </summary>
+        public static byte[] SystemWorkflowActivities => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowActivities, "net472.System.Workflow.Activities");
+        private static byte[]? _SystemWorkflowActivities;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemWorkflowComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowComponentModel, "net472.System.Workflow.ComponentModel");
+        private static byte[]? _SystemWorkflowComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.Workflow.Runtime.dll
+        /// </summary>
+        public static byte[] SystemWorkflowRuntime => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowRuntime, "net472.System.Workflow.Runtime");
+        private static byte[]? _SystemWorkflowRuntime;
+
+        /// <summary>
+        /// The image bytes for System.WorkflowServices.dll
+        /// </summary>
+        public static byte[] SystemWorkflowServices => ResourceLoader.GetOrCreateResource(ref _SystemWorkflowServices, "net472.System.WorkflowServices");
+        private static byte[]? _SystemWorkflowServices;
+
+        /// <summary>
+        /// The image bytes for System.Xaml.dll
+        /// </summary>
+        public static byte[] SystemXaml => ResourceLoader.GetOrCreateResource(ref _SystemXaml, "net472.System.Xaml");
+        private static byte[]? _SystemXaml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net472.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net472.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net472.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClient.dll
+        /// </summary>
+        public static byte[] UIAutomationClient => ResourceLoader.GetOrCreateResource(ref _UIAutomationClient, "net472.UIAutomationClient");
+        private static byte[]? _UIAutomationClient;
+
+        /// <summary>
+        /// The image bytes for UIAutomationClientsideProviders.dll
+        /// </summary>
+        public static byte[] UIAutomationClientsideProviders => ResourceLoader.GetOrCreateResource(ref _UIAutomationClientsideProviders, "net472.UIAutomationClientsideProviders");
+        private static byte[]? _UIAutomationClientsideProviders;
+
+        /// <summary>
+        /// The image bytes for UIAutomationProvider.dll
+        /// </summary>
+        public static byte[] UIAutomationProvider => ResourceLoader.GetOrCreateResource(ref _UIAutomationProvider, "net472.UIAutomationProvider");
+        private static byte[]? _UIAutomationProvider;
+
+        /// <summary>
+        /// The image bytes for UIAutomationTypes.dll
+        /// </summary>
+        public static byte[] UIAutomationTypes => ResourceLoader.GetOrCreateResource(ref _UIAutomationTypes, "net472.UIAutomationTypes");
+        private static byte[]? _UIAutomationTypes;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net472.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+        /// <summary>
+        /// The image bytes for WindowsFormsIntegration.dll
+        /// </summary>
+        public static byte[] WindowsFormsIntegration => ResourceLoader.GetOrCreateResource(ref _WindowsFormsIntegration, "net472.WindowsFormsIntegration");
+        private static byte[]? _WindowsFormsIntegration;
+
+        /// <summary>
+        /// The image bytes for XamlBuildTask.dll
+        /// </summary>
+        public static byte[] XamlBuildTask => ResourceLoader.GetOrCreateResource(ref _XamlBuildTask, "net472.XamlBuildTask");
+        private static byte[]? _XamlBuildTask;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net472.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net472.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net472.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net472.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net472.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net472.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net472.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net472.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net472.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net472.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net472.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net472.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net472.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net472.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net472.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net472.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net472.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net472.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net472.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net472.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net472.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net472.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net472.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net472.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net472.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net472.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net472.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net472.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net472.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net472.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net472.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net472.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net472.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net472.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net472.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net472.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net472.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net472.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net472.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net472.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net472.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Rtc.dll
+        /// </summary>
+        public static byte[] SystemNetHttpRtc => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpRtc, "net472.System.Net.Http.Rtc");
+        private static byte[]? _SystemNetHttpRtc;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net472.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net472.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net472.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net472.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net472.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net472.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net472.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net472.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net472.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net472.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net472.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net472.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net472.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net472.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net472.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net472.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net472.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net472.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net472.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net472.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net472.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net472.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net472.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net472.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net472.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net472.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.WindowsRuntime.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesWindowsRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesWindowsRuntime, "net472.System.Runtime.InteropServices.WindowsRuntime");
+        private static byte[]? _SystemRuntimeInteropServicesWindowsRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net472.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net472.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net472.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net472.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net472.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net472.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net472.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net472.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net472.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net472.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net472.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net472.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net472.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Duplex.dll
+        /// </summary>
+        public static byte[] SystemServiceModelDuplex => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelDuplex, "net472.System.ServiceModel.Duplex");
+        private static byte[]? _SystemServiceModelDuplex;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Http.dll
+        /// </summary>
+        public static byte[] SystemServiceModelHttp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelHttp, "net472.System.ServiceModel.Http");
+        private static byte[]? _SystemServiceModelHttp;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.NetTcp.dll
+        /// </summary>
+        public static byte[] SystemServiceModelNetTcp => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelNetTcp, "net472.System.ServiceModel.NetTcp");
+        private static byte[]? _SystemServiceModelNetTcp;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemServiceModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelPrimitives, "net472.System.ServiceModel.Primitives");
+        private static byte[]? _SystemServiceModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Security.dll
+        /// </summary>
+        public static byte[] SystemServiceModelSecurity => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelSecurity, "net472.System.ServiceModel.Security");
+        private static byte[]? _SystemServiceModelSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net472.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net472.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net472.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net472.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net472.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net472.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net472.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net472.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net472.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net472.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net472.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net472.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net472.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net472.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net472.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net472.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net472.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies/Generated.Net80.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.Net80.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -992,6 +992,7 @@ public static partial class Net80
 
     }
 }
+
 public static partial class Net80
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies/Generated.Net80.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.Net80.cs
@@ -9,992 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class Net80
 {
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net80.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.Core.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net80.Microsoft.VisualBasic.Core");
-        private static byte[]? _MicrosoftVisualBasicCore;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net80.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net80.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Registry.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net80.Microsoft.Win32.Registry");
-        private static byte[]? _MicrosoftWin32Registry;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net80.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net80.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net80.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Buffers.dll
-        /// </summary>
-        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net80.System.Buffers");
-        private static byte[]? _SystemBuffers;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net80.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net80.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Immutable.dll
-        /// </summary>
-        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net80.System.Collections.Immutable");
-        private static byte[]? _SystemCollectionsImmutable;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net80.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net80.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Annotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net80.System.ComponentModel.Annotations");
-        private static byte[]? _SystemComponentModelAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.DataAnnotations.dll
-        /// </summary>
-        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net80.System.ComponentModel.DataAnnotations");
-        private static byte[]? _SystemComponentModelDataAnnotations;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net80.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net80.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net80.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net80.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Configuration.dll
-        /// </summary>
-        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net80.System.Configuration");
-        private static byte[]? _SystemConfiguration;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net80.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net80.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net80.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.DataSetExtensions.dll
-        /// </summary>
-        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net80.System.Data.DataSetExtensions");
-        private static byte[]? _SystemDataDataSetExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net80.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net80.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net80.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net80.System.Diagnostics.DiagnosticSource");
-        private static byte[]? _SystemDiagnosticsDiagnosticSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net80.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net80.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net80.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net80.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net80.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net80.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net80.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net80.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net80.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net80.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net80.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Asn1.dll
-        /// </summary>
-        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net80.System.Formats.Asn1");
-        private static byte[]? _SystemFormatsAsn1;
-
-        /// <summary>
-        /// The image bytes for System.Formats.Tar.dll
-        /// </summary>
-        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net80.System.Formats.Tar");
-        private static byte[]? _SystemFormatsTar;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net80.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net80.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net80.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.Brotli.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net80.System.IO.Compression.Brotli");
-        private static byte[]? _SystemIOCompressionBrotli;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net80.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net80.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net80.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net80.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net80.System.IO.FileSystem.AccessControl");
-        private static byte[]? _SystemIOFileSystemAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net80.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net80.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net80.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net80.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net80.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net80.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net80.System.IO.Pipes.AccessControl");
-        private static byte[]? _SystemIOPipesAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net80.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net80.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net80.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net80.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net80.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net80.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Memory.dll
-        /// </summary>
-        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net80.System.Memory");
-        private static byte[]? _SystemMemory;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net80.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net80.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.Json.dll
-        /// </summary>
-        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net80.System.Net.Http.Json");
-        private static byte[]? _SystemNetHttpJson;
-
-        /// <summary>
-        /// The image bytes for System.Net.HttpListener.dll
-        /// </summary>
-        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net80.System.Net.HttpListener");
-        private static byte[]? _SystemNetHttpListener;
-
-        /// <summary>
-        /// The image bytes for System.Net.Mail.dll
-        /// </summary>
-        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net80.System.Net.Mail");
-        private static byte[]? _SystemNetMail;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net80.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net80.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net80.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net80.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Quic.dll
-        /// </summary>
-        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net80.System.Net.Quic");
-        private static byte[]? _SystemNetQuic;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net80.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net80.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.ServicePoint.dll
-        /// </summary>
-        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net80.System.Net.ServicePoint");
-        private static byte[]? _SystemNetServicePoint;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net80.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebClient.dll
-        /// </summary>
-        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net80.System.Net.WebClient");
-        private static byte[]? _SystemNetWebClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net80.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebProxy.dll
-        /// </summary>
-        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net80.System.Net.WebProxy");
-        private static byte[]? _SystemNetWebProxy;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net80.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net80.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net80.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.Vectors.dll
-        /// </summary>
-        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net80.System.Numerics.Vectors");
-        private static byte[]? _SystemNumericsVectors;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net80.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.DispatchProxy.dll
-        /// </summary>
-        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net80.System.Reflection.DispatchProxy");
-        private static byte[]? _SystemReflectionDispatchProxy;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net80.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net80.System.Reflection.Emit");
-        private static byte[]? _SystemReflectionEmit;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net80.System.Reflection.Emit.ILGeneration");
-        private static byte[]? _SystemReflectionEmitILGeneration;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Emit.Lightweight.dll
-        /// </summary>
-        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net80.System.Reflection.Emit.Lightweight");
-        private static byte[]? _SystemReflectionEmitLightweight;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net80.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Metadata.dll
-        /// </summary>
-        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net80.System.Reflection.Metadata");
-        private static byte[]? _SystemReflectionMetadata;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net80.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.TypeExtensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net80.System.Reflection.TypeExtensions");
-        private static byte[]? _SystemReflectionTypeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net80.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net80.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net80.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net80.System.Runtime.CompilerServices.Unsafe");
-        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net80.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net80.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net80.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net80.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net80.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net80.System.Runtime.InteropServices.JavaScript");
-        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net80.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Intrinsics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net80.System.Runtime.Intrinsics");
-        private static byte[]? _SystemRuntimeIntrinsics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Loader.dll
-        /// </summary>
-        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net80.System.Runtime.Loader");
-        private static byte[]? _SystemRuntimeLoader;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net80.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net80.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net80.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net80.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net80.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net80.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.AccessControl.dll
-        /// </summary>
-        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net80.System.Security.AccessControl");
-        private static byte[]? _SystemSecurityAccessControl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net80.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net80.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Cng.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net80.System.Security.Cryptography.Cng");
-        private static byte[]? _SystemSecurityCryptographyCng;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net80.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net80.System.Security.Cryptography");
-        private static byte[]? _SystemSecurityCryptography;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net80.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net80.System.Security.Cryptography.OpenSsl");
-        private static byte[]? _SystemSecurityCryptographyOpenSsl;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net80.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net80.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.dll
-        /// </summary>
-        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net80.System.Security");
-        private static byte[]? _SystemSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net80.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.Windows.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net80.System.Security.Principal.Windows");
-        private static byte[]? _SystemSecurityPrincipalWindows;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net80.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net80.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.ServiceProcess.dll
-        /// </summary>
-        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net80.System.ServiceProcess");
-        private static byte[]? _SystemServiceProcess;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.CodePages.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net80.System.Text.Encoding.CodePages");
-        private static byte[]? _SystemTextEncodingCodePages;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net80.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net80.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encodings.Web.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net80.System.Text.Encodings.Web");
-        private static byte[]? _SystemTextEncodingsWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Json.dll
-        /// </summary>
-        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net80.System.Text.Json");
-        private static byte[]? _SystemTextJson;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net80.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Channels.dll
-        /// </summary>
-        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net80.System.Threading.Channels");
-        private static byte[]? _SystemThreadingChannels;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net80.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net80.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Dataflow.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net80.System.Threading.Tasks.Dataflow");
-        private static byte[]? _SystemThreadingTasksDataflow;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net80.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net80.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net80.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net80.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net80.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net80.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net80.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.Local.dll
-        /// </summary>
-        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net80.System.Transactions.Local");
-        private static byte[]? _SystemTransactionsLocal;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net80.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net80.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Web.HttpUtility.dll
-        /// </summary>
-        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net80.System.Web.HttpUtility");
-        private static byte[]? _SystemWebHttpUtility;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net80.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net80.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net80.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net80.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net80.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net80.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net80.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net80.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net80.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net80.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for WindowsBase.dll
-        /// </summary>
-        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net80.WindowsBase");
-        private static byte[]? _WindowsBase;
-
-
-    }
-}
-
-public static partial class Net80
-{
     public static class ReferenceInfos
     {
 
@@ -4946,6 +3960,992 @@ public static partial class Net80
                 return _all;
             }
         }
+    }
+}
+
+public static partial class Net80
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "net80.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.Core.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasicCore => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasicCore, "net80.Microsoft.VisualBasic.Core");
+        private static byte[]? _MicrosoftVisualBasicCore;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "net80.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "net80.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Registry.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Registry => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Registry, "net80.Microsoft.Win32.Registry");
+        private static byte[]? _MicrosoftWin32Registry;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "net80.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "net80.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "net80.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Buffers.dll
+        /// </summary>
+        public static byte[] SystemBuffers => ResourceLoader.GetOrCreateResource(ref _SystemBuffers, "net80.System.Buffers");
+        private static byte[]? _SystemBuffers;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "net80.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "net80.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Immutable.dll
+        /// </summary>
+        public static byte[] SystemCollectionsImmutable => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsImmutable, "net80.System.Collections.Immutable");
+        private static byte[]? _SystemCollectionsImmutable;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "net80.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "net80.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Annotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelAnnotations, "net80.System.ComponentModel.Annotations");
+        private static byte[]? _SystemComponentModelAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.DataAnnotations.dll
+        /// </summary>
+        public static byte[] SystemComponentModelDataAnnotations => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelDataAnnotations, "net80.System.ComponentModel.DataAnnotations");
+        private static byte[]? _SystemComponentModelDataAnnotations;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "net80.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "net80.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "net80.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "net80.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Configuration.dll
+        /// </summary>
+        public static byte[] SystemConfiguration => ResourceLoader.GetOrCreateResource(ref _SystemConfiguration, "net80.System.Configuration");
+        private static byte[]? _SystemConfiguration;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "net80.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "net80.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "net80.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.DataSetExtensions.dll
+        /// </summary>
+        public static byte[] SystemDataDataSetExtensions => ResourceLoader.GetOrCreateResource(ref _SystemDataDataSetExtensions, "net80.System.Data.DataSetExtensions");
+        private static byte[]? _SystemDataDataSetExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "net80.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "net80.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "net80.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.DiagnosticSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDiagnosticSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDiagnosticSource, "net80.System.Diagnostics.DiagnosticSource");
+        private static byte[]? _SystemDiagnosticsDiagnosticSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "net80.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "net80.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "net80.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "net80.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "net80.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "net80.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "net80.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "net80.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "net80.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "net80.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "net80.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Asn1.dll
+        /// </summary>
+        public static byte[] SystemFormatsAsn1 => ResourceLoader.GetOrCreateResource(ref _SystemFormatsAsn1, "net80.System.Formats.Asn1");
+        private static byte[]? _SystemFormatsAsn1;
+
+        /// <summary>
+        /// The image bytes for System.Formats.Tar.dll
+        /// </summary>
+        public static byte[] SystemFormatsTar => ResourceLoader.GetOrCreateResource(ref _SystemFormatsTar, "net80.System.Formats.Tar");
+        private static byte[]? _SystemFormatsTar;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "net80.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "net80.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "net80.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.Brotli.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionBrotli => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionBrotli, "net80.System.IO.Compression.Brotli");
+        private static byte[]? _SystemIOCompressionBrotli;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "net80.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "net80.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "net80.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "net80.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemAccessControl, "net80.System.IO.FileSystem.AccessControl");
+        private static byte[]? _SystemIOFileSystemAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "net80.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "net80.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "net80.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "net80.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "net80.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "net80.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemIOPipesAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemIOPipesAccessControl, "net80.System.IO.Pipes.AccessControl");
+        private static byte[]? _SystemIOPipesAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "net80.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "net80.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "net80.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "net80.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "net80.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "net80.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Memory.dll
+        /// </summary>
+        public static byte[] SystemMemory => ResourceLoader.GetOrCreateResource(ref _SystemMemory, "net80.System.Memory");
+        private static byte[]? _SystemMemory;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "net80.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "net80.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.Json.dll
+        /// </summary>
+        public static byte[] SystemNetHttpJson => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpJson, "net80.System.Net.Http.Json");
+        private static byte[]? _SystemNetHttpJson;
+
+        /// <summary>
+        /// The image bytes for System.Net.HttpListener.dll
+        /// </summary>
+        public static byte[] SystemNetHttpListener => ResourceLoader.GetOrCreateResource(ref _SystemNetHttpListener, "net80.System.Net.HttpListener");
+        private static byte[]? _SystemNetHttpListener;
+
+        /// <summary>
+        /// The image bytes for System.Net.Mail.dll
+        /// </summary>
+        public static byte[] SystemNetMail => ResourceLoader.GetOrCreateResource(ref _SystemNetMail, "net80.System.Net.Mail");
+        private static byte[]? _SystemNetMail;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "net80.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "net80.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "net80.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "net80.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Quic.dll
+        /// </summary>
+        public static byte[] SystemNetQuic => ResourceLoader.GetOrCreateResource(ref _SystemNetQuic, "net80.System.Net.Quic");
+        private static byte[]? _SystemNetQuic;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "net80.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "net80.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.ServicePoint.dll
+        /// </summary>
+        public static byte[] SystemNetServicePoint => ResourceLoader.GetOrCreateResource(ref _SystemNetServicePoint, "net80.System.Net.ServicePoint");
+        private static byte[]? _SystemNetServicePoint;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "net80.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebClient.dll
+        /// </summary>
+        public static byte[] SystemNetWebClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebClient, "net80.System.Net.WebClient");
+        private static byte[]? _SystemNetWebClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "net80.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebProxy.dll
+        /// </summary>
+        public static byte[] SystemNetWebProxy => ResourceLoader.GetOrCreateResource(ref _SystemNetWebProxy, "net80.System.Net.WebProxy");
+        private static byte[]? _SystemNetWebProxy;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "net80.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "net80.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "net80.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.Vectors.dll
+        /// </summary>
+        public static byte[] SystemNumericsVectors => ResourceLoader.GetOrCreateResource(ref _SystemNumericsVectors, "net80.System.Numerics.Vectors");
+        private static byte[]? _SystemNumericsVectors;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "net80.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.DispatchProxy.dll
+        /// </summary>
+        public static byte[] SystemReflectionDispatchProxy => ResourceLoader.GetOrCreateResource(ref _SystemReflectionDispatchProxy, "net80.System.Reflection.DispatchProxy");
+        private static byte[]? _SystemReflectionDispatchProxy;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "net80.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmit => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmit, "net80.System.Reflection.Emit");
+        private static byte[]? _SystemReflectionEmit;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.ILGeneration.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitILGeneration => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitILGeneration, "net80.System.Reflection.Emit.ILGeneration");
+        private static byte[]? _SystemReflectionEmitILGeneration;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Emit.Lightweight.dll
+        /// </summary>
+        public static byte[] SystemReflectionEmitLightweight => ResourceLoader.GetOrCreateResource(ref _SystemReflectionEmitLightweight, "net80.System.Reflection.Emit.Lightweight");
+        private static byte[]? _SystemReflectionEmitLightweight;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "net80.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Metadata.dll
+        /// </summary>
+        public static byte[] SystemReflectionMetadata => ResourceLoader.GetOrCreateResource(ref _SystemReflectionMetadata, "net80.System.Reflection.Metadata");
+        private static byte[]? _SystemReflectionMetadata;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "net80.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.TypeExtensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionTypeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionTypeExtensions, "net80.System.Reflection.TypeExtensions");
+        private static byte[]? _SystemReflectionTypeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "net80.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "net80.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "net80.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.Unsafe.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesUnsafe => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesUnsafe, "net80.System.Runtime.CompilerServices.Unsafe");
+        private static byte[]? _SystemRuntimeCompilerServicesUnsafe;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "net80.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "net80.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "net80.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "net80.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "net80.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.JavaScript.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesJavaScript => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesJavaScript, "net80.System.Runtime.InteropServices.JavaScript");
+        private static byte[]? _SystemRuntimeInteropServicesJavaScript;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "net80.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Intrinsics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeIntrinsics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeIntrinsics, "net80.System.Runtime.Intrinsics");
+        private static byte[]? _SystemRuntimeIntrinsics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Loader.dll
+        /// </summary>
+        public static byte[] SystemRuntimeLoader => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeLoader, "net80.System.Runtime.Loader");
+        private static byte[]? _SystemRuntimeLoader;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "net80.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "net80.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "net80.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "net80.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "net80.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "net80.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.AccessControl.dll
+        /// </summary>
+        public static byte[] SystemSecurityAccessControl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityAccessControl, "net80.System.Security.AccessControl");
+        private static byte[]? _SystemSecurityAccessControl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "net80.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "net80.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Cng.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCng => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCng, "net80.System.Security.Cryptography.Cng");
+        private static byte[]? _SystemSecurityCryptographyCng;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "net80.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptography => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptography, "net80.System.Security.Cryptography");
+        private static byte[]? _SystemSecurityCryptography;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "net80.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.OpenSsl.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyOpenSsl => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyOpenSsl, "net80.System.Security.Cryptography.OpenSsl");
+        private static byte[]? _SystemSecurityCryptographyOpenSsl;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "net80.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "net80.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.dll
+        /// </summary>
+        public static byte[] SystemSecurity => ResourceLoader.GetOrCreateResource(ref _SystemSecurity, "net80.System.Security");
+        private static byte[]? _SystemSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "net80.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.Windows.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipalWindows => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipalWindows, "net80.System.Security.Principal.Windows");
+        private static byte[]? _SystemSecurityPrincipalWindows;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "net80.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "net80.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.ServiceProcess.dll
+        /// </summary>
+        public static byte[] SystemServiceProcess => ResourceLoader.GetOrCreateResource(ref _SystemServiceProcess, "net80.System.ServiceProcess");
+        private static byte[]? _SystemServiceProcess;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.CodePages.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingCodePages => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingCodePages, "net80.System.Text.Encoding.CodePages");
+        private static byte[]? _SystemTextEncodingCodePages;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "net80.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "net80.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encodings.Web.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingsWeb => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingsWeb, "net80.System.Text.Encodings.Web");
+        private static byte[]? _SystemTextEncodingsWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Json.dll
+        /// </summary>
+        public static byte[] SystemTextJson => ResourceLoader.GetOrCreateResource(ref _SystemTextJson, "net80.System.Text.Json");
+        private static byte[]? _SystemTextJson;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "net80.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Channels.dll
+        /// </summary>
+        public static byte[] SystemThreadingChannels => ResourceLoader.GetOrCreateResource(ref _SystemThreadingChannels, "net80.System.Threading.Channels");
+        private static byte[]? _SystemThreadingChannels;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "net80.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "net80.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Dataflow.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksDataflow => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksDataflow, "net80.System.Threading.Tasks.Dataflow");
+        private static byte[]? _SystemThreadingTasksDataflow;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "net80.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "net80.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "net80.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "net80.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "net80.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "net80.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "net80.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.Local.dll
+        /// </summary>
+        public static byte[] SystemTransactionsLocal => ResourceLoader.GetOrCreateResource(ref _SystemTransactionsLocal, "net80.System.Transactions.Local");
+        private static byte[]? _SystemTransactionsLocal;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "net80.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "net80.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Web.HttpUtility.dll
+        /// </summary>
+        public static byte[] SystemWebHttpUtility => ResourceLoader.GetOrCreateResource(ref _SystemWebHttpUtility, "net80.System.Web.HttpUtility");
+        private static byte[]? _SystemWebHttpUtility;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "net80.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "net80.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "net80.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "net80.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "net80.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "net80.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "net80.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "net80.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "net80.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "net80.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for WindowsBase.dll
+        /// </summary>
+        public static byte[] WindowsBase => ResourceLoader.GetOrCreateResource(ref _WindowsBase, "net80.WindowsBase");
+        private static byte[]? _WindowsBase;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
@@ -9,826 +9,6 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class NetStandard20
 {
-    public static class ExtraReferenceInfos
-    {
-
-        /// <summary>
-        /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
-        /// </summary>
-        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
-
-        /// <summary>
-        /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
-
-        /// <summary>
-        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, NetStandard20.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("619062a8-972f-4ae5-bbee-e36ac541d14f"));
-        private static ImmutableArray<ReferenceInfo> _all;
-        public static ImmutableArray<ReferenceInfo> All
-        {
-            get
-            {
-                if (_all.IsDefault)
-                {
-                    _all =
-                    [
-                        MicrosoftCSharp,
-                        MicrosoftVisualBasic,
-                        SystemThreadingTasksExtensions,
-                    ];
-                }
-                return _all;
-            }
-        }
-
-        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
-    }
-}
-
-public static partial class NetStandard20
-{
-    public static class ExtraReferences
-    {
-        private static PortableExecutableReference? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The <see cref="PortableExecutableReference"/> for Microsoft.CSharp.dll
-        /// </summary>
-        public static PortableExecutableReference MicrosoftCSharp
-        {
-            get
-            {
-                if (_MicrosoftCSharp is null)
-                {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
-                }
-                return _MicrosoftCSharp;
-            }
-        }
-
-        private static PortableExecutableReference? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The <see cref="PortableExecutableReference"/> for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static PortableExecutableReference MicrosoftVisualBasic
-        {
-            get
-            {
-                if (_MicrosoftVisualBasic is null)
-                {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
-                }
-                return _MicrosoftVisualBasic;
-            }
-        }
-
-        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
-
-        /// <summary>
-        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static PortableExecutableReference SystemThreadingTasksExtensions
-        {
-            get
-            {
-                if (_SystemThreadingTasksExtensions is null)
-                {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
-                }
-                return _SystemThreadingTasksExtensions;
-            }
-        }
-
-        private static ImmutableArray<PortableExecutableReference> _all;
-        public static ImmutableArray<PortableExecutableReference> All
-        {
-            get
-            {
-                if (_all.IsDefault)
-                {
-                    _all =
-                    [
-                        MicrosoftCSharp,
-                        MicrosoftVisualBasic,
-                        SystemThreadingTasksExtensions,
-                    ];
-                }
-                return _all;
-            }
-        }
-    }
-}
-
-public static partial class NetStandard20
-{
-    public static class Resources
-    {
-        /// <summary>
-        /// The image bytes for Microsoft.Win32.Primitives.dll
-        /// </summary>
-        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netstandard20.Microsoft.Win32.Primitives");
-        private static byte[]? _MicrosoftWin32Primitives;
-
-        /// <summary>
-        /// The image bytes for mscorlib.dll
-        /// </summary>
-        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netstandard20.mscorlib");
-        private static byte[]? _mscorlib;
-
-        /// <summary>
-        /// The image bytes for netstandard.dll
-        /// </summary>
-        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netstandard20.netstandard");
-        private static byte[]? _netstandard;
-
-        /// <summary>
-        /// The image bytes for System.AppContext.dll
-        /// </summary>
-        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netstandard20.System.AppContext");
-        private static byte[]? _SystemAppContext;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Concurrent.dll
-        /// </summary>
-        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netstandard20.System.Collections.Concurrent");
-        private static byte[]? _SystemCollectionsConcurrent;
-
-        /// <summary>
-        /// The image bytes for System.Collections.dll
-        /// </summary>
-        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netstandard20.System.Collections");
-        private static byte[]? _SystemCollections;
-
-        /// <summary>
-        /// The image bytes for System.Collections.NonGeneric.dll
-        /// </summary>
-        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "netstandard20.System.Collections.NonGeneric");
-        private static byte[]? _SystemCollectionsNonGeneric;
-
-        /// <summary>
-        /// The image bytes for System.Collections.Specialized.dll
-        /// </summary>
-        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "netstandard20.System.Collections.Specialized");
-        private static byte[]? _SystemCollectionsSpecialized;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Composition.dll
-        /// </summary>
-        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "netstandard20.System.ComponentModel.Composition");
-        private static byte[]? _SystemComponentModelComposition;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.dll
-        /// </summary>
-        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "netstandard20.System.ComponentModel");
-        private static byte[]? _SystemComponentModel;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
-        /// </summary>
-        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "netstandard20.System.ComponentModel.EventBasedAsync");
-        private static byte[]? _SystemComponentModelEventBasedAsync;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.Primitives.dll
-        /// </summary>
-        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "netstandard20.System.ComponentModel.Primitives");
-        private static byte[]? _SystemComponentModelPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.ComponentModel.TypeConverter.dll
-        /// </summary>
-        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "netstandard20.System.ComponentModel.TypeConverter");
-        private static byte[]? _SystemComponentModelTypeConverter;
-
-        /// <summary>
-        /// The image bytes for System.Console.dll
-        /// </summary>
-        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netstandard20.System.Console");
-        private static byte[]? _SystemConsole;
-
-        /// <summary>
-        /// The image bytes for System.Core.dll
-        /// </summary>
-        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netstandard20.System.Core");
-        private static byte[]? _SystemCore;
-
-        /// <summary>
-        /// The image bytes for System.Data.Common.dll
-        /// </summary>
-        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "netstandard20.System.Data.Common");
-        private static byte[]? _SystemDataCommon;
-
-        /// <summary>
-        /// The image bytes for System.Data.dll
-        /// </summary>
-        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "netstandard20.System.Data");
-        private static byte[]? _SystemData;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Contracts.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "netstandard20.System.Diagnostics.Contracts");
-        private static byte[]? _SystemDiagnosticsContracts;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Debug.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netstandard20.System.Diagnostics.Debug");
-        private static byte[]? _SystemDiagnosticsDebug;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netstandard20.System.Diagnostics.FileVersionInfo");
-        private static byte[]? _SystemDiagnosticsFileVersionInfo;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Process.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netstandard20.System.Diagnostics.Process");
-        private static byte[]? _SystemDiagnosticsProcess;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.StackTrace.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "netstandard20.System.Diagnostics.StackTrace");
-        private static byte[]? _SystemDiagnosticsStackTrace;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "netstandard20.System.Diagnostics.TextWriterTraceListener");
-        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tools.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netstandard20.System.Diagnostics.Tools");
-        private static byte[]? _SystemDiagnosticsTools;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.TraceSource.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "netstandard20.System.Diagnostics.TraceSource");
-        private static byte[]? _SystemDiagnosticsTraceSource;
-
-        /// <summary>
-        /// The image bytes for System.Diagnostics.Tracing.dll
-        /// </summary>
-        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netstandard20.System.Diagnostics.Tracing");
-        private static byte[]? _SystemDiagnosticsTracing;
-
-        /// <summary>
-        /// The image bytes for System.dll
-        /// </summary>
-        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netstandard20.System");
-        private static byte[]? _System;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.dll
-        /// </summary>
-        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "netstandard20.System.Drawing");
-        private static byte[]? _SystemDrawing;
-
-        /// <summary>
-        /// The image bytes for System.Drawing.Primitives.dll
-        /// </summary>
-        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "netstandard20.System.Drawing.Primitives");
-        private static byte[]? _SystemDrawingPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Dynamic.Runtime.dll
-        /// </summary>
-        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "netstandard20.System.Dynamic.Runtime");
-        private static byte[]? _SystemDynamicRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Calendars.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netstandard20.System.Globalization.Calendars");
-        private static byte[]? _SystemGlobalizationCalendars;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.dll
-        /// </summary>
-        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netstandard20.System.Globalization");
-        private static byte[]? _SystemGlobalization;
-
-        /// <summary>
-        /// The image bytes for System.Globalization.Extensions.dll
-        /// </summary>
-        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "netstandard20.System.Globalization.Extensions");
-        private static byte[]? _SystemGlobalizationExtensions;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.dll
-        /// </summary>
-        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netstandard20.System.IO.Compression");
-        private static byte[]? _SystemIOCompression;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "netstandard20.System.IO.Compression.FileSystem");
-        private static byte[]? _SystemIOCompressionFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.Compression.ZipFile.dll
-        /// </summary>
-        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netstandard20.System.IO.Compression.ZipFile");
-        private static byte[]? _SystemIOCompressionZipFile;
-
-        /// <summary>
-        /// The image bytes for System.IO.dll
-        /// </summary>
-        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netstandard20.System.IO");
-        private static byte[]? _SystemIO;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netstandard20.System.IO.FileSystem");
-        private static byte[]? _SystemIOFileSystem;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "netstandard20.System.IO.FileSystem.DriveInfo");
-        private static byte[]? _SystemIOFileSystemDriveInfo;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Primitives.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netstandard20.System.IO.FileSystem.Primitives");
-        private static byte[]? _SystemIOFileSystemPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.IO.FileSystem.Watcher.dll
-        /// </summary>
-        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "netstandard20.System.IO.FileSystem.Watcher");
-        private static byte[]? _SystemIOFileSystemWatcher;
-
-        /// <summary>
-        /// The image bytes for System.IO.IsolatedStorage.dll
-        /// </summary>
-        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "netstandard20.System.IO.IsolatedStorage");
-        private static byte[]? _SystemIOIsolatedStorage;
-
-        /// <summary>
-        /// The image bytes for System.IO.MemoryMappedFiles.dll
-        /// </summary>
-        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "netstandard20.System.IO.MemoryMappedFiles");
-        private static byte[]? _SystemIOMemoryMappedFiles;
-
-        /// <summary>
-        /// The image bytes for System.IO.Pipes.dll
-        /// </summary>
-        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "netstandard20.System.IO.Pipes");
-        private static byte[]? _SystemIOPipes;
-
-        /// <summary>
-        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
-        /// </summary>
-        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "netstandard20.System.IO.UnmanagedMemoryStream");
-        private static byte[]? _SystemIOUnmanagedMemoryStream;
-
-        /// <summary>
-        /// The image bytes for System.Linq.dll
-        /// </summary>
-        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netstandard20.System.Linq");
-        private static byte[]? _SystemLinq;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Expressions.dll
-        /// </summary>
-        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netstandard20.System.Linq.Expressions");
-        private static byte[]? _SystemLinqExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Parallel.dll
-        /// </summary>
-        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "netstandard20.System.Linq.Parallel");
-        private static byte[]? _SystemLinqParallel;
-
-        /// <summary>
-        /// The image bytes for System.Linq.Queryable.dll
-        /// </summary>
-        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "netstandard20.System.Linq.Queryable");
-        private static byte[]? _SystemLinqQueryable;
-
-        /// <summary>
-        /// The image bytes for System.Net.dll
-        /// </summary>
-        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "netstandard20.System.Net");
-        private static byte[]? _SystemNet;
-
-        /// <summary>
-        /// The image bytes for System.Net.Http.dll
-        /// </summary>
-        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netstandard20.System.Net.Http");
-        private static byte[]? _SystemNetHttp;
-
-        /// <summary>
-        /// The image bytes for System.Net.NameResolution.dll
-        /// </summary>
-        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "netstandard20.System.Net.NameResolution");
-        private static byte[]? _SystemNetNameResolution;
-
-        /// <summary>
-        /// The image bytes for System.Net.NetworkInformation.dll
-        /// </summary>
-        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "netstandard20.System.Net.NetworkInformation");
-        private static byte[]? _SystemNetNetworkInformation;
-
-        /// <summary>
-        /// The image bytes for System.Net.Ping.dll
-        /// </summary>
-        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "netstandard20.System.Net.Ping");
-        private static byte[]? _SystemNetPing;
-
-        /// <summary>
-        /// The image bytes for System.Net.Primitives.dll
-        /// </summary>
-        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netstandard20.System.Net.Primitives");
-        private static byte[]? _SystemNetPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Net.Requests.dll
-        /// </summary>
-        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "netstandard20.System.Net.Requests");
-        private static byte[]? _SystemNetRequests;
-
-        /// <summary>
-        /// The image bytes for System.Net.Security.dll
-        /// </summary>
-        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netstandard20.System.Net.Security");
-        private static byte[]? _SystemNetSecurity;
-
-        /// <summary>
-        /// The image bytes for System.Net.Sockets.dll
-        /// </summary>
-        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netstandard20.System.Net.Sockets");
-        private static byte[]? _SystemNetSockets;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebHeaderCollection.dll
-        /// </summary>
-        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "netstandard20.System.Net.WebHeaderCollection");
-        private static byte[]? _SystemNetWebHeaderCollection;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.Client.dll
-        /// </summary>
-        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "netstandard20.System.Net.WebSockets.Client");
-        private static byte[]? _SystemNetWebSocketsClient;
-
-        /// <summary>
-        /// The image bytes for System.Net.WebSockets.dll
-        /// </summary>
-        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "netstandard20.System.Net.WebSockets");
-        private static byte[]? _SystemNetWebSockets;
-
-        /// <summary>
-        /// The image bytes for System.Numerics.dll
-        /// </summary>
-        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "netstandard20.System.Numerics");
-        private static byte[]? _SystemNumerics;
-
-        /// <summary>
-        /// The image bytes for System.ObjectModel.dll
-        /// </summary>
-        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netstandard20.System.ObjectModel");
-        private static byte[]? _SystemObjectModel;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.dll
-        /// </summary>
-        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netstandard20.System.Reflection");
-        private static byte[]? _SystemReflection;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Extensions.dll
-        /// </summary>
-        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netstandard20.System.Reflection.Extensions");
-        private static byte[]? _SystemReflectionExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Reflection.Primitives.dll
-        /// </summary>
-        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netstandard20.System.Reflection.Primitives");
-        private static byte[]? _SystemReflectionPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Reader.dll
-        /// </summary>
-        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "netstandard20.System.Resources.Reader");
-        private static byte[]? _SystemResourcesReader;
-
-        /// <summary>
-        /// The image bytes for System.Resources.ResourceManager.dll
-        /// </summary>
-        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netstandard20.System.Resources.ResourceManager");
-        private static byte[]? _SystemResourcesResourceManager;
-
-        /// <summary>
-        /// The image bytes for System.Resources.Writer.dll
-        /// </summary>
-        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "netstandard20.System.Resources.Writer");
-        private static byte[]? _SystemResourcesWriter;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
-        /// </summary>
-        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "netstandard20.System.Runtime.CompilerServices.VisualC");
-        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.dll
-        /// </summary>
-        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netstandard20.System.Runtime");
-        private static byte[]? _SystemRuntime;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Extensions.dll
-        /// </summary>
-        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netstandard20.System.Runtime.Extensions");
-        private static byte[]? _SystemRuntimeExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Handles.dll
-        /// </summary>
-        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netstandard20.System.Runtime.Handles");
-        private static byte[]? _SystemRuntimeHandles;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netstandard20.System.Runtime.InteropServices");
-        private static byte[]? _SystemRuntimeInteropServices;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
-        /// </summary>
-        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netstandard20.System.Runtime.InteropServices.RuntimeInformation");
-        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Numerics.dll
-        /// </summary>
-        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netstandard20.System.Runtime.Numerics");
-        private static byte[]? _SystemRuntimeNumerics;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "netstandard20.System.Runtime.Serialization");
-        private static byte[]? _SystemRuntimeSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Formatters.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "netstandard20.System.Runtime.Serialization.Formatters");
-        private static byte[]? _SystemRuntimeSerializationFormatters;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Json.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "netstandard20.System.Runtime.Serialization.Json");
-        private static byte[]? _SystemRuntimeSerializationJson;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Primitives.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netstandard20.System.Runtime.Serialization.Primitives");
-        private static byte[]? _SystemRuntimeSerializationPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Runtime.Serialization.Xml.dll
-        /// </summary>
-        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "netstandard20.System.Runtime.Serialization.Xml");
-        private static byte[]? _SystemRuntimeSerializationXml;
-
-        /// <summary>
-        /// The image bytes for System.Security.Claims.dll
-        /// </summary>
-        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netstandard20.System.Security.Claims");
-        private static byte[]? _SystemSecurityClaims;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Algorithms.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netstandard20.System.Security.Cryptography.Algorithms");
-        private static byte[]? _SystemSecurityCryptographyAlgorithms;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Csp.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netstandard20.System.Security.Cryptography.Csp");
-        private static byte[]? _SystemSecurityCryptographyCsp;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Encoding.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netstandard20.System.Security.Cryptography.Encoding");
-        private static byte[]? _SystemSecurityCryptographyEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.Primitives.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netstandard20.System.Security.Cryptography.Primitives");
-        private static byte[]? _SystemSecurityCryptographyPrimitives;
-
-        /// <summary>
-        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
-        /// </summary>
-        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netstandard20.System.Security.Cryptography.X509Certificates");
-        private static byte[]? _SystemSecurityCryptographyX509Certificates;
-
-        /// <summary>
-        /// The image bytes for System.Security.Principal.dll
-        /// </summary>
-        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netstandard20.System.Security.Principal");
-        private static byte[]? _SystemSecurityPrincipal;
-
-        /// <summary>
-        /// The image bytes for System.Security.SecureString.dll
-        /// </summary>
-        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "netstandard20.System.Security.SecureString");
-        private static byte[]? _SystemSecuritySecureString;
-
-        /// <summary>
-        /// The image bytes for System.ServiceModel.Web.dll
-        /// </summary>
-        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "netstandard20.System.ServiceModel.Web");
-        private static byte[]? _SystemServiceModelWeb;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.dll
-        /// </summary>
-        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netstandard20.System.Text.Encoding");
-        private static byte[]? _SystemTextEncoding;
-
-        /// <summary>
-        /// The image bytes for System.Text.Encoding.Extensions.dll
-        /// </summary>
-        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netstandard20.System.Text.Encoding.Extensions");
-        private static byte[]? _SystemTextEncodingExtensions;
-
-        /// <summary>
-        /// The image bytes for System.Text.RegularExpressions.dll
-        /// </summary>
-        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netstandard20.System.Text.RegularExpressions");
-        private static byte[]? _SystemTextRegularExpressions;
-
-        /// <summary>
-        /// The image bytes for System.Threading.dll
-        /// </summary>
-        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netstandard20.System.Threading");
-        private static byte[]? _SystemThreading;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Overlapped.dll
-        /// </summary>
-        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "netstandard20.System.Threading.Overlapped");
-        private static byte[]? _SystemThreadingOverlapped;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netstandard20.System.Threading.Tasks");
-        private static byte[]? _SystemThreadingTasks;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Parallel.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "netstandard20.System.Threading.Tasks.Parallel");
-        private static byte[]? _SystemThreadingTasksParallel;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Thread.dll
-        /// </summary>
-        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "netstandard20.System.Threading.Thread");
-        private static byte[]? _SystemThreadingThread;
-
-        /// <summary>
-        /// The image bytes for System.Threading.ThreadPool.dll
-        /// </summary>
-        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "netstandard20.System.Threading.ThreadPool");
-        private static byte[]? _SystemThreadingThreadPool;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Timer.dll
-        /// </summary>
-        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netstandard20.System.Threading.Timer");
-        private static byte[]? _SystemThreadingTimer;
-
-        /// <summary>
-        /// The image bytes for System.Transactions.dll
-        /// </summary>
-        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "netstandard20.System.Transactions");
-        private static byte[]? _SystemTransactions;
-
-        /// <summary>
-        /// The image bytes for System.ValueTuple.dll
-        /// </summary>
-        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netstandard20.System.ValueTuple");
-        private static byte[]? _SystemValueTuple;
-
-        /// <summary>
-        /// The image bytes for System.Web.dll
-        /// </summary>
-        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "netstandard20.System.Web");
-        private static byte[]? _SystemWeb;
-
-        /// <summary>
-        /// The image bytes for System.Windows.dll
-        /// </summary>
-        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "netstandard20.System.Windows");
-        private static byte[]? _SystemWindows;
-
-        /// <summary>
-        /// The image bytes for System.Xml.dll
-        /// </summary>
-        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "netstandard20.System.Xml");
-        private static byte[]? _SystemXml;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Linq.dll
-        /// </summary>
-        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "netstandard20.System.Xml.Linq");
-        private static byte[]? _SystemXmlLinq;
-
-        /// <summary>
-        /// The image bytes for System.Xml.ReaderWriter.dll
-        /// </summary>
-        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netstandard20.System.Xml.ReaderWriter");
-        private static byte[]? _SystemXmlReaderWriter;
-
-        /// <summary>
-        /// The image bytes for System.Xml.Serialization.dll
-        /// </summary>
-        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "netstandard20.System.Xml.Serialization");
-        private static byte[]? _SystemXmlSerialization;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netstandard20.System.Xml.XDocument");
-        private static byte[]? _SystemXmlXDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netstandard20.System.Xml.XmlDocument");
-        private static byte[]? _SystemXmlXmlDocument;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XmlSerializer.dll
-        /// </summary>
-        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "netstandard20.System.Xml.XmlSerializer");
-        private static byte[]? _SystemXmlXmlSerializer;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.dll
-        /// </summary>
-        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netstandard20.System.Xml.XPath");
-        private static byte[]? _SystemXmlXPath;
-
-        /// <summary>
-        /// The image bytes for System.Xml.XPath.XDocument.dll
-        /// </summary>
-        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard20.System.Xml.XPath.XDocument");
-        private static byte[]? _SystemXmlXPathXDocument;
-
-        /// <summary>
-        /// The image bytes for Microsoft.CSharp.dll
-        /// </summary>
-        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netstandard20.Microsoft.CSharp");
-        private static byte[]? _MicrosoftCSharp;
-
-        /// <summary>
-        /// The image bytes for Microsoft.VisualBasic.dll
-        /// </summary>
-        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netstandard20.Microsoft.VisualBasic");
-        private static byte[]? _MicrosoftVisualBasic;
-
-        /// <summary>
-        /// The image bytes for System.Threading.Tasks.Extensions.dll
-        /// </summary>
-        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard20.System.Threading.Tasks.Extensions");
-        private static byte[]? _SystemThreadingTasksExtensions;
-
-
-    }
-}
-
-public static partial class NetStandard20
-{
     public static class ReferenceInfos
     {
 
@@ -3580,6 +2760,826 @@ public static partial class NetStandard20
                 return _all;
             }
         }
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class ExtraReferenceInfos
+    {
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, NetStandard20.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("619062a8-972f-4ae5-bbee-e36ac541d14f"));
+        private static ImmutableArray<ReferenceInfo> _all;
+        public static ImmutableArray<ReferenceInfo> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+
+        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class ExtraReferences
+    {
+        private static PortableExecutableReference? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftCSharp
+        {
+            get
+            {
+                if (_MicrosoftCSharp is null)
+                {
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
+                }
+                return _MicrosoftCSharp;
+            }
+        }
+
+        private static PortableExecutableReference? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftVisualBasic
+        {
+            get
+            {
+                if (_MicrosoftVisualBasic is null)
+                {
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
+                }
+                return _MicrosoftVisualBasic;
+            }
+        }
+
+        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static PortableExecutableReference SystemThreadingTasksExtensions
+        {
+            get
+            {
+                if (_SystemThreadingTasksExtensions is null)
+                {
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
+                }
+                return _SystemThreadingTasksExtensions;
+            }
+        }
+
+        private static ImmutableArray<PortableExecutableReference> _all;
+        public static ImmutableArray<PortableExecutableReference> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class Resources
+    {
+        /// <summary>
+        /// The image bytes for Microsoft.Win32.Primitives.dll
+        /// </summary>
+        public static byte[] MicrosoftWin32Primitives => ResourceLoader.GetOrCreateResource(ref _MicrosoftWin32Primitives, "netstandard20.Microsoft.Win32.Primitives");
+        private static byte[]? _MicrosoftWin32Primitives;
+
+        /// <summary>
+        /// The image bytes for mscorlib.dll
+        /// </summary>
+        public static byte[] mscorlib => ResourceLoader.GetOrCreateResource(ref _mscorlib, "netstandard20.mscorlib");
+        private static byte[]? _mscorlib;
+
+        /// <summary>
+        /// The image bytes for netstandard.dll
+        /// </summary>
+        public static byte[] netstandard => ResourceLoader.GetOrCreateResource(ref _netstandard, "netstandard20.netstandard");
+        private static byte[]? _netstandard;
+
+        /// <summary>
+        /// The image bytes for System.AppContext.dll
+        /// </summary>
+        public static byte[] SystemAppContext => ResourceLoader.GetOrCreateResource(ref _SystemAppContext, "netstandard20.System.AppContext");
+        private static byte[]? _SystemAppContext;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Concurrent.dll
+        /// </summary>
+        public static byte[] SystemCollectionsConcurrent => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsConcurrent, "netstandard20.System.Collections.Concurrent");
+        private static byte[]? _SystemCollectionsConcurrent;
+
+        /// <summary>
+        /// The image bytes for System.Collections.dll
+        /// </summary>
+        public static byte[] SystemCollections => ResourceLoader.GetOrCreateResource(ref _SystemCollections, "netstandard20.System.Collections");
+        private static byte[]? _SystemCollections;
+
+        /// <summary>
+        /// The image bytes for System.Collections.NonGeneric.dll
+        /// </summary>
+        public static byte[] SystemCollectionsNonGeneric => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsNonGeneric, "netstandard20.System.Collections.NonGeneric");
+        private static byte[]? _SystemCollectionsNonGeneric;
+
+        /// <summary>
+        /// The image bytes for System.Collections.Specialized.dll
+        /// </summary>
+        public static byte[] SystemCollectionsSpecialized => ResourceLoader.GetOrCreateResource(ref _SystemCollectionsSpecialized, "netstandard20.System.Collections.Specialized");
+        private static byte[]? _SystemCollectionsSpecialized;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Composition.dll
+        /// </summary>
+        public static byte[] SystemComponentModelComposition => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelComposition, "netstandard20.System.ComponentModel.Composition");
+        private static byte[]? _SystemComponentModelComposition;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.dll
+        /// </summary>
+        public static byte[] SystemComponentModel => ResourceLoader.GetOrCreateResource(ref _SystemComponentModel, "netstandard20.System.ComponentModel");
+        private static byte[]? _SystemComponentModel;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.EventBasedAsync.dll
+        /// </summary>
+        public static byte[] SystemComponentModelEventBasedAsync => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelEventBasedAsync, "netstandard20.System.ComponentModel.EventBasedAsync");
+        private static byte[]? _SystemComponentModelEventBasedAsync;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.Primitives.dll
+        /// </summary>
+        public static byte[] SystemComponentModelPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelPrimitives, "netstandard20.System.ComponentModel.Primitives");
+        private static byte[]? _SystemComponentModelPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.ComponentModel.TypeConverter.dll
+        /// </summary>
+        public static byte[] SystemComponentModelTypeConverter => ResourceLoader.GetOrCreateResource(ref _SystemComponentModelTypeConverter, "netstandard20.System.ComponentModel.TypeConverter");
+        private static byte[]? _SystemComponentModelTypeConverter;
+
+        /// <summary>
+        /// The image bytes for System.Console.dll
+        /// </summary>
+        public static byte[] SystemConsole => ResourceLoader.GetOrCreateResource(ref _SystemConsole, "netstandard20.System.Console");
+        private static byte[]? _SystemConsole;
+
+        /// <summary>
+        /// The image bytes for System.Core.dll
+        /// </summary>
+        public static byte[] SystemCore => ResourceLoader.GetOrCreateResource(ref _SystemCore, "netstandard20.System.Core");
+        private static byte[]? _SystemCore;
+
+        /// <summary>
+        /// The image bytes for System.Data.Common.dll
+        /// </summary>
+        public static byte[] SystemDataCommon => ResourceLoader.GetOrCreateResource(ref _SystemDataCommon, "netstandard20.System.Data.Common");
+        private static byte[]? _SystemDataCommon;
+
+        /// <summary>
+        /// The image bytes for System.Data.dll
+        /// </summary>
+        public static byte[] SystemData => ResourceLoader.GetOrCreateResource(ref _SystemData, "netstandard20.System.Data");
+        private static byte[]? _SystemData;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Contracts.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsContracts => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsContracts, "netstandard20.System.Diagnostics.Contracts");
+        private static byte[]? _SystemDiagnosticsContracts;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Debug.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsDebug => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsDebug, "netstandard20.System.Diagnostics.Debug");
+        private static byte[]? _SystemDiagnosticsDebug;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.FileVersionInfo.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsFileVersionInfo => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsFileVersionInfo, "netstandard20.System.Diagnostics.FileVersionInfo");
+        private static byte[]? _SystemDiagnosticsFileVersionInfo;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Process.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsProcess => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsProcess, "netstandard20.System.Diagnostics.Process");
+        private static byte[]? _SystemDiagnosticsProcess;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.StackTrace.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsStackTrace => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsStackTrace, "netstandard20.System.Diagnostics.StackTrace");
+        private static byte[]? _SystemDiagnosticsStackTrace;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TextWriterTraceListener.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTextWriterTraceListener => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTextWriterTraceListener, "netstandard20.System.Diagnostics.TextWriterTraceListener");
+        private static byte[]? _SystemDiagnosticsTextWriterTraceListener;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tools.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTools => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTools, "netstandard20.System.Diagnostics.Tools");
+        private static byte[]? _SystemDiagnosticsTools;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.TraceSource.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTraceSource => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTraceSource, "netstandard20.System.Diagnostics.TraceSource");
+        private static byte[]? _SystemDiagnosticsTraceSource;
+
+        /// <summary>
+        /// The image bytes for System.Diagnostics.Tracing.dll
+        /// </summary>
+        public static byte[] SystemDiagnosticsTracing => ResourceLoader.GetOrCreateResource(ref _SystemDiagnosticsTracing, "netstandard20.System.Diagnostics.Tracing");
+        private static byte[]? _SystemDiagnosticsTracing;
+
+        /// <summary>
+        /// The image bytes for System.dll
+        /// </summary>
+        public static byte[] System => ResourceLoader.GetOrCreateResource(ref _System, "netstandard20.System");
+        private static byte[]? _System;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.dll
+        /// </summary>
+        public static byte[] SystemDrawing => ResourceLoader.GetOrCreateResource(ref _SystemDrawing, "netstandard20.System.Drawing");
+        private static byte[]? _SystemDrawing;
+
+        /// <summary>
+        /// The image bytes for System.Drawing.Primitives.dll
+        /// </summary>
+        public static byte[] SystemDrawingPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemDrawingPrimitives, "netstandard20.System.Drawing.Primitives");
+        private static byte[]? _SystemDrawingPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Dynamic.Runtime.dll
+        /// </summary>
+        public static byte[] SystemDynamicRuntime => ResourceLoader.GetOrCreateResource(ref _SystemDynamicRuntime, "netstandard20.System.Dynamic.Runtime");
+        private static byte[]? _SystemDynamicRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Calendars.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationCalendars => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationCalendars, "netstandard20.System.Globalization.Calendars");
+        private static byte[]? _SystemGlobalizationCalendars;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.dll
+        /// </summary>
+        public static byte[] SystemGlobalization => ResourceLoader.GetOrCreateResource(ref _SystemGlobalization, "netstandard20.System.Globalization");
+        private static byte[]? _SystemGlobalization;
+
+        /// <summary>
+        /// The image bytes for System.Globalization.Extensions.dll
+        /// </summary>
+        public static byte[] SystemGlobalizationExtensions => ResourceLoader.GetOrCreateResource(ref _SystemGlobalizationExtensions, "netstandard20.System.Globalization.Extensions");
+        private static byte[]? _SystemGlobalizationExtensions;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.dll
+        /// </summary>
+        public static byte[] SystemIOCompression => ResourceLoader.GetOrCreateResource(ref _SystemIOCompression, "netstandard20.System.IO.Compression");
+        private static byte[]? _SystemIOCompression;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionFileSystem, "netstandard20.System.IO.Compression.FileSystem");
+        private static byte[]? _SystemIOCompressionFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.Compression.ZipFile.dll
+        /// </summary>
+        public static byte[] SystemIOCompressionZipFile => ResourceLoader.GetOrCreateResource(ref _SystemIOCompressionZipFile, "netstandard20.System.IO.Compression.ZipFile");
+        private static byte[]? _SystemIOCompressionZipFile;
+
+        /// <summary>
+        /// The image bytes for System.IO.dll
+        /// </summary>
+        public static byte[] SystemIO => ResourceLoader.GetOrCreateResource(ref _SystemIO, "netstandard20.System.IO");
+        private static byte[]? _SystemIO;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystem => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystem, "netstandard20.System.IO.FileSystem");
+        private static byte[]? _SystemIOFileSystem;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.DriveInfo.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemDriveInfo => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemDriveInfo, "netstandard20.System.IO.FileSystem.DriveInfo");
+        private static byte[]? _SystemIOFileSystemDriveInfo;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Primitives.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemPrimitives, "netstandard20.System.IO.FileSystem.Primitives");
+        private static byte[]? _SystemIOFileSystemPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.IO.FileSystem.Watcher.dll
+        /// </summary>
+        public static byte[] SystemIOFileSystemWatcher => ResourceLoader.GetOrCreateResource(ref _SystemIOFileSystemWatcher, "netstandard20.System.IO.FileSystem.Watcher");
+        private static byte[]? _SystemIOFileSystemWatcher;
+
+        /// <summary>
+        /// The image bytes for System.IO.IsolatedStorage.dll
+        /// </summary>
+        public static byte[] SystemIOIsolatedStorage => ResourceLoader.GetOrCreateResource(ref _SystemIOIsolatedStorage, "netstandard20.System.IO.IsolatedStorage");
+        private static byte[]? _SystemIOIsolatedStorage;
+
+        /// <summary>
+        /// The image bytes for System.IO.MemoryMappedFiles.dll
+        /// </summary>
+        public static byte[] SystemIOMemoryMappedFiles => ResourceLoader.GetOrCreateResource(ref _SystemIOMemoryMappedFiles, "netstandard20.System.IO.MemoryMappedFiles");
+        private static byte[]? _SystemIOMemoryMappedFiles;
+
+        /// <summary>
+        /// The image bytes for System.IO.Pipes.dll
+        /// </summary>
+        public static byte[] SystemIOPipes => ResourceLoader.GetOrCreateResource(ref _SystemIOPipes, "netstandard20.System.IO.Pipes");
+        private static byte[]? _SystemIOPipes;
+
+        /// <summary>
+        /// The image bytes for System.IO.UnmanagedMemoryStream.dll
+        /// </summary>
+        public static byte[] SystemIOUnmanagedMemoryStream => ResourceLoader.GetOrCreateResource(ref _SystemIOUnmanagedMemoryStream, "netstandard20.System.IO.UnmanagedMemoryStream");
+        private static byte[]? _SystemIOUnmanagedMemoryStream;
+
+        /// <summary>
+        /// The image bytes for System.Linq.dll
+        /// </summary>
+        public static byte[] SystemLinq => ResourceLoader.GetOrCreateResource(ref _SystemLinq, "netstandard20.System.Linq");
+        private static byte[]? _SystemLinq;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Expressions.dll
+        /// </summary>
+        public static byte[] SystemLinqExpressions => ResourceLoader.GetOrCreateResource(ref _SystemLinqExpressions, "netstandard20.System.Linq.Expressions");
+        private static byte[]? _SystemLinqExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Parallel.dll
+        /// </summary>
+        public static byte[] SystemLinqParallel => ResourceLoader.GetOrCreateResource(ref _SystemLinqParallel, "netstandard20.System.Linq.Parallel");
+        private static byte[]? _SystemLinqParallel;
+
+        /// <summary>
+        /// The image bytes for System.Linq.Queryable.dll
+        /// </summary>
+        public static byte[] SystemLinqQueryable => ResourceLoader.GetOrCreateResource(ref _SystemLinqQueryable, "netstandard20.System.Linq.Queryable");
+        private static byte[]? _SystemLinqQueryable;
+
+        /// <summary>
+        /// The image bytes for System.Net.dll
+        /// </summary>
+        public static byte[] SystemNet => ResourceLoader.GetOrCreateResource(ref _SystemNet, "netstandard20.System.Net");
+        private static byte[]? _SystemNet;
+
+        /// <summary>
+        /// The image bytes for System.Net.Http.dll
+        /// </summary>
+        public static byte[] SystemNetHttp => ResourceLoader.GetOrCreateResource(ref _SystemNetHttp, "netstandard20.System.Net.Http");
+        private static byte[]? _SystemNetHttp;
+
+        /// <summary>
+        /// The image bytes for System.Net.NameResolution.dll
+        /// </summary>
+        public static byte[] SystemNetNameResolution => ResourceLoader.GetOrCreateResource(ref _SystemNetNameResolution, "netstandard20.System.Net.NameResolution");
+        private static byte[]? _SystemNetNameResolution;
+
+        /// <summary>
+        /// The image bytes for System.Net.NetworkInformation.dll
+        /// </summary>
+        public static byte[] SystemNetNetworkInformation => ResourceLoader.GetOrCreateResource(ref _SystemNetNetworkInformation, "netstandard20.System.Net.NetworkInformation");
+        private static byte[]? _SystemNetNetworkInformation;
+
+        /// <summary>
+        /// The image bytes for System.Net.Ping.dll
+        /// </summary>
+        public static byte[] SystemNetPing => ResourceLoader.GetOrCreateResource(ref _SystemNetPing, "netstandard20.System.Net.Ping");
+        private static byte[]? _SystemNetPing;
+
+        /// <summary>
+        /// The image bytes for System.Net.Primitives.dll
+        /// </summary>
+        public static byte[] SystemNetPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemNetPrimitives, "netstandard20.System.Net.Primitives");
+        private static byte[]? _SystemNetPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Net.Requests.dll
+        /// </summary>
+        public static byte[] SystemNetRequests => ResourceLoader.GetOrCreateResource(ref _SystemNetRequests, "netstandard20.System.Net.Requests");
+        private static byte[]? _SystemNetRequests;
+
+        /// <summary>
+        /// The image bytes for System.Net.Security.dll
+        /// </summary>
+        public static byte[] SystemNetSecurity => ResourceLoader.GetOrCreateResource(ref _SystemNetSecurity, "netstandard20.System.Net.Security");
+        private static byte[]? _SystemNetSecurity;
+
+        /// <summary>
+        /// The image bytes for System.Net.Sockets.dll
+        /// </summary>
+        public static byte[] SystemNetSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetSockets, "netstandard20.System.Net.Sockets");
+        private static byte[]? _SystemNetSockets;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebHeaderCollection.dll
+        /// </summary>
+        public static byte[] SystemNetWebHeaderCollection => ResourceLoader.GetOrCreateResource(ref _SystemNetWebHeaderCollection, "netstandard20.System.Net.WebHeaderCollection");
+        private static byte[]? _SystemNetWebHeaderCollection;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.Client.dll
+        /// </summary>
+        public static byte[] SystemNetWebSocketsClient => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSocketsClient, "netstandard20.System.Net.WebSockets.Client");
+        private static byte[]? _SystemNetWebSocketsClient;
+
+        /// <summary>
+        /// The image bytes for System.Net.WebSockets.dll
+        /// </summary>
+        public static byte[] SystemNetWebSockets => ResourceLoader.GetOrCreateResource(ref _SystemNetWebSockets, "netstandard20.System.Net.WebSockets");
+        private static byte[]? _SystemNetWebSockets;
+
+        /// <summary>
+        /// The image bytes for System.Numerics.dll
+        /// </summary>
+        public static byte[] SystemNumerics => ResourceLoader.GetOrCreateResource(ref _SystemNumerics, "netstandard20.System.Numerics");
+        private static byte[]? _SystemNumerics;
+
+        /// <summary>
+        /// The image bytes for System.ObjectModel.dll
+        /// </summary>
+        public static byte[] SystemObjectModel => ResourceLoader.GetOrCreateResource(ref _SystemObjectModel, "netstandard20.System.ObjectModel");
+        private static byte[]? _SystemObjectModel;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.dll
+        /// </summary>
+        public static byte[] SystemReflection => ResourceLoader.GetOrCreateResource(ref _SystemReflection, "netstandard20.System.Reflection");
+        private static byte[]? _SystemReflection;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Extensions.dll
+        /// </summary>
+        public static byte[] SystemReflectionExtensions => ResourceLoader.GetOrCreateResource(ref _SystemReflectionExtensions, "netstandard20.System.Reflection.Extensions");
+        private static byte[]? _SystemReflectionExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Reflection.Primitives.dll
+        /// </summary>
+        public static byte[] SystemReflectionPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemReflectionPrimitives, "netstandard20.System.Reflection.Primitives");
+        private static byte[]? _SystemReflectionPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Reader.dll
+        /// </summary>
+        public static byte[] SystemResourcesReader => ResourceLoader.GetOrCreateResource(ref _SystemResourcesReader, "netstandard20.System.Resources.Reader");
+        private static byte[]? _SystemResourcesReader;
+
+        /// <summary>
+        /// The image bytes for System.Resources.ResourceManager.dll
+        /// </summary>
+        public static byte[] SystemResourcesResourceManager => ResourceLoader.GetOrCreateResource(ref _SystemResourcesResourceManager, "netstandard20.System.Resources.ResourceManager");
+        private static byte[]? _SystemResourcesResourceManager;
+
+        /// <summary>
+        /// The image bytes for System.Resources.Writer.dll
+        /// </summary>
+        public static byte[] SystemResourcesWriter => ResourceLoader.GetOrCreateResource(ref _SystemResourcesWriter, "netstandard20.System.Resources.Writer");
+        private static byte[]? _SystemResourcesWriter;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.CompilerServices.VisualC.dll
+        /// </summary>
+        public static byte[] SystemRuntimeCompilerServicesVisualC => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeCompilerServicesVisualC, "netstandard20.System.Runtime.CompilerServices.VisualC");
+        private static byte[]? _SystemRuntimeCompilerServicesVisualC;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.dll
+        /// </summary>
+        public static byte[] SystemRuntime => ResourceLoader.GetOrCreateResource(ref _SystemRuntime, "netstandard20.System.Runtime");
+        private static byte[]? _SystemRuntime;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Extensions.dll
+        /// </summary>
+        public static byte[] SystemRuntimeExtensions => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeExtensions, "netstandard20.System.Runtime.Extensions");
+        private static byte[]? _SystemRuntimeExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Handles.dll
+        /// </summary>
+        public static byte[] SystemRuntimeHandles => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeHandles, "netstandard20.System.Runtime.Handles");
+        private static byte[]? _SystemRuntimeHandles;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServices => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServices, "netstandard20.System.Runtime.InteropServices");
+        private static byte[]? _SystemRuntimeInteropServices;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.InteropServices.RuntimeInformation.dll
+        /// </summary>
+        public static byte[] SystemRuntimeInteropServicesRuntimeInformation => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeInteropServicesRuntimeInformation, "netstandard20.System.Runtime.InteropServices.RuntimeInformation");
+        private static byte[]? _SystemRuntimeInteropServicesRuntimeInformation;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Numerics.dll
+        /// </summary>
+        public static byte[] SystemRuntimeNumerics => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeNumerics, "netstandard20.System.Runtime.Numerics");
+        private static byte[]? _SystemRuntimeNumerics;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerialization => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerialization, "netstandard20.System.Runtime.Serialization");
+        private static byte[]? _SystemRuntimeSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Formatters.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationFormatters => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationFormatters, "netstandard20.System.Runtime.Serialization.Formatters");
+        private static byte[]? _SystemRuntimeSerializationFormatters;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Json.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationJson => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationJson, "netstandard20.System.Runtime.Serialization.Json");
+        private static byte[]? _SystemRuntimeSerializationJson;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Primitives.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationPrimitives, "netstandard20.System.Runtime.Serialization.Primitives");
+        private static byte[]? _SystemRuntimeSerializationPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Runtime.Serialization.Xml.dll
+        /// </summary>
+        public static byte[] SystemRuntimeSerializationXml => ResourceLoader.GetOrCreateResource(ref _SystemRuntimeSerializationXml, "netstandard20.System.Runtime.Serialization.Xml");
+        private static byte[]? _SystemRuntimeSerializationXml;
+
+        /// <summary>
+        /// The image bytes for System.Security.Claims.dll
+        /// </summary>
+        public static byte[] SystemSecurityClaims => ResourceLoader.GetOrCreateResource(ref _SystemSecurityClaims, "netstandard20.System.Security.Claims");
+        private static byte[]? _SystemSecurityClaims;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Algorithms.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyAlgorithms => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyAlgorithms, "netstandard20.System.Security.Cryptography.Algorithms");
+        private static byte[]? _SystemSecurityCryptographyAlgorithms;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Csp.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyCsp => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyCsp, "netstandard20.System.Security.Cryptography.Csp");
+        private static byte[]? _SystemSecurityCryptographyCsp;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Encoding.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyEncoding => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyEncoding, "netstandard20.System.Security.Cryptography.Encoding");
+        private static byte[]? _SystemSecurityCryptographyEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.Primitives.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyPrimitives => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyPrimitives, "netstandard20.System.Security.Cryptography.Primitives");
+        private static byte[]? _SystemSecurityCryptographyPrimitives;
+
+        /// <summary>
+        /// The image bytes for System.Security.Cryptography.X509Certificates.dll
+        /// </summary>
+        public static byte[] SystemSecurityCryptographyX509Certificates => ResourceLoader.GetOrCreateResource(ref _SystemSecurityCryptographyX509Certificates, "netstandard20.System.Security.Cryptography.X509Certificates");
+        private static byte[]? _SystemSecurityCryptographyX509Certificates;
+
+        /// <summary>
+        /// The image bytes for System.Security.Principal.dll
+        /// </summary>
+        public static byte[] SystemSecurityPrincipal => ResourceLoader.GetOrCreateResource(ref _SystemSecurityPrincipal, "netstandard20.System.Security.Principal");
+        private static byte[]? _SystemSecurityPrincipal;
+
+        /// <summary>
+        /// The image bytes for System.Security.SecureString.dll
+        /// </summary>
+        public static byte[] SystemSecuritySecureString => ResourceLoader.GetOrCreateResource(ref _SystemSecuritySecureString, "netstandard20.System.Security.SecureString");
+        private static byte[]? _SystemSecuritySecureString;
+
+        /// <summary>
+        /// The image bytes for System.ServiceModel.Web.dll
+        /// </summary>
+        public static byte[] SystemServiceModelWeb => ResourceLoader.GetOrCreateResource(ref _SystemServiceModelWeb, "netstandard20.System.ServiceModel.Web");
+        private static byte[]? _SystemServiceModelWeb;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.dll
+        /// </summary>
+        public static byte[] SystemTextEncoding => ResourceLoader.GetOrCreateResource(ref _SystemTextEncoding, "netstandard20.System.Text.Encoding");
+        private static byte[]? _SystemTextEncoding;
+
+        /// <summary>
+        /// The image bytes for System.Text.Encoding.Extensions.dll
+        /// </summary>
+        public static byte[] SystemTextEncodingExtensions => ResourceLoader.GetOrCreateResource(ref _SystemTextEncodingExtensions, "netstandard20.System.Text.Encoding.Extensions");
+        private static byte[]? _SystemTextEncodingExtensions;
+
+        /// <summary>
+        /// The image bytes for System.Text.RegularExpressions.dll
+        /// </summary>
+        public static byte[] SystemTextRegularExpressions => ResourceLoader.GetOrCreateResource(ref _SystemTextRegularExpressions, "netstandard20.System.Text.RegularExpressions");
+        private static byte[]? _SystemTextRegularExpressions;
+
+        /// <summary>
+        /// The image bytes for System.Threading.dll
+        /// </summary>
+        public static byte[] SystemThreading => ResourceLoader.GetOrCreateResource(ref _SystemThreading, "netstandard20.System.Threading");
+        private static byte[]? _SystemThreading;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Overlapped.dll
+        /// </summary>
+        public static byte[] SystemThreadingOverlapped => ResourceLoader.GetOrCreateResource(ref _SystemThreadingOverlapped, "netstandard20.System.Threading.Overlapped");
+        private static byte[]? _SystemThreadingOverlapped;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasks => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasks, "netstandard20.System.Threading.Tasks");
+        private static byte[]? _SystemThreadingTasks;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Parallel.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksParallel => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksParallel, "netstandard20.System.Threading.Tasks.Parallel");
+        private static byte[]? _SystemThreadingTasksParallel;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Thread.dll
+        /// </summary>
+        public static byte[] SystemThreadingThread => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThread, "netstandard20.System.Threading.Thread");
+        private static byte[]? _SystemThreadingThread;
+
+        /// <summary>
+        /// The image bytes for System.Threading.ThreadPool.dll
+        /// </summary>
+        public static byte[] SystemThreadingThreadPool => ResourceLoader.GetOrCreateResource(ref _SystemThreadingThreadPool, "netstandard20.System.Threading.ThreadPool");
+        private static byte[]? _SystemThreadingThreadPool;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Timer.dll
+        /// </summary>
+        public static byte[] SystemThreadingTimer => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTimer, "netstandard20.System.Threading.Timer");
+        private static byte[]? _SystemThreadingTimer;
+
+        /// <summary>
+        /// The image bytes for System.Transactions.dll
+        /// </summary>
+        public static byte[] SystemTransactions => ResourceLoader.GetOrCreateResource(ref _SystemTransactions, "netstandard20.System.Transactions");
+        private static byte[]? _SystemTransactions;
+
+        /// <summary>
+        /// The image bytes for System.ValueTuple.dll
+        /// </summary>
+        public static byte[] SystemValueTuple => ResourceLoader.GetOrCreateResource(ref _SystemValueTuple, "netstandard20.System.ValueTuple");
+        private static byte[]? _SystemValueTuple;
+
+        /// <summary>
+        /// The image bytes for System.Web.dll
+        /// </summary>
+        public static byte[] SystemWeb => ResourceLoader.GetOrCreateResource(ref _SystemWeb, "netstandard20.System.Web");
+        private static byte[]? _SystemWeb;
+
+        /// <summary>
+        /// The image bytes for System.Windows.dll
+        /// </summary>
+        public static byte[] SystemWindows => ResourceLoader.GetOrCreateResource(ref _SystemWindows, "netstandard20.System.Windows");
+        private static byte[]? _SystemWindows;
+
+        /// <summary>
+        /// The image bytes for System.Xml.dll
+        /// </summary>
+        public static byte[] SystemXml => ResourceLoader.GetOrCreateResource(ref _SystemXml, "netstandard20.System.Xml");
+        private static byte[]? _SystemXml;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Linq.dll
+        /// </summary>
+        public static byte[] SystemXmlLinq => ResourceLoader.GetOrCreateResource(ref _SystemXmlLinq, "netstandard20.System.Xml.Linq");
+        private static byte[]? _SystemXmlLinq;
+
+        /// <summary>
+        /// The image bytes for System.Xml.ReaderWriter.dll
+        /// </summary>
+        public static byte[] SystemXmlReaderWriter => ResourceLoader.GetOrCreateResource(ref _SystemXmlReaderWriter, "netstandard20.System.Xml.ReaderWriter");
+        private static byte[]? _SystemXmlReaderWriter;
+
+        /// <summary>
+        /// The image bytes for System.Xml.Serialization.dll
+        /// </summary>
+        public static byte[] SystemXmlSerialization => ResourceLoader.GetOrCreateResource(ref _SystemXmlSerialization, "netstandard20.System.Xml.Serialization");
+        private static byte[]? _SystemXmlSerialization;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXDocument, "netstandard20.System.Xml.XDocument");
+        private static byte[]? _SystemXmlXDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlDocument, "netstandard20.System.Xml.XmlDocument");
+        private static byte[]? _SystemXmlXmlDocument;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XmlSerializer.dll
+        /// </summary>
+        public static byte[] SystemXmlXmlSerializer => ResourceLoader.GetOrCreateResource(ref _SystemXmlXmlSerializer, "netstandard20.System.Xml.XmlSerializer");
+        private static byte[]? _SystemXmlXmlSerializer;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.dll
+        /// </summary>
+        public static byte[] SystemXmlXPath => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPath, "netstandard20.System.Xml.XPath");
+        private static byte[]? _SystemXmlXPath;
+
+        /// <summary>
+        /// The image bytes for System.Xml.XPath.XDocument.dll
+        /// </summary>
+        public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard20.System.Xml.XPath.XDocument");
+        private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netstandard20.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netstandard20.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard20.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
+
+
     }
 }
 

--- a/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
@@ -9,6 +9,122 @@ using Microsoft.CodeAnalysis;
 namespace Basic.Reference.Assemblies;
 public static partial class NetStandard20
 {
+    public static class ExtraReferenceInfos
+    {
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
+
+        /// <summary>
+        /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static ReferenceInfo SystemThreadingTasksExtensions => new ReferenceInfo("System.Threading.Tasks.Extensions.dll", Resources.SystemThreadingTasksExtensions, NetStandard20.ExtraReferences.SystemThreadingTasksExtensions, global::System.Guid.Parse("619062a8-972f-4ae5-bbee-e36ac541d14f"));
+        private static ImmutableArray<ReferenceInfo> _all;
+        public static ImmutableArray<ReferenceInfo> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+
+        public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
+    }
+}
+
+public static partial class NetStandard20
+{
+    public static class ExtraReferences
+    {
+        private static PortableExecutableReference? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.CSharp.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftCSharp
+        {
+            get
+            {
+                if (_MicrosoftCSharp is null)
+                {
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
+                }
+                return _MicrosoftCSharp;
+            }
+        }
+
+        private static PortableExecutableReference? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static PortableExecutableReference MicrosoftVisualBasic
+        {
+            get
+            {
+                if (_MicrosoftVisualBasic is null)
+                {
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
+                }
+                return _MicrosoftVisualBasic;
+            }
+        }
+
+        private static PortableExecutableReference? _SystemThreadingTasksExtensions;
+
+        /// <summary>
+        /// The <see cref="PortableExecutableReference"/> for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static PortableExecutableReference SystemThreadingTasksExtensions
+        {
+            get
+            {
+                if (_SystemThreadingTasksExtensions is null)
+                {
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
+                }
+                return _SystemThreadingTasksExtensions;
+            }
+        }
+
+        private static ImmutableArray<PortableExecutableReference> _all;
+        public static ImmutableArray<PortableExecutableReference> All
+        {
+            get
+            {
+                if (_all.IsDefault)
+                {
+                    _all =
+                    [
+                        MicrosoftCSharp,
+                        MicrosoftVisualBasic,
+                        SystemThreadingTasksExtensions,
+                    ];
+                }
+                return _all;
+            }
+        }
+    }
+}
+
+public static partial class NetStandard20
+{
     public static class Resources
     {
         /// <summary>
@@ -688,6 +804,24 @@ public static partial class NetStandard20
         /// </summary>
         public static byte[] SystemXmlXPathXDocument => ResourceLoader.GetOrCreateResource(ref _SystemXmlXPathXDocument, "netstandard20.System.Xml.XPath.XDocument");
         private static byte[]? _SystemXmlXPathXDocument;
+
+        /// <summary>
+        /// The image bytes for Microsoft.CSharp.dll
+        /// </summary>
+        public static byte[] MicrosoftCSharp => ResourceLoader.GetOrCreateResource(ref _MicrosoftCSharp, "netstandard20.Microsoft.CSharp");
+        private static byte[]? _MicrosoftCSharp;
+
+        /// <summary>
+        /// The image bytes for Microsoft.VisualBasic.dll
+        /// </summary>
+        public static byte[] MicrosoftVisualBasic => ResourceLoader.GetOrCreateResource(ref _MicrosoftVisualBasic, "netstandard20.Microsoft.VisualBasic");
+        private static byte[]? _MicrosoftVisualBasic;
+
+        /// <summary>
+        /// The image bytes for System.Threading.Tasks.Extensions.dll
+        /// </summary>
+        public static byte[] SystemThreadingTasksExtensions => ResourceLoader.GetOrCreateResource(ref _SystemThreadingTasksExtensions, "netstandard20.System.Threading.Tasks.Extensions");
+        private static byte[]? _SystemThreadingTasksExtensions;
 
 
     }

--- a/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
@@ -1,4 +1,4 @@
-// This is a generated file, please edit Generate\Program.cs to change the contents
+// This is a generated file, please edit Src\Generate\Program.cs to change the contents
 
 using System;
 using System.Collections.Generic;
@@ -692,6 +692,7 @@ public static partial class NetStandard20
 
     }
 }
+
 public static partial class NetStandard20
 {
     public static class ReferenceInfos

--- a/Src/Basic.Reference.Assemblies/Generated.NetStandard20.targets
+++ b/Src/Basic.Reference.Assemblies/Generated.NetStandard20.targets
@@ -452,5 +452,17 @@
             <LogicalName>netstandard20.System.Xml.XPath.XDocument</LogicalName>
             <Link>Resources\netstandard20\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\4.7.0\lib\netstandard2.0\Microsoft.CSharp.dll" WithCulture="false">
+            <LogicalName>netstandard20.Microsoft.CSharp</LogicalName>
+            <Link>Resources\netstandard20\Microsoft.CSharp.dll</Link>
+        </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.visualbasic\10.3.0\lib\netstandard2.0\Microsoft.VisualBasic.dll" WithCulture="false">
+            <LogicalName>netstandard20.Microsoft.VisualBasic</LogicalName>
+            <Link>Resources\netstandard20\Microsoft.VisualBasic.dll</Link>
+        </EmbeddedResource>
+        <EmbeddedResource Include="$(NuGetPackageRoot)\system.threading.tasks.extensions\4.5.4\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll" WithCulture="false">
+            <LogicalName>netstandard20.System.Threading.Tasks.Extensions</LogicalName>
+            <Link>Resources\netstandard20\System.Threading.Tasks.Extensions.dll</Link>
+        </EmbeddedResource>
     </ItemGroup>
 </Project>

--- a/Src/Generate/Program.cs
+++ b/Src/Generate/Program.cs
@@ -332,7 +332,7 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
             {
         """);
 
-    var allPropNames = ProcessDlls(
+    ProcessDlls(
         name,
         realPackagePaths,
         realPackagePrefix,
@@ -341,58 +341,6 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
         resourcesContent,
         refContent,
         refInfoContent);
-
-    refInfoContent.AppendLine("""
-                private static ImmutableArray<ReferenceInfo> _all;
-                public static ImmutableArray<ReferenceInfo> All
-                {
-                    get
-                    {
-                        if (_all.IsDefault)
-                        {
-                            _all =
-                            [
-        """);
-
-    refContent.AppendLine("""
-                private static ImmutableArray<PortableExecutableReference> _all;
-                public static ImmutableArray<PortableExecutableReference> All
-                {
-                    get
-                    {
-                        if (_all.IsDefault)
-                        {
-                            _all =
-                            [
-        """);
-
-    foreach (var propName in allPropNames)
-    {
-      refInfoContent.AppendLine($"                        {propName},");
-      refContent.AppendLine($"                        {propName},");
-    }
-
-    refContent.AppendLine("""
-                            ];
-                        }
-                        return _all;
-                    }
-                }
-            }
-        }
-        """);
-
-    refInfoContent.AppendLine("""
-                            ];
-                        }
-                        return _all;
-                    }
-                }
-
-                public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
-            }
-        }
-        """);
 
     resourcesContent.AppendLine("""
 
@@ -425,7 +373,7 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
 
     return (codeContent.ToString(), targetsContent.ToString());
 
-    static List<string> ProcessDlls(
+    void ProcessDlls(
         string name,
         string[] packagePaths,
         string packagePrefix,
@@ -492,7 +440,57 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
                 """);
         }
 
-        return allPropNames;
+        refInfoContent.AppendLine("""
+                    private static ImmutableArray<ReferenceInfo> _all;
+                    public static ImmutableArray<ReferenceInfo> All
+                    {
+                        get
+                        {
+                            if (_all.IsDefault)
+                            {
+                                _all =
+                                [
+            """);
+
+        refContent.AppendLine("""
+                    private static ImmutableArray<PortableExecutableReference> _all;
+                    public static ImmutableArray<PortableExecutableReference> All
+                    {
+                        get
+                        {
+                            if (_all.IsDefault)
+                            {
+                                _all =
+                                [
+            """);
+
+        foreach (var propName in allPropNames)
+        {
+        refInfoContent.AppendLine($"                        {propName},");
+        refContent.AppendLine($"                        {propName},");
+        }
+
+        refContent.AppendLine("""
+                                ];
+                            }
+                            return _all;
+                        }
+                    }
+                }
+            }
+            """);
+
+        refInfoContent.AppendLine("""
+                                ];
+                            }
+                            return _all;
+                        }
+                    }
+
+                    public static IEnumerable<(string FileName, byte[] ImageBytes, PortableExecutableReference Reference, Guid Mvid)> AllValues => All.Select(x => x.AsTuple());
+                }
+            }
+            """);
     }
 
     static IEnumerable<(string FilePath, string RelativeFilePath, Guid Mvid)> FindDlls(string[] packagePaths, string packagePrefix)

--- a/Src/Generate/Program.cs
+++ b/Src/Generate/Program.cs
@@ -365,6 +365,9 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
         namespace Basic.Reference.Assemblies;
         """);
 
+    codeContent.AppendLine(refInfoContent.ToString());
+    codeContent.AppendLine(refContent.ToString());
+
     if (extraPackagePaths.Length > 0)
     {
         var extraRefContent = new StringBuilder();
@@ -403,11 +406,7 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
         }
         """);
 
-
     codeContent.AppendLine(resourcesContent.ToString());
-    codeContent.AppendLine(refInfoContent.ToString());
-    codeContent.AppendLine(refContent.ToString());
-
     codeContent.AppendLine(GetReferenceInfo(name));
 
     targetsContent.AppendLine("""


### PR DESCRIPTION
Several of the TFMS require extra references in order to produce common programs. For example `netstandard2.0` on it's own cannot use `dynamic` until you add `Microsoft.CSharp`. This change adds support in the generation layer for extra references and then includes a few common ones for `netstandard2.0` and `net461`. 

The new references are deliberately put into a different type than `References`. The reason is that `NetStandard20.References.All` should mimic targeting `netstandard2.0` as closely as possible. Extra types should require explicit decisions by the consumption code.

Extra references should be added sparingly. Its' really only meant for common scenarios that popup. 