### PR TITLE
Use the ref instead of lib assemblies

### DIFF
--- a/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
@@ -2771,12 +2771,12 @@ public static partial class NetStandard20
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
+        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("77c6c890-19ac-4339-a953-ed9afe11ea30"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
+        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("ac737773-c586-4e01-96c3-8bee70ea9575"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Generated.targets
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Generated.targets
@@ -452,11 +452,11 @@
             <LogicalName>netstandard20.System.Xml.XPath.XDocument</LogicalName>
             <Link>Resources\netstandard20\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\4.7.0\lib\netstandard2.0\Microsoft.CSharp.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\4.7.0\ref\netstandard2.0\Microsoft.CSharp.dll" WithCulture="false">
             <LogicalName>netstandard20.Microsoft.CSharp</LogicalName>
             <Link>Resources\netstandard20\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.visualbasic\10.3.0\lib\netstandard2.0\Microsoft.VisualBasic.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.visualbasic\10.3.0\ref\netstandard2.0\Microsoft.VisualBasic.dll" WithCulture="false">
             <LogicalName>netstandard20.Microsoft.VisualBasic</LogicalName>
             <Link>Resources\netstandard20\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>

--- a/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
@@ -2771,12 +2771,12 @@ public static partial class NetStandard20
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.CSharp.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("481b904b-3433-4e80-b896-766a3cc8e857"));
+        public static ReferenceInfo MicrosoftCSharp => new ReferenceInfo("Microsoft.CSharp.dll", Resources.MicrosoftCSharp, NetStandard20.ExtraReferences.MicrosoftCSharp, global::System.Guid.Parse("77c6c890-19ac-4339-a953-ed9afe11ea30"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for Microsoft.VisualBasic.dll
         /// </summary>
-        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("b61ee3c6-71d0-4726-931a-fa448a2e8f0e"));
+        public static ReferenceInfo MicrosoftVisualBasic => new ReferenceInfo("Microsoft.VisualBasic.dll", Resources.MicrosoftVisualBasic, NetStandard20.ExtraReferences.MicrosoftVisualBasic, global::System.Guid.Parse("ac737773-c586-4e01-96c3-8bee70ea9575"));
 
         /// <summary>
         /// The <see cref="ReferenceInfo"/> for System.Threading.Tasks.Extensions.dll

--- a/Src/Basic.Reference.Assemblies/Generated.NetStandard20.targets
+++ b/Src/Basic.Reference.Assemblies/Generated.NetStandard20.targets
@@ -452,11 +452,11 @@
             <LogicalName>netstandard20.System.Xml.XPath.XDocument</LogicalName>
             <Link>Resources\netstandard20\System.Xml.XPath.XDocument.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\4.7.0\lib\netstandard2.0\Microsoft.CSharp.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.csharp\4.7.0\ref\netstandard2.0\Microsoft.CSharp.dll" WithCulture="false">
             <LogicalName>netstandard20.Microsoft.CSharp</LogicalName>
             <Link>Resources\netstandard20\Microsoft.CSharp.dll</Link>
         </EmbeddedResource>
-        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.visualbasic\10.3.0\lib\netstandard2.0\Microsoft.VisualBasic.dll" WithCulture="false">
+        <EmbeddedResource Include="$(NuGetPackageRoot)\microsoft.visualbasic\10.3.0\ref\netstandard2.0\Microsoft.VisualBasic.dll" WithCulture="false">
             <LogicalName>netstandard20.Microsoft.VisualBasic</LogicalName>
             <Link>Resources\netstandard20\Microsoft.VisualBasic.dll</Link>
         </EmbeddedResource>

--- a/Src/Generate/Program.cs
+++ b/Src/Generate/Program.cs
@@ -127,8 +127,8 @@ void NetStandard20()
         "NetStandard20",
         [@"netstandard.library\2.0.3\build\netstandard2.0\ref"],
         [
-            @"microsoft.csharp\4.7.0\lib\netstandard2.0",
-            @"microsoft.visualbasic\10.3.0\lib\netstandard2.0",
+            @"microsoft.csharp\4.7.0\ref\netstandard2.0",
+            @"microsoft.visualbasic\10.3.0\ref\netstandard2.0",
             @"system.threading.tasks.extensions\4.5.4\lib\netstandard2.0"]);
     var targetDir = Path.Combine(srcPath, "Basic.Reference.Assemblies.NetStandard20");
     File.WriteAllText(Path.Combine(targetDir, "Generated.cs"), content.CodeContent, encoding);


### PR DESCRIPTION
That was a mistake and caused runtime issues when trying to load the resulting compilations.