### PR TITLE
Reduce allocations

### DIFF
--- a/Src/Basic.Reference.Assemblies.AspNet80/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.AspNet80/Generated.cs
@@ -1851,7 +1851,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (aspnet80)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (aspnet80)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1868,7 +1868,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (aspnet80)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (aspnet80)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -1885,7 +1885,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (aspnet80)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (aspnet80)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1902,7 +1902,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (aspnet80)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (aspnet80)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1919,7 +1919,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftWin32Registry is null)
                 {
-                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Registry).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (aspnet80)");
+                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Win32.Registry")).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (aspnet80)");
                 }
                 return _MicrosoftWin32Registry;
             }
@@ -1936,7 +1936,7 @@ public static partial class AspNet80
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (aspnet80)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (aspnet80)");
                 }
                 return _mscorlib;
             }
@@ -1953,7 +1953,7 @@ public static partial class AspNet80
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (aspnet80)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (aspnet80)");
                 }
                 return _netstandard;
             }
@@ -1970,7 +1970,7 @@ public static partial class AspNet80
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (aspnet80)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (aspnet80)");
                 }
                 return _SystemAppContext;
             }
@@ -1987,7 +1987,7 @@ public static partial class AspNet80
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (aspnet80)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (aspnet80)");
                 }
                 return _SystemBuffers;
             }
@@ -2004,7 +2004,7 @@ public static partial class AspNet80
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (aspnet80)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (aspnet80)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -2021,7 +2021,7 @@ public static partial class AspNet80
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (aspnet80)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (aspnet80)");
                 }
                 return _SystemCollections;
             }
@@ -2038,7 +2038,7 @@ public static partial class AspNet80
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (aspnet80)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (aspnet80)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -2055,7 +2055,7 @@ public static partial class AspNet80
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (aspnet80)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (aspnet80)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -2072,7 +2072,7 @@ public static partial class AspNet80
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (aspnet80)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (aspnet80)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -2089,7 +2089,7 @@ public static partial class AspNet80
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (aspnet80)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (aspnet80)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -2106,7 +2106,7 @@ public static partial class AspNet80
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (aspnet80)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (aspnet80)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -2123,7 +2123,7 @@ public static partial class AspNet80
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (aspnet80)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (aspnet80)");
                 }
                 return _SystemComponentModel;
             }
@@ -2140,7 +2140,7 @@ public static partial class AspNet80
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (aspnet80)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (aspnet80)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -2157,7 +2157,7 @@ public static partial class AspNet80
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (aspnet80)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (aspnet80)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -2174,7 +2174,7 @@ public static partial class AspNet80
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (aspnet80)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (aspnet80)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -2191,7 +2191,7 @@ public static partial class AspNet80
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (aspnet80)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (aspnet80)");
                 }
                 return _SystemConfiguration;
             }
@@ -2208,7 +2208,7 @@ public static partial class AspNet80
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (aspnet80)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (aspnet80)");
                 }
                 return _SystemConsole;
             }
@@ -2225,7 +2225,7 @@ public static partial class AspNet80
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (aspnet80)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (aspnet80)");
                 }
                 return _SystemCore;
             }
@@ -2242,7 +2242,7 @@ public static partial class AspNet80
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (aspnet80)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (aspnet80)");
                 }
                 return _SystemDataCommon;
             }
@@ -2259,7 +2259,7 @@ public static partial class AspNet80
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (aspnet80)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (aspnet80)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -2276,7 +2276,7 @@ public static partial class AspNet80
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (aspnet80)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (aspnet80)");
                 }
                 return _SystemData;
             }
@@ -2293,7 +2293,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (aspnet80)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (aspnet80)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -2310,7 +2310,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (aspnet80)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (aspnet80)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -2327,7 +2327,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (aspnet80)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (aspnet80)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -2344,7 +2344,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (aspnet80)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (aspnet80)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -2361,7 +2361,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (aspnet80)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (aspnet80)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -2378,7 +2378,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (aspnet80)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (aspnet80)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -2395,7 +2395,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (aspnet80)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (aspnet80)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -2412,7 +2412,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (aspnet80)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (aspnet80)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -2429,7 +2429,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (aspnet80)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (aspnet80)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -2446,7 +2446,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (aspnet80)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (aspnet80)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -2463,7 +2463,7 @@ public static partial class AspNet80
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (aspnet80)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System")).GetReference(filePath: "System.dll", display: "System (aspnet80)");
                 }
                 return _System;
             }
@@ -2480,7 +2480,7 @@ public static partial class AspNet80
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (aspnet80)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (aspnet80)");
                 }
                 return _SystemDrawing;
             }
@@ -2497,7 +2497,7 @@ public static partial class AspNet80
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (aspnet80)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (aspnet80)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -2514,7 +2514,7 @@ public static partial class AspNet80
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (aspnet80)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (aspnet80)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -2531,7 +2531,7 @@ public static partial class AspNet80
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (aspnet80)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (aspnet80)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -2548,7 +2548,7 @@ public static partial class AspNet80
             {
                 if (_SystemFormatsTar is null)
                 {
-                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsTar).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (aspnet80)");
+                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Formats.Tar")).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (aspnet80)");
                 }
                 return _SystemFormatsTar;
             }
@@ -2565,7 +2565,7 @@ public static partial class AspNet80
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (aspnet80)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (aspnet80)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -2582,7 +2582,7 @@ public static partial class AspNet80
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (aspnet80)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (aspnet80)");
                 }
                 return _SystemGlobalization;
             }
@@ -2599,7 +2599,7 @@ public static partial class AspNet80
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (aspnet80)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (aspnet80)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -2616,7 +2616,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (aspnet80)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (aspnet80)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -2633,7 +2633,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (aspnet80)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (aspnet80)");
                 }
                 return _SystemIOCompression;
             }
@@ -2650,7 +2650,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (aspnet80)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (aspnet80)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -2667,7 +2667,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (aspnet80)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (aspnet80)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -2684,7 +2684,7 @@ public static partial class AspNet80
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (aspnet80)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (aspnet80)");
                 }
                 return _SystemIO;
             }
@@ -2701,7 +2701,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOFileSystemAccessControl is null)
                 {
-                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemAccessControl).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (aspnet80)");
+                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.FileSystem.AccessControl")).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (aspnet80)");
                 }
                 return _SystemIOFileSystemAccessControl;
             }
@@ -2718,7 +2718,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (aspnet80)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (aspnet80)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -2735,7 +2735,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (aspnet80)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (aspnet80)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -2752,7 +2752,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (aspnet80)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (aspnet80)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -2769,7 +2769,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (aspnet80)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (aspnet80)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -2786,7 +2786,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (aspnet80)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (aspnet80)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -2803,7 +2803,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (aspnet80)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (aspnet80)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -2820,7 +2820,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOPipesAccessControl is null)
                 {
-                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipesAccessControl).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (aspnet80)");
+                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.Pipes.AccessControl")).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (aspnet80)");
                 }
                 return _SystemIOPipesAccessControl;
             }
@@ -2837,7 +2837,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (aspnet80)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (aspnet80)");
                 }
                 return _SystemIOPipes;
             }
@@ -2854,7 +2854,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (aspnet80)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (aspnet80)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -2871,7 +2871,7 @@ public static partial class AspNet80
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (aspnet80)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (aspnet80)");
                 }
                 return _SystemLinq;
             }
@@ -2888,7 +2888,7 @@ public static partial class AspNet80
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (aspnet80)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (aspnet80)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -2905,7 +2905,7 @@ public static partial class AspNet80
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (aspnet80)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (aspnet80)");
                 }
                 return _SystemLinqParallel;
             }
@@ -2922,7 +2922,7 @@ public static partial class AspNet80
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (aspnet80)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (aspnet80)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -2939,7 +2939,7 @@ public static partial class AspNet80
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (aspnet80)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (aspnet80)");
                 }
                 return _SystemMemory;
             }
@@ -2956,7 +2956,7 @@ public static partial class AspNet80
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (aspnet80)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (aspnet80)");
                 }
                 return _SystemNet;
             }
@@ -2973,7 +2973,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (aspnet80)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (aspnet80)");
                 }
                 return _SystemNetHttp;
             }
@@ -2990,7 +2990,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (aspnet80)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (aspnet80)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -3007,7 +3007,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (aspnet80)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (aspnet80)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -3024,7 +3024,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (aspnet80)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (aspnet80)");
                 }
                 return _SystemNetMail;
             }
@@ -3041,7 +3041,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (aspnet80)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (aspnet80)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -3058,7 +3058,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (aspnet80)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (aspnet80)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -3075,7 +3075,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (aspnet80)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (aspnet80)");
                 }
                 return _SystemNetPing;
             }
@@ -3092,7 +3092,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (aspnet80)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (aspnet80)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -3109,7 +3109,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetQuic is null)
                 {
-                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(Resources.SystemNetQuic).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (aspnet80)");
+                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Quic")).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (aspnet80)");
                 }
                 return _SystemNetQuic;
             }
@@ -3126,7 +3126,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (aspnet80)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (aspnet80)");
                 }
                 return _SystemNetRequests;
             }
@@ -3143,7 +3143,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (aspnet80)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (aspnet80)");
                 }
                 return _SystemNetSecurity;
             }
@@ -3160,7 +3160,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (aspnet80)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (aspnet80)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -3177,7 +3177,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (aspnet80)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (aspnet80)");
                 }
                 return _SystemNetSockets;
             }
@@ -3194,7 +3194,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (aspnet80)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (aspnet80)");
                 }
                 return _SystemNetWebClient;
             }
@@ -3211,7 +3211,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (aspnet80)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (aspnet80)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -3228,7 +3228,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (aspnet80)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (aspnet80)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -3245,7 +3245,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (aspnet80)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (aspnet80)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -3262,7 +3262,7 @@ public static partial class AspNet80
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (aspnet80)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (aspnet80)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -3279,7 +3279,7 @@ public static partial class AspNet80
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (aspnet80)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (aspnet80)");
                 }
                 return _SystemNumerics;
             }
@@ -3296,7 +3296,7 @@ public static partial class AspNet80
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (aspnet80)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (aspnet80)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -3313,7 +3313,7 @@ public static partial class AspNet80
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (aspnet80)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (aspnet80)");
                 }
                 return _SystemObjectModel;
             }
@@ -3330,7 +3330,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (aspnet80)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (aspnet80)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -3347,7 +3347,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (aspnet80)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (aspnet80)");
                 }
                 return _SystemReflection;
             }
@@ -3364,7 +3364,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (aspnet80)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (aspnet80)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -3381,7 +3381,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (aspnet80)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (aspnet80)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -3398,7 +3398,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (aspnet80)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (aspnet80)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -3415,7 +3415,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (aspnet80)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (aspnet80)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -3432,7 +3432,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (aspnet80)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (aspnet80)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -3449,7 +3449,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (aspnet80)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (aspnet80)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -3466,7 +3466,7 @@ public static partial class AspNet80
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (aspnet80)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (aspnet80)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -3483,7 +3483,7 @@ public static partial class AspNet80
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (aspnet80)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (aspnet80)");
                 }
                 return _SystemResourcesReader;
             }
@@ -3500,7 +3500,7 @@ public static partial class AspNet80
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (aspnet80)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (aspnet80)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -3517,7 +3517,7 @@ public static partial class AspNet80
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (aspnet80)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (aspnet80)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -3534,7 +3534,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (aspnet80)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (aspnet80)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -3551,7 +3551,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (aspnet80)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (aspnet80)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -3568,7 +3568,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (aspnet80)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (aspnet80)");
                 }
                 return _SystemRuntime;
             }
@@ -3585,7 +3585,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (aspnet80)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (aspnet80)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -3602,7 +3602,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (aspnet80)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (aspnet80)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -3619,7 +3619,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (aspnet80)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (aspnet80)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -3636,7 +3636,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeInteropServicesJavaScript is null)
                 {
-                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesJavaScript).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (aspnet80)");
+                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.InteropServices.JavaScript")).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (aspnet80)");
                 }
                 return _SystemRuntimeInteropServicesJavaScript;
             }
@@ -3653,7 +3653,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (aspnet80)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (aspnet80)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -3670,7 +3670,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (aspnet80)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (aspnet80)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -3687,7 +3687,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (aspnet80)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (aspnet80)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -3704,7 +3704,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (aspnet80)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (aspnet80)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -3721,7 +3721,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (aspnet80)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (aspnet80)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -3738,7 +3738,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (aspnet80)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (aspnet80)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -3755,7 +3755,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (aspnet80)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (aspnet80)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -3772,7 +3772,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (aspnet80)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (aspnet80)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -3789,7 +3789,7 @@ public static partial class AspNet80
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (aspnet80)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (aspnet80)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -3806,7 +3806,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (aspnet80)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (aspnet80)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -3823,7 +3823,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (aspnet80)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (aspnet80)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -3840,7 +3840,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (aspnet80)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (aspnet80)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -3857,7 +3857,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyCng is null)
                 {
-                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCng).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (aspnet80)");
+                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.Cng")).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (aspnet80)");
                 }
                 return _SystemSecurityCryptographyCng;
             }
@@ -3874,7 +3874,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (aspnet80)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (aspnet80)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -3891,7 +3891,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptography is null)
                 {
-                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptography).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (aspnet80)");
+                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography")).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (aspnet80)");
                 }
                 return _SystemSecurityCryptography;
             }
@@ -3908,7 +3908,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (aspnet80)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (aspnet80)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -3925,7 +3925,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyOpenSsl is null)
                 {
-                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyOpenSsl).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (aspnet80)");
+                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.OpenSsl")).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (aspnet80)");
                 }
                 return _SystemSecurityCryptographyOpenSsl;
             }
@@ -3942,7 +3942,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (aspnet80)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (aspnet80)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -3959,7 +3959,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (aspnet80)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (aspnet80)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -3976,7 +3976,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (aspnet80)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (aspnet80)");
                 }
                 return _SystemSecurity;
             }
@@ -3993,7 +3993,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (aspnet80)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (aspnet80)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -4010,7 +4010,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (aspnet80)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (aspnet80)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -4027,7 +4027,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (aspnet80)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (aspnet80)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -4044,7 +4044,7 @@ public static partial class AspNet80
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (aspnet80)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (aspnet80)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -4061,7 +4061,7 @@ public static partial class AspNet80
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (aspnet80)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (aspnet80)");
                 }
                 return _SystemServiceProcess;
             }
@@ -4078,7 +4078,7 @@ public static partial class AspNet80
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (aspnet80)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (aspnet80)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -4095,7 +4095,7 @@ public static partial class AspNet80
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (aspnet80)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (aspnet80)");
                 }
                 return _SystemTextEncoding;
             }
@@ -4112,7 +4112,7 @@ public static partial class AspNet80
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (aspnet80)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (aspnet80)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -4129,7 +4129,7 @@ public static partial class AspNet80
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (aspnet80)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (aspnet80)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -4146,7 +4146,7 @@ public static partial class AspNet80
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (aspnet80)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (aspnet80)");
                 }
                 return _SystemTextJson;
             }
@@ -4163,7 +4163,7 @@ public static partial class AspNet80
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (aspnet80)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (aspnet80)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -4180,7 +4180,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (aspnet80)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (aspnet80)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -4197,7 +4197,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (aspnet80)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (aspnet80)");
                 }
                 return _SystemThreading;
             }
@@ -4214,7 +4214,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (aspnet80)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (aspnet80)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -4231,7 +4231,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (aspnet80)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (aspnet80)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -4248,7 +4248,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (aspnet80)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (aspnet80)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -4265,7 +4265,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (aspnet80)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (aspnet80)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -4282,7 +4282,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (aspnet80)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (aspnet80)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -4299,7 +4299,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (aspnet80)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (aspnet80)");
                 }
                 return _SystemThreadingThread;
             }
@@ -4316,7 +4316,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (aspnet80)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (aspnet80)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -4333,7 +4333,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (aspnet80)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (aspnet80)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -4350,7 +4350,7 @@ public static partial class AspNet80
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (aspnet80)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (aspnet80)");
                 }
                 return _SystemTransactions;
             }
@@ -4367,7 +4367,7 @@ public static partial class AspNet80
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (aspnet80)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (aspnet80)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -4384,7 +4384,7 @@ public static partial class AspNet80
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (aspnet80)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (aspnet80)");
                 }
                 return _SystemValueTuple;
             }
@@ -4401,7 +4401,7 @@ public static partial class AspNet80
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (aspnet80)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (aspnet80)");
                 }
                 return _SystemWeb;
             }
@@ -4418,7 +4418,7 @@ public static partial class AspNet80
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (aspnet80)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (aspnet80)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -4435,7 +4435,7 @@ public static partial class AspNet80
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (aspnet80)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (aspnet80)");
                 }
                 return _SystemWindows;
             }
@@ -4452,7 +4452,7 @@ public static partial class AspNet80
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (aspnet80)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (aspnet80)");
                 }
                 return _SystemXml;
             }
@@ -4469,7 +4469,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (aspnet80)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (aspnet80)");
                 }
                 return _SystemXmlLinq;
             }
@@ -4486,7 +4486,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (aspnet80)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (aspnet80)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -4503,7 +4503,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (aspnet80)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (aspnet80)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -4520,7 +4520,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (aspnet80)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (aspnet80)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -4537,7 +4537,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (aspnet80)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (aspnet80)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -4554,7 +4554,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (aspnet80)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (aspnet80)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -4571,7 +4571,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (aspnet80)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (aspnet80)");
                 }
                 return _SystemXmlXPath;
             }
@@ -4588,7 +4588,7 @@ public static partial class AspNet80
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (aspnet80)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (aspnet80)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -4605,7 +4605,7 @@ public static partial class AspNet80
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (aspnet80)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (aspnet80)");
                 }
                 return _WindowsBase;
             }
@@ -4622,7 +4622,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAntiforgery is null)
                 {
-                    _MicrosoftAspNetCoreAntiforgery = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAntiforgery).GetReference(filePath: "Microsoft.AspNetCore.Antiforgery.dll", display: "Microsoft.AspNetCore.Antiforgery (aspnet80)");
+                    _MicrosoftAspNetCoreAntiforgery = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Antiforgery")).GetReference(filePath: "Microsoft.AspNetCore.Antiforgery.dll", display: "Microsoft.AspNetCore.Antiforgery (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAntiforgery;
             }
@@ -4639,7 +4639,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthenticationAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Abstractions.dll", display: "Microsoft.AspNetCore.Authentication.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreAuthenticationAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authentication.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Abstractions.dll", display: "Microsoft.AspNetCore.Authentication.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationAbstractions;
             }
@@ -4656,7 +4656,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthenticationBearerToken is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationBearerToken = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationBearerToken).GetReference(filePath: "Microsoft.AspNetCore.Authentication.BearerToken.dll", display: "Microsoft.AspNetCore.Authentication.BearerToken (aspnet80)");
+                    _MicrosoftAspNetCoreAuthenticationBearerToken = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authentication.BearerToken")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.BearerToken.dll", display: "Microsoft.AspNetCore.Authentication.BearerToken (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationBearerToken;
             }
@@ -4673,7 +4673,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthenticationCookies is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationCookies = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationCookies).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Cookies.dll", display: "Microsoft.AspNetCore.Authentication.Cookies (aspnet80)");
+                    _MicrosoftAspNetCoreAuthenticationCookies = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authentication.Cookies")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Cookies.dll", display: "Microsoft.AspNetCore.Authentication.Cookies (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationCookies;
             }
@@ -4690,7 +4690,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthenticationCore is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationCore).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Core.dll", display: "Microsoft.AspNetCore.Authentication.Core (aspnet80)");
+                    _MicrosoftAspNetCoreAuthenticationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authentication.Core")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Core.dll", display: "Microsoft.AspNetCore.Authentication.Core (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationCore;
             }
@@ -4707,7 +4707,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthentication is null)
                 {
-                    _MicrosoftAspNetCoreAuthentication = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthentication).GetReference(filePath: "Microsoft.AspNetCore.Authentication.dll", display: "Microsoft.AspNetCore.Authentication (aspnet80)");
+                    _MicrosoftAspNetCoreAuthentication = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authentication")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.dll", display: "Microsoft.AspNetCore.Authentication (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthentication;
             }
@@ -4724,7 +4724,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthenticationOAuth is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationOAuth = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationOAuth).GetReference(filePath: "Microsoft.AspNetCore.Authentication.OAuth.dll", display: "Microsoft.AspNetCore.Authentication.OAuth (aspnet80)");
+                    _MicrosoftAspNetCoreAuthenticationOAuth = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authentication.OAuth")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.OAuth.dll", display: "Microsoft.AspNetCore.Authentication.OAuth (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationOAuth;
             }
@@ -4741,7 +4741,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthorization is null)
                 {
-                    _MicrosoftAspNetCoreAuthorization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthorization).GetReference(filePath: "Microsoft.AspNetCore.Authorization.dll", display: "Microsoft.AspNetCore.Authorization (aspnet80)");
+                    _MicrosoftAspNetCoreAuthorization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authorization")).GetReference(filePath: "Microsoft.AspNetCore.Authorization.dll", display: "Microsoft.AspNetCore.Authorization (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthorization;
             }
@@ -4758,7 +4758,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreAuthorizationPolicy is null)
                 {
-                    _MicrosoftAspNetCoreAuthorizationPolicy = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthorizationPolicy).GetReference(filePath: "Microsoft.AspNetCore.Authorization.Policy.dll", display: "Microsoft.AspNetCore.Authorization.Policy (aspnet80)");
+                    _MicrosoftAspNetCoreAuthorizationPolicy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Authorization.Policy")).GetReference(filePath: "Microsoft.AspNetCore.Authorization.Policy.dll", display: "Microsoft.AspNetCore.Authorization.Policy (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreAuthorizationPolicy;
             }
@@ -4775,7 +4775,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreComponentsAuthorization is null)
                 {
-                    _MicrosoftAspNetCoreComponentsAuthorization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsAuthorization).GetReference(filePath: "Microsoft.AspNetCore.Components.Authorization.dll", display: "Microsoft.AspNetCore.Components.Authorization (aspnet80)");
+                    _MicrosoftAspNetCoreComponentsAuthorization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Components.Authorization")).GetReference(filePath: "Microsoft.AspNetCore.Components.Authorization.dll", display: "Microsoft.AspNetCore.Components.Authorization (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreComponentsAuthorization;
             }
@@ -4792,7 +4792,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreComponents is null)
                 {
-                    _MicrosoftAspNetCoreComponents = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponents).GetReference(filePath: "Microsoft.AspNetCore.Components.dll", display: "Microsoft.AspNetCore.Components (aspnet80)");
+                    _MicrosoftAspNetCoreComponents = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Components")).GetReference(filePath: "Microsoft.AspNetCore.Components.dll", display: "Microsoft.AspNetCore.Components (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreComponents;
             }
@@ -4809,7 +4809,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreComponentsEndpoints is null)
                 {
-                    _MicrosoftAspNetCoreComponentsEndpoints = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsEndpoints).GetReference(filePath: "Microsoft.AspNetCore.Components.Endpoints.dll", display: "Microsoft.AspNetCore.Components.Endpoints (aspnet80)");
+                    _MicrosoftAspNetCoreComponentsEndpoints = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Components.Endpoints")).GetReference(filePath: "Microsoft.AspNetCore.Components.Endpoints.dll", display: "Microsoft.AspNetCore.Components.Endpoints (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreComponentsEndpoints;
             }
@@ -4826,7 +4826,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreComponentsForms is null)
                 {
-                    _MicrosoftAspNetCoreComponentsForms = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsForms).GetReference(filePath: "Microsoft.AspNetCore.Components.Forms.dll", display: "Microsoft.AspNetCore.Components.Forms (aspnet80)");
+                    _MicrosoftAspNetCoreComponentsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Components.Forms")).GetReference(filePath: "Microsoft.AspNetCore.Components.Forms.dll", display: "Microsoft.AspNetCore.Components.Forms (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreComponentsForms;
             }
@@ -4843,7 +4843,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreComponentsServer is null)
                 {
-                    _MicrosoftAspNetCoreComponentsServer = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsServer).GetReference(filePath: "Microsoft.AspNetCore.Components.Server.dll", display: "Microsoft.AspNetCore.Components.Server (aspnet80)");
+                    _MicrosoftAspNetCoreComponentsServer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Components.Server")).GetReference(filePath: "Microsoft.AspNetCore.Components.Server.dll", display: "Microsoft.AspNetCore.Components.Server (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreComponentsServer;
             }
@@ -4860,7 +4860,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreComponentsWeb is null)
                 {
-                    _MicrosoftAspNetCoreComponentsWeb = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsWeb).GetReference(filePath: "Microsoft.AspNetCore.Components.Web.dll", display: "Microsoft.AspNetCore.Components.Web (aspnet80)");
+                    _MicrosoftAspNetCoreComponentsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Components.Web")).GetReference(filePath: "Microsoft.AspNetCore.Components.Web.dll", display: "Microsoft.AspNetCore.Components.Web (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreComponentsWeb;
             }
@@ -4877,7 +4877,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreConnectionsAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreConnectionsAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreConnectionsAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Connections.Abstractions.dll", display: "Microsoft.AspNetCore.Connections.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreConnectionsAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Connections.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Connections.Abstractions.dll", display: "Microsoft.AspNetCore.Connections.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreConnectionsAbstractions;
             }
@@ -4894,7 +4894,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreCookiePolicy is null)
                 {
-                    _MicrosoftAspNetCoreCookiePolicy = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCookiePolicy).GetReference(filePath: "Microsoft.AspNetCore.CookiePolicy.dll", display: "Microsoft.AspNetCore.CookiePolicy (aspnet80)");
+                    _MicrosoftAspNetCoreCookiePolicy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.CookiePolicy")).GetReference(filePath: "Microsoft.AspNetCore.CookiePolicy.dll", display: "Microsoft.AspNetCore.CookiePolicy (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreCookiePolicy;
             }
@@ -4911,7 +4911,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreCors is null)
                 {
-                    _MicrosoftAspNetCoreCors = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCors).GetReference(filePath: "Microsoft.AspNetCore.Cors.dll", display: "Microsoft.AspNetCore.Cors (aspnet80)");
+                    _MicrosoftAspNetCoreCors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Cors")).GetReference(filePath: "Microsoft.AspNetCore.Cors.dll", display: "Microsoft.AspNetCore.Cors (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreCors;
             }
@@ -4928,7 +4928,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreCryptographyInternal is null)
                 {
-                    _MicrosoftAspNetCoreCryptographyInternal = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCryptographyInternal).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.Internal.dll", display: "Microsoft.AspNetCore.Cryptography.Internal (aspnet80)");
+                    _MicrosoftAspNetCoreCryptographyInternal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Cryptography.Internal")).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.Internal.dll", display: "Microsoft.AspNetCore.Cryptography.Internal (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreCryptographyInternal;
             }
@@ -4945,7 +4945,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreCryptographyKeyDerivation is null)
                 {
-                    _MicrosoftAspNetCoreCryptographyKeyDerivation = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCryptographyKeyDerivation).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.KeyDerivation.dll", display: "Microsoft.AspNetCore.Cryptography.KeyDerivation (aspnet80)");
+                    _MicrosoftAspNetCoreCryptographyKeyDerivation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Cryptography.KeyDerivation")).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.KeyDerivation.dll", display: "Microsoft.AspNetCore.Cryptography.KeyDerivation (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreCryptographyKeyDerivation;
             }
@@ -4962,7 +4962,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreDataProtectionAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreDataProtectionAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDataProtectionAbstractions).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Abstractions.dll", display: "Microsoft.AspNetCore.DataProtection.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreDataProtectionAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.DataProtection.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Abstractions.dll", display: "Microsoft.AspNetCore.DataProtection.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreDataProtectionAbstractions;
             }
@@ -4979,7 +4979,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreDataProtection is null)
                 {
-                    _MicrosoftAspNetCoreDataProtection = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDataProtection).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.dll", display: "Microsoft.AspNetCore.DataProtection (aspnet80)");
+                    _MicrosoftAspNetCoreDataProtection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.DataProtection")).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.dll", display: "Microsoft.AspNetCore.DataProtection (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreDataProtection;
             }
@@ -4996,7 +4996,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreDataProtectionExtensions is null)
                 {
-                    _MicrosoftAspNetCoreDataProtectionExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDataProtectionExtensions).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Extensions.dll", display: "Microsoft.AspNetCore.DataProtection.Extensions (aspnet80)");
+                    _MicrosoftAspNetCoreDataProtectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.DataProtection.Extensions")).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Extensions.dll", display: "Microsoft.AspNetCore.DataProtection.Extensions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreDataProtectionExtensions;
             }
@@ -5013,7 +5013,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreDiagnosticsAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDiagnosticsAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.Abstractions.dll", display: "Microsoft.AspNetCore.Diagnostics.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Diagnostics.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.Abstractions.dll", display: "Microsoft.AspNetCore.Diagnostics.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreDiagnosticsAbstractions;
             }
@@ -5030,7 +5030,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreDiagnostics is null)
                 {
-                    _MicrosoftAspNetCoreDiagnostics = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDiagnostics).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.dll", display: "Microsoft.AspNetCore.Diagnostics (aspnet80)");
+                    _MicrosoftAspNetCoreDiagnostics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Diagnostics")).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.dll", display: "Microsoft.AspNetCore.Diagnostics (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreDiagnostics;
             }
@@ -5047,7 +5047,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreDiagnosticsHealthChecks is null)
                 {
-                    _MicrosoftAspNetCoreDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDiagnosticsHealthChecks).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.HealthChecks.dll", display: "Microsoft.AspNetCore.Diagnostics.HealthChecks (aspnet80)");
+                    _MicrosoftAspNetCoreDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Diagnostics.HealthChecks")).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.HealthChecks.dll", display: "Microsoft.AspNetCore.Diagnostics.HealthChecks (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreDiagnosticsHealthChecks;
             }
@@ -5064,7 +5064,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCore is null)
                 {
-                    _MicrosoftAspNetCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCore).GetReference(filePath: "Microsoft.AspNetCore.dll", display: "Microsoft.AspNetCore (aspnet80)");
+                    _MicrosoftAspNetCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore")).GetReference(filePath: "Microsoft.AspNetCore.dll", display: "Microsoft.AspNetCore (aspnet80)");
                 }
                 return _MicrosoftAspNetCore;
             }
@@ -5081,7 +5081,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHostFiltering is null)
                 {
-                    _MicrosoftAspNetCoreHostFiltering = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHostFiltering).GetReference(filePath: "Microsoft.AspNetCore.HostFiltering.dll", display: "Microsoft.AspNetCore.HostFiltering (aspnet80)");
+                    _MicrosoftAspNetCoreHostFiltering = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.HostFiltering")).GetReference(filePath: "Microsoft.AspNetCore.HostFiltering.dll", display: "Microsoft.AspNetCore.HostFiltering (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHostFiltering;
             }
@@ -5098,7 +5098,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHostingAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHostingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHostingAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreHostingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Hosting.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHostingAbstractions;
             }
@@ -5115,7 +5115,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHosting is null)
                 {
-                    _MicrosoftAspNetCoreHosting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHosting).GetReference(filePath: "Microsoft.AspNetCore.Hosting.dll", display: "Microsoft.AspNetCore.Hosting (aspnet80)");
+                    _MicrosoftAspNetCoreHosting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Hosting")).GetReference(filePath: "Microsoft.AspNetCore.Hosting.dll", display: "Microsoft.AspNetCore.Hosting (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHosting;
             }
@@ -5132,7 +5132,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHostingServerAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHostingServerAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHostingServerAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Server.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Server.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreHostingServerAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Hosting.Server.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Server.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Server.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHostingServerAbstractions;
             }
@@ -5149,7 +5149,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHtmlAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHtmlAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHtmlAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Html.Abstractions.dll", display: "Microsoft.AspNetCore.Html.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreHtmlAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Html.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Html.Abstractions.dll", display: "Microsoft.AspNetCore.Html.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHtmlAbstractions;
             }
@@ -5166,7 +5166,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHttpAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Http.Abstractions.dll", display: "Microsoft.AspNetCore.Http.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreHttpAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Http.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Http.Abstractions.dll", display: "Microsoft.AspNetCore.Http.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpAbstractions;
             }
@@ -5183,7 +5183,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpConnectionsCommon is null)
                 {
-                    _MicrosoftAspNetCoreHttpConnectionsCommon = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpConnectionsCommon).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.Common.dll", display: "Microsoft.AspNetCore.Http.Connections.Common (aspnet80)");
+                    _MicrosoftAspNetCoreHttpConnectionsCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Http.Connections.Common")).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.Common.dll", display: "Microsoft.AspNetCore.Http.Connections.Common (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpConnectionsCommon;
             }
@@ -5200,7 +5200,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpConnections is null)
                 {
-                    _MicrosoftAspNetCoreHttpConnections = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpConnections).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.dll", display: "Microsoft.AspNetCore.Http.Connections (aspnet80)");
+                    _MicrosoftAspNetCoreHttpConnections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Http.Connections")).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.dll", display: "Microsoft.AspNetCore.Http.Connections (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpConnections;
             }
@@ -5217,7 +5217,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttp is null)
                 {
-                    _MicrosoftAspNetCoreHttp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttp).GetReference(filePath: "Microsoft.AspNetCore.Http.dll", display: "Microsoft.AspNetCore.Http (aspnet80)");
+                    _MicrosoftAspNetCoreHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Http")).GetReference(filePath: "Microsoft.AspNetCore.Http.dll", display: "Microsoft.AspNetCore.Http (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttp;
             }
@@ -5234,7 +5234,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpExtensions is null)
                 {
-                    _MicrosoftAspNetCoreHttpExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpExtensions).GetReference(filePath: "Microsoft.AspNetCore.Http.Extensions.dll", display: "Microsoft.AspNetCore.Http.Extensions (aspnet80)");
+                    _MicrosoftAspNetCoreHttpExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Http.Extensions")).GetReference(filePath: "Microsoft.AspNetCore.Http.Extensions.dll", display: "Microsoft.AspNetCore.Http.Extensions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpExtensions;
             }
@@ -5251,7 +5251,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpFeatures is null)
                 {
-                    _MicrosoftAspNetCoreHttpFeatures = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpFeatures).GetReference(filePath: "Microsoft.AspNetCore.Http.Features.dll", display: "Microsoft.AspNetCore.Http.Features (aspnet80)");
+                    _MicrosoftAspNetCoreHttpFeatures = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Http.Features")).GetReference(filePath: "Microsoft.AspNetCore.Http.Features.dll", display: "Microsoft.AspNetCore.Http.Features (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpFeatures;
             }
@@ -5268,7 +5268,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpResults is null)
                 {
-                    _MicrosoftAspNetCoreHttpResults = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpResults).GetReference(filePath: "Microsoft.AspNetCore.Http.Results.dll", display: "Microsoft.AspNetCore.Http.Results (aspnet80)");
+                    _MicrosoftAspNetCoreHttpResults = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Http.Results")).GetReference(filePath: "Microsoft.AspNetCore.Http.Results.dll", display: "Microsoft.AspNetCore.Http.Results (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpResults;
             }
@@ -5285,7 +5285,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpLogging is null)
                 {
-                    _MicrosoftAspNetCoreHttpLogging = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpLogging).GetReference(filePath: "Microsoft.AspNetCore.HttpLogging.dll", display: "Microsoft.AspNetCore.HttpLogging (aspnet80)");
+                    _MicrosoftAspNetCoreHttpLogging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.HttpLogging")).GetReference(filePath: "Microsoft.AspNetCore.HttpLogging.dll", display: "Microsoft.AspNetCore.HttpLogging (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpLogging;
             }
@@ -5302,7 +5302,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpOverrides is null)
                 {
-                    _MicrosoftAspNetCoreHttpOverrides = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpOverrides).GetReference(filePath: "Microsoft.AspNetCore.HttpOverrides.dll", display: "Microsoft.AspNetCore.HttpOverrides (aspnet80)");
+                    _MicrosoftAspNetCoreHttpOverrides = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.HttpOverrides")).GetReference(filePath: "Microsoft.AspNetCore.HttpOverrides.dll", display: "Microsoft.AspNetCore.HttpOverrides (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpOverrides;
             }
@@ -5319,7 +5319,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreHttpsPolicy is null)
                 {
-                    _MicrosoftAspNetCoreHttpsPolicy = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpsPolicy).GetReference(filePath: "Microsoft.AspNetCore.HttpsPolicy.dll", display: "Microsoft.AspNetCore.HttpsPolicy (aspnet80)");
+                    _MicrosoftAspNetCoreHttpsPolicy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.HttpsPolicy")).GetReference(filePath: "Microsoft.AspNetCore.HttpsPolicy.dll", display: "Microsoft.AspNetCore.HttpsPolicy (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreHttpsPolicy;
             }
@@ -5336,7 +5336,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreIdentity is null)
                 {
-                    _MicrosoftAspNetCoreIdentity = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreIdentity).GetReference(filePath: "Microsoft.AspNetCore.Identity.dll", display: "Microsoft.AspNetCore.Identity (aspnet80)");
+                    _MicrosoftAspNetCoreIdentity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Identity")).GetReference(filePath: "Microsoft.AspNetCore.Identity.dll", display: "Microsoft.AspNetCore.Identity (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreIdentity;
             }
@@ -5353,7 +5353,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreLocalization is null)
                 {
-                    _MicrosoftAspNetCoreLocalization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreLocalization).GetReference(filePath: "Microsoft.AspNetCore.Localization.dll", display: "Microsoft.AspNetCore.Localization (aspnet80)");
+                    _MicrosoftAspNetCoreLocalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Localization")).GetReference(filePath: "Microsoft.AspNetCore.Localization.dll", display: "Microsoft.AspNetCore.Localization (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreLocalization;
             }
@@ -5370,7 +5370,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreLocalizationRouting is null)
                 {
-                    _MicrosoftAspNetCoreLocalizationRouting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreLocalizationRouting).GetReference(filePath: "Microsoft.AspNetCore.Localization.Routing.dll", display: "Microsoft.AspNetCore.Localization.Routing (aspnet80)");
+                    _MicrosoftAspNetCoreLocalizationRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Localization.Routing")).GetReference(filePath: "Microsoft.AspNetCore.Localization.Routing.dll", display: "Microsoft.AspNetCore.Localization.Routing (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreLocalizationRouting;
             }
@@ -5387,7 +5387,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMetadata is null)
                 {
-                    _MicrosoftAspNetCoreMetadata = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMetadata).GetReference(filePath: "Microsoft.AspNetCore.Metadata.dll", display: "Microsoft.AspNetCore.Metadata (aspnet80)");
+                    _MicrosoftAspNetCoreMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Metadata")).GetReference(filePath: "Microsoft.AspNetCore.Metadata.dll", display: "Microsoft.AspNetCore.Metadata (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMetadata;
             }
@@ -5404,7 +5404,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreMvcAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Abstractions.dll", display: "Microsoft.AspNetCore.Mvc.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreMvcAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Abstractions.dll", display: "Microsoft.AspNetCore.Mvc.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcAbstractions;
             }
@@ -5421,7 +5421,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcApiExplorer is null)
                 {
-                    _MicrosoftAspNetCoreMvcApiExplorer = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcApiExplorer).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ApiExplorer.dll", display: "Microsoft.AspNetCore.Mvc.ApiExplorer (aspnet80)");
+                    _MicrosoftAspNetCoreMvcApiExplorer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.ApiExplorer")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ApiExplorer.dll", display: "Microsoft.AspNetCore.Mvc.ApiExplorer (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcApiExplorer;
             }
@@ -5438,7 +5438,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcCore is null)
                 {
-                    _MicrosoftAspNetCoreMvcCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcCore).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Core.dll", display: "Microsoft.AspNetCore.Mvc.Core (aspnet80)");
+                    _MicrosoftAspNetCoreMvcCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.Core")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Core.dll", display: "Microsoft.AspNetCore.Mvc.Core (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcCore;
             }
@@ -5455,7 +5455,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcCors is null)
                 {
-                    _MicrosoftAspNetCoreMvcCors = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcCors).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Cors.dll", display: "Microsoft.AspNetCore.Mvc.Cors (aspnet80)");
+                    _MicrosoftAspNetCoreMvcCors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.Cors")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Cors.dll", display: "Microsoft.AspNetCore.Mvc.Cors (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcCors;
             }
@@ -5472,7 +5472,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcDataAnnotations is null)
                 {
-                    _MicrosoftAspNetCoreMvcDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcDataAnnotations).GetReference(filePath: "Microsoft.AspNetCore.Mvc.DataAnnotations.dll", display: "Microsoft.AspNetCore.Mvc.DataAnnotations (aspnet80)");
+                    _MicrosoftAspNetCoreMvcDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.DataAnnotations")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.DataAnnotations.dll", display: "Microsoft.AspNetCore.Mvc.DataAnnotations (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcDataAnnotations;
             }
@@ -5489,7 +5489,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvc is null)
                 {
-                    _MicrosoftAspNetCoreMvc = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvc).GetReference(filePath: "Microsoft.AspNetCore.Mvc.dll", display: "Microsoft.AspNetCore.Mvc (aspnet80)");
+                    _MicrosoftAspNetCoreMvc = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.dll", display: "Microsoft.AspNetCore.Mvc (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvc;
             }
@@ -5506,7 +5506,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcFormattersJson is null)
                 {
-                    _MicrosoftAspNetCoreMvcFormattersJson = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcFormattersJson).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Json.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Json (aspnet80)");
+                    _MicrosoftAspNetCoreMvcFormattersJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.Formatters.Json")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Json.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Json (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcFormattersJson;
             }
@@ -5523,7 +5523,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcFormattersXml is null)
                 {
-                    _MicrosoftAspNetCoreMvcFormattersXml = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcFormattersXml).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Xml.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Xml (aspnet80)");
+                    _MicrosoftAspNetCoreMvcFormattersXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.Formatters.Xml")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Xml.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Xml (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcFormattersXml;
             }
@@ -5540,7 +5540,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcLocalization is null)
                 {
-                    _MicrosoftAspNetCoreMvcLocalization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcLocalization).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Localization.dll", display: "Microsoft.AspNetCore.Mvc.Localization (aspnet80)");
+                    _MicrosoftAspNetCoreMvcLocalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.Localization")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Localization.dll", display: "Microsoft.AspNetCore.Mvc.Localization (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcLocalization;
             }
@@ -5557,7 +5557,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcRazor is null)
                 {
-                    _MicrosoftAspNetCoreMvcRazor = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcRazor).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Razor.dll", display: "Microsoft.AspNetCore.Mvc.Razor (aspnet80)");
+                    _MicrosoftAspNetCoreMvcRazor = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.Razor")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Razor.dll", display: "Microsoft.AspNetCore.Mvc.Razor (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcRazor;
             }
@@ -5574,7 +5574,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcRazorPages is null)
                 {
-                    _MicrosoftAspNetCoreMvcRazorPages = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcRazorPages).GetReference(filePath: "Microsoft.AspNetCore.Mvc.RazorPages.dll", display: "Microsoft.AspNetCore.Mvc.RazorPages (aspnet80)");
+                    _MicrosoftAspNetCoreMvcRazorPages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.RazorPages")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.RazorPages.dll", display: "Microsoft.AspNetCore.Mvc.RazorPages (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcRazorPages;
             }
@@ -5591,7 +5591,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcTagHelpers is null)
                 {
-                    _MicrosoftAspNetCoreMvcTagHelpers = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcTagHelpers).GetReference(filePath: "Microsoft.AspNetCore.Mvc.TagHelpers.dll", display: "Microsoft.AspNetCore.Mvc.TagHelpers (aspnet80)");
+                    _MicrosoftAspNetCoreMvcTagHelpers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.TagHelpers")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.TagHelpers.dll", display: "Microsoft.AspNetCore.Mvc.TagHelpers (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcTagHelpers;
             }
@@ -5608,7 +5608,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreMvcViewFeatures is null)
                 {
-                    _MicrosoftAspNetCoreMvcViewFeatures = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcViewFeatures).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ViewFeatures.dll", display: "Microsoft.AspNetCore.Mvc.ViewFeatures (aspnet80)");
+                    _MicrosoftAspNetCoreMvcViewFeatures = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Mvc.ViewFeatures")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ViewFeatures.dll", display: "Microsoft.AspNetCore.Mvc.ViewFeatures (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreMvcViewFeatures;
             }
@@ -5625,7 +5625,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreOutputCaching is null)
                 {
-                    _MicrosoftAspNetCoreOutputCaching = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreOutputCaching).GetReference(filePath: "Microsoft.AspNetCore.OutputCaching.dll", display: "Microsoft.AspNetCore.OutputCaching (aspnet80)");
+                    _MicrosoftAspNetCoreOutputCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.OutputCaching")).GetReference(filePath: "Microsoft.AspNetCore.OutputCaching.dll", display: "Microsoft.AspNetCore.OutputCaching (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreOutputCaching;
             }
@@ -5642,7 +5642,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreRateLimiting is null)
                 {
-                    _MicrosoftAspNetCoreRateLimiting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRateLimiting).GetReference(filePath: "Microsoft.AspNetCore.RateLimiting.dll", display: "Microsoft.AspNetCore.RateLimiting (aspnet80)");
+                    _MicrosoftAspNetCoreRateLimiting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.RateLimiting")).GetReference(filePath: "Microsoft.AspNetCore.RateLimiting.dll", display: "Microsoft.AspNetCore.RateLimiting (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreRateLimiting;
             }
@@ -5659,7 +5659,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreRazor is null)
                 {
-                    _MicrosoftAspNetCoreRazor = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRazor).GetReference(filePath: "Microsoft.AspNetCore.Razor.dll", display: "Microsoft.AspNetCore.Razor (aspnet80)");
+                    _MicrosoftAspNetCoreRazor = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Razor")).GetReference(filePath: "Microsoft.AspNetCore.Razor.dll", display: "Microsoft.AspNetCore.Razor (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreRazor;
             }
@@ -5676,7 +5676,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreRazorRuntime is null)
                 {
-                    _MicrosoftAspNetCoreRazorRuntime = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRazorRuntime).GetReference(filePath: "Microsoft.AspNetCore.Razor.Runtime.dll", display: "Microsoft.AspNetCore.Razor.Runtime (aspnet80)");
+                    _MicrosoftAspNetCoreRazorRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Razor.Runtime")).GetReference(filePath: "Microsoft.AspNetCore.Razor.Runtime.dll", display: "Microsoft.AspNetCore.Razor.Runtime (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreRazorRuntime;
             }
@@ -5693,7 +5693,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreRequestDecompression is null)
                 {
-                    _MicrosoftAspNetCoreRequestDecompression = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRequestDecompression).GetReference(filePath: "Microsoft.AspNetCore.RequestDecompression.dll", display: "Microsoft.AspNetCore.RequestDecompression (aspnet80)");
+                    _MicrosoftAspNetCoreRequestDecompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.RequestDecompression")).GetReference(filePath: "Microsoft.AspNetCore.RequestDecompression.dll", display: "Microsoft.AspNetCore.RequestDecompression (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreRequestDecompression;
             }
@@ -5710,7 +5710,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreResponseCachingAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreResponseCachingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreResponseCachingAbstractions).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.Abstractions.dll", display: "Microsoft.AspNetCore.ResponseCaching.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreResponseCachingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.ResponseCaching.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.Abstractions.dll", display: "Microsoft.AspNetCore.ResponseCaching.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreResponseCachingAbstractions;
             }
@@ -5727,7 +5727,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreResponseCaching is null)
                 {
-                    _MicrosoftAspNetCoreResponseCaching = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreResponseCaching).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.dll", display: "Microsoft.AspNetCore.ResponseCaching (aspnet80)");
+                    _MicrosoftAspNetCoreResponseCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.ResponseCaching")).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.dll", display: "Microsoft.AspNetCore.ResponseCaching (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreResponseCaching;
             }
@@ -5744,7 +5744,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreResponseCompression is null)
                 {
-                    _MicrosoftAspNetCoreResponseCompression = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreResponseCompression).GetReference(filePath: "Microsoft.AspNetCore.ResponseCompression.dll", display: "Microsoft.AspNetCore.ResponseCompression (aspnet80)");
+                    _MicrosoftAspNetCoreResponseCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.ResponseCompression")).GetReference(filePath: "Microsoft.AspNetCore.ResponseCompression.dll", display: "Microsoft.AspNetCore.ResponseCompression (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreResponseCompression;
             }
@@ -5761,7 +5761,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreRewrite is null)
                 {
-                    _MicrosoftAspNetCoreRewrite = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRewrite).GetReference(filePath: "Microsoft.AspNetCore.Rewrite.dll", display: "Microsoft.AspNetCore.Rewrite (aspnet80)");
+                    _MicrosoftAspNetCoreRewrite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Rewrite")).GetReference(filePath: "Microsoft.AspNetCore.Rewrite.dll", display: "Microsoft.AspNetCore.Rewrite (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreRewrite;
             }
@@ -5778,7 +5778,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreRoutingAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreRoutingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRoutingAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Routing.Abstractions.dll", display: "Microsoft.AspNetCore.Routing.Abstractions (aspnet80)");
+                    _MicrosoftAspNetCoreRoutingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Routing.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Routing.Abstractions.dll", display: "Microsoft.AspNetCore.Routing.Abstractions (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreRoutingAbstractions;
             }
@@ -5795,7 +5795,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreRouting is null)
                 {
-                    _MicrosoftAspNetCoreRouting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRouting).GetReference(filePath: "Microsoft.AspNetCore.Routing.dll", display: "Microsoft.AspNetCore.Routing (aspnet80)");
+                    _MicrosoftAspNetCoreRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Routing")).GetReference(filePath: "Microsoft.AspNetCore.Routing.dll", display: "Microsoft.AspNetCore.Routing (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreRouting;
             }
@@ -5812,7 +5812,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerHttpSys is null)
                 {
-                    _MicrosoftAspNetCoreServerHttpSys = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerHttpSys).GetReference(filePath: "Microsoft.AspNetCore.Server.HttpSys.dll", display: "Microsoft.AspNetCore.Server.HttpSys (aspnet80)");
+                    _MicrosoftAspNetCoreServerHttpSys = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.HttpSys")).GetReference(filePath: "Microsoft.AspNetCore.Server.HttpSys.dll", display: "Microsoft.AspNetCore.Server.HttpSys (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerHttpSys;
             }
@@ -5829,7 +5829,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerIIS is null)
                 {
-                    _MicrosoftAspNetCoreServerIIS = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerIIS).GetReference(filePath: "Microsoft.AspNetCore.Server.IIS.dll", display: "Microsoft.AspNetCore.Server.IIS (aspnet80)");
+                    _MicrosoftAspNetCoreServerIIS = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.IIS")).GetReference(filePath: "Microsoft.AspNetCore.Server.IIS.dll", display: "Microsoft.AspNetCore.Server.IIS (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerIIS;
             }
@@ -5846,7 +5846,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerIISIntegration is null)
                 {
-                    _MicrosoftAspNetCoreServerIISIntegration = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerIISIntegration).GetReference(filePath: "Microsoft.AspNetCore.Server.IISIntegration.dll", display: "Microsoft.AspNetCore.Server.IISIntegration (aspnet80)");
+                    _MicrosoftAspNetCoreServerIISIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.IISIntegration")).GetReference(filePath: "Microsoft.AspNetCore.Server.IISIntegration.dll", display: "Microsoft.AspNetCore.Server.IISIntegration (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerIISIntegration;
             }
@@ -5863,7 +5863,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerKestrelCore is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelCore).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Core.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Core (aspnet80)");
+                    _MicrosoftAspNetCoreServerKestrelCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.Kestrel.Core")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Core.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Core (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelCore;
             }
@@ -5880,7 +5880,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerKestrel is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrel = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrel).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.dll", display: "Microsoft.AspNetCore.Server.Kestrel (aspnet80)");
+                    _MicrosoftAspNetCoreServerKestrel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.Kestrel")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.dll", display: "Microsoft.AspNetCore.Server.Kestrel (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerKestrel;
             }
@@ -5897,7 +5897,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerKestrelTransportNamedPipes is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelTransportNamedPipes = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelTransportNamedPipes).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes (aspnet80)");
+                    _MicrosoftAspNetCoreServerKestrelTransportNamedPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelTransportNamedPipes;
             }
@@ -5914,7 +5914,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerKestrelTransportQuic is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelTransportQuic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelTransportQuic).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic (aspnet80)");
+                    _MicrosoftAspNetCoreServerKestrelTransportQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.Quic")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelTransportQuic;
             }
@@ -5931,7 +5931,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreServerKestrelTransportSockets is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelTransportSockets = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelTransportSockets).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (aspnet80)");
+                    _MicrosoftAspNetCoreServerKestrelTransportSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelTransportSockets;
             }
@@ -5948,7 +5948,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreSession is null)
                 {
-                    _MicrosoftAspNetCoreSession = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSession).GetReference(filePath: "Microsoft.AspNetCore.Session.dll", display: "Microsoft.AspNetCore.Session (aspnet80)");
+                    _MicrosoftAspNetCoreSession = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.Session")).GetReference(filePath: "Microsoft.AspNetCore.Session.dll", display: "Microsoft.AspNetCore.Session (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreSession;
             }
@@ -5965,7 +5965,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreSignalRCommon is null)
                 {
-                    _MicrosoftAspNetCoreSignalRCommon = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalRCommon).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Common.dll", display: "Microsoft.AspNetCore.SignalR.Common (aspnet80)");
+                    _MicrosoftAspNetCoreSignalRCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.SignalR.Common")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Common.dll", display: "Microsoft.AspNetCore.SignalR.Common (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreSignalRCommon;
             }
@@ -5982,7 +5982,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreSignalRCore is null)
                 {
-                    _MicrosoftAspNetCoreSignalRCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalRCore).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Core.dll", display: "Microsoft.AspNetCore.SignalR.Core (aspnet80)");
+                    _MicrosoftAspNetCoreSignalRCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.SignalR.Core")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Core.dll", display: "Microsoft.AspNetCore.SignalR.Core (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreSignalRCore;
             }
@@ -5999,7 +5999,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreSignalR is null)
                 {
-                    _MicrosoftAspNetCoreSignalR = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalR).GetReference(filePath: "Microsoft.AspNetCore.SignalR.dll", display: "Microsoft.AspNetCore.SignalR (aspnet80)");
+                    _MicrosoftAspNetCoreSignalR = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.SignalR")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.dll", display: "Microsoft.AspNetCore.SignalR (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreSignalR;
             }
@@ -6016,7 +6016,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreSignalRProtocolsJson is null)
                 {
-                    _MicrosoftAspNetCoreSignalRProtocolsJson = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalRProtocolsJson).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Protocols.Json.dll", display: "Microsoft.AspNetCore.SignalR.Protocols.Json (aspnet80)");
+                    _MicrosoftAspNetCoreSignalRProtocolsJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.SignalR.Protocols.Json")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Protocols.Json.dll", display: "Microsoft.AspNetCore.SignalR.Protocols.Json (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreSignalRProtocolsJson;
             }
@@ -6033,7 +6033,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreStaticFiles is null)
                 {
-                    _MicrosoftAspNetCoreStaticFiles = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreStaticFiles).GetReference(filePath: "Microsoft.AspNetCore.StaticFiles.dll", display: "Microsoft.AspNetCore.StaticFiles (aspnet80)");
+                    _MicrosoftAspNetCoreStaticFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.StaticFiles")).GetReference(filePath: "Microsoft.AspNetCore.StaticFiles.dll", display: "Microsoft.AspNetCore.StaticFiles (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreStaticFiles;
             }
@@ -6050,7 +6050,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreWebSockets is null)
                 {
-                    _MicrosoftAspNetCoreWebSockets = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreWebSockets).GetReference(filePath: "Microsoft.AspNetCore.WebSockets.dll", display: "Microsoft.AspNetCore.WebSockets (aspnet80)");
+                    _MicrosoftAspNetCoreWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.WebSockets")).GetReference(filePath: "Microsoft.AspNetCore.WebSockets.dll", display: "Microsoft.AspNetCore.WebSockets (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreWebSockets;
             }
@@ -6067,7 +6067,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftAspNetCoreWebUtilities is null)
                 {
-                    _MicrosoftAspNetCoreWebUtilities = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreWebUtilities).GetReference(filePath: "Microsoft.AspNetCore.WebUtilities.dll", display: "Microsoft.AspNetCore.WebUtilities (aspnet80)");
+                    _MicrosoftAspNetCoreWebUtilities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.AspNetCore.WebUtilities")).GetReference(filePath: "Microsoft.AspNetCore.WebUtilities.dll", display: "Microsoft.AspNetCore.WebUtilities (aspnet80)");
                 }
                 return _MicrosoftAspNetCoreWebUtilities;
             }
@@ -6084,7 +6084,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsCachingAbstractions is null)
                 {
-                    _MicrosoftExtensionsCachingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsCachingAbstractions).GetReference(filePath: "Microsoft.Extensions.Caching.Abstractions.dll", display: "Microsoft.Extensions.Caching.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsCachingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Caching.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Caching.Abstractions.dll", display: "Microsoft.Extensions.Caching.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsCachingAbstractions;
             }
@@ -6101,7 +6101,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsCachingMemory is null)
                 {
-                    _MicrosoftExtensionsCachingMemory = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsCachingMemory).GetReference(filePath: "Microsoft.Extensions.Caching.Memory.dll", display: "Microsoft.Extensions.Caching.Memory (aspnet80)");
+                    _MicrosoftExtensionsCachingMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Caching.Memory")).GetReference(filePath: "Microsoft.Extensions.Caching.Memory.dll", display: "Microsoft.Extensions.Caching.Memory (aspnet80)");
                 }
                 return _MicrosoftExtensionsCachingMemory;
             }
@@ -6118,7 +6118,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationAbstractions is null)
                 {
-                    _MicrosoftExtensionsConfigurationAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationAbstractions).GetReference(filePath: "Microsoft.Extensions.Configuration.Abstractions.dll", display: "Microsoft.Extensions.Configuration.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsConfigurationAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Configuration.Abstractions.dll", display: "Microsoft.Extensions.Configuration.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationAbstractions;
             }
@@ -6135,7 +6135,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationBinder is null)
                 {
-                    _MicrosoftExtensionsConfigurationBinder = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationBinder).GetReference(filePath: "Microsoft.Extensions.Configuration.Binder.dll", display: "Microsoft.Extensions.Configuration.Binder (aspnet80)");
+                    _MicrosoftExtensionsConfigurationBinder = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.Binder")).GetReference(filePath: "Microsoft.Extensions.Configuration.Binder.dll", display: "Microsoft.Extensions.Configuration.Binder (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationBinder;
             }
@@ -6152,7 +6152,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationCommandLine is null)
                 {
-                    _MicrosoftExtensionsConfigurationCommandLine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationCommandLine).GetReference(filePath: "Microsoft.Extensions.Configuration.CommandLine.dll", display: "Microsoft.Extensions.Configuration.CommandLine (aspnet80)");
+                    _MicrosoftExtensionsConfigurationCommandLine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.CommandLine")).GetReference(filePath: "Microsoft.Extensions.Configuration.CommandLine.dll", display: "Microsoft.Extensions.Configuration.CommandLine (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationCommandLine;
             }
@@ -6169,7 +6169,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfiguration is null)
                 {
-                    _MicrosoftExtensionsConfiguration = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfiguration).GetReference(filePath: "Microsoft.Extensions.Configuration.dll", display: "Microsoft.Extensions.Configuration (aspnet80)");
+                    _MicrosoftExtensionsConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration")).GetReference(filePath: "Microsoft.Extensions.Configuration.dll", display: "Microsoft.Extensions.Configuration (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfiguration;
             }
@@ -6186,7 +6186,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationEnvironmentVariables is null)
                 {
-                    _MicrosoftExtensionsConfigurationEnvironmentVariables = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationEnvironmentVariables).GetReference(filePath: "Microsoft.Extensions.Configuration.EnvironmentVariables.dll", display: "Microsoft.Extensions.Configuration.EnvironmentVariables (aspnet80)");
+                    _MicrosoftExtensionsConfigurationEnvironmentVariables = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.EnvironmentVariables")).GetReference(filePath: "Microsoft.Extensions.Configuration.EnvironmentVariables.dll", display: "Microsoft.Extensions.Configuration.EnvironmentVariables (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationEnvironmentVariables;
             }
@@ -6203,7 +6203,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationFileExtensions is null)
                 {
-                    _MicrosoftExtensionsConfigurationFileExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationFileExtensions).GetReference(filePath: "Microsoft.Extensions.Configuration.FileExtensions.dll", display: "Microsoft.Extensions.Configuration.FileExtensions (aspnet80)");
+                    _MicrosoftExtensionsConfigurationFileExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.FileExtensions")).GetReference(filePath: "Microsoft.Extensions.Configuration.FileExtensions.dll", display: "Microsoft.Extensions.Configuration.FileExtensions (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationFileExtensions;
             }
@@ -6220,7 +6220,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationIni is null)
                 {
-                    _MicrosoftExtensionsConfigurationIni = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationIni).GetReference(filePath: "Microsoft.Extensions.Configuration.Ini.dll", display: "Microsoft.Extensions.Configuration.Ini (aspnet80)");
+                    _MicrosoftExtensionsConfigurationIni = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.Ini")).GetReference(filePath: "Microsoft.Extensions.Configuration.Ini.dll", display: "Microsoft.Extensions.Configuration.Ini (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationIni;
             }
@@ -6237,7 +6237,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationJson is null)
                 {
-                    _MicrosoftExtensionsConfigurationJson = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationJson).GetReference(filePath: "Microsoft.Extensions.Configuration.Json.dll", display: "Microsoft.Extensions.Configuration.Json (aspnet80)");
+                    _MicrosoftExtensionsConfigurationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.Json")).GetReference(filePath: "Microsoft.Extensions.Configuration.Json.dll", display: "Microsoft.Extensions.Configuration.Json (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationJson;
             }
@@ -6254,7 +6254,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationKeyPerFile is null)
                 {
-                    _MicrosoftExtensionsConfigurationKeyPerFile = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationKeyPerFile).GetReference(filePath: "Microsoft.Extensions.Configuration.KeyPerFile.dll", display: "Microsoft.Extensions.Configuration.KeyPerFile (aspnet80)");
+                    _MicrosoftExtensionsConfigurationKeyPerFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.KeyPerFile")).GetReference(filePath: "Microsoft.Extensions.Configuration.KeyPerFile.dll", display: "Microsoft.Extensions.Configuration.KeyPerFile (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationKeyPerFile;
             }
@@ -6271,7 +6271,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationUserSecrets is null)
                 {
-                    _MicrosoftExtensionsConfigurationUserSecrets = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationUserSecrets).GetReference(filePath: "Microsoft.Extensions.Configuration.UserSecrets.dll", display: "Microsoft.Extensions.Configuration.UserSecrets (aspnet80)");
+                    _MicrosoftExtensionsConfigurationUserSecrets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.UserSecrets")).GetReference(filePath: "Microsoft.Extensions.Configuration.UserSecrets.dll", display: "Microsoft.Extensions.Configuration.UserSecrets (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationUserSecrets;
             }
@@ -6288,7 +6288,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsConfigurationXml is null)
                 {
-                    _MicrosoftExtensionsConfigurationXml = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationXml).GetReference(filePath: "Microsoft.Extensions.Configuration.Xml.dll", display: "Microsoft.Extensions.Configuration.Xml (aspnet80)");
+                    _MicrosoftExtensionsConfigurationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Configuration.Xml")).GetReference(filePath: "Microsoft.Extensions.Configuration.Xml.dll", display: "Microsoft.Extensions.Configuration.Xml (aspnet80)");
                 }
                 return _MicrosoftExtensionsConfigurationXml;
             }
@@ -6305,7 +6305,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsDependencyInjectionAbstractions is null)
                 {
-                    _MicrosoftExtensionsDependencyInjectionAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDependencyInjectionAbstractions).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.Abstractions.dll", display: "Microsoft.Extensions.DependencyInjection.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsDependencyInjectionAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.DependencyInjection.Abstractions")).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.Abstractions.dll", display: "Microsoft.Extensions.DependencyInjection.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsDependencyInjectionAbstractions;
             }
@@ -6322,7 +6322,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsDependencyInjection is null)
                 {
-                    _MicrosoftExtensionsDependencyInjection = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDependencyInjection).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.dll", display: "Microsoft.Extensions.DependencyInjection (aspnet80)");
+                    _MicrosoftExtensionsDependencyInjection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.DependencyInjection")).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.dll", display: "Microsoft.Extensions.DependencyInjection (aspnet80)");
                 }
                 return _MicrosoftExtensionsDependencyInjection;
             }
@@ -6339,7 +6339,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsDiagnosticsAbstractions is null)
                 {
-                    _MicrosoftExtensionsDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnosticsAbstractions).GetReference(filePath: "Microsoft.Extensions.Diagnostics.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Diagnostics.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsDiagnosticsAbstractions;
             }
@@ -6356,7 +6356,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsDiagnostics is null)
                 {
-                    _MicrosoftExtensionsDiagnostics = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnostics).GetReference(filePath: "Microsoft.Extensions.Diagnostics.dll", display: "Microsoft.Extensions.Diagnostics (aspnet80)");
+                    _MicrosoftExtensionsDiagnostics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Diagnostics")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.dll", display: "Microsoft.Extensions.Diagnostics (aspnet80)");
                 }
                 return _MicrosoftExtensionsDiagnostics;
             }
@@ -6373,7 +6373,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsDiagnosticsHealthChecksAbstractions is null)
                 {
-                    _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnosticsHealthChecksAbstractions).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions;
             }
@@ -6390,7 +6390,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsDiagnosticsHealthChecks is null)
                 {
-                    _MicrosoftExtensionsDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnosticsHealthChecks).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks (aspnet80)");
+                    _MicrosoftExtensionsDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Diagnostics.HealthChecks")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks (aspnet80)");
                 }
                 return _MicrosoftExtensionsDiagnosticsHealthChecks;
             }
@@ -6407,7 +6407,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsFeatures is null)
                 {
-                    _MicrosoftExtensionsFeatures = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFeatures).GetReference(filePath: "Microsoft.Extensions.Features.dll", display: "Microsoft.Extensions.Features (aspnet80)");
+                    _MicrosoftExtensionsFeatures = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Features")).GetReference(filePath: "Microsoft.Extensions.Features.dll", display: "Microsoft.Extensions.Features (aspnet80)");
                 }
                 return _MicrosoftExtensionsFeatures;
             }
@@ -6424,7 +6424,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsFileProvidersAbstractions is null)
                 {
-                    _MicrosoftExtensionsFileProvidersAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersAbstractions).GetReference(filePath: "Microsoft.Extensions.FileProviders.Abstractions.dll", display: "Microsoft.Extensions.FileProviders.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsFileProvidersAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.FileProviders.Abstractions")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Abstractions.dll", display: "Microsoft.Extensions.FileProviders.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsFileProvidersAbstractions;
             }
@@ -6441,7 +6441,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsFileProvidersComposite is null)
                 {
-                    _MicrosoftExtensionsFileProvidersComposite = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersComposite).GetReference(filePath: "Microsoft.Extensions.FileProviders.Composite.dll", display: "Microsoft.Extensions.FileProviders.Composite (aspnet80)");
+                    _MicrosoftExtensionsFileProvidersComposite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.FileProviders.Composite")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Composite.dll", display: "Microsoft.Extensions.FileProviders.Composite (aspnet80)");
                 }
                 return _MicrosoftExtensionsFileProvidersComposite;
             }
@@ -6458,7 +6458,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsFileProvidersEmbedded is null)
                 {
-                    _MicrosoftExtensionsFileProvidersEmbedded = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersEmbedded).GetReference(filePath: "Microsoft.Extensions.FileProviders.Embedded.dll", display: "Microsoft.Extensions.FileProviders.Embedded (aspnet80)");
+                    _MicrosoftExtensionsFileProvidersEmbedded = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.FileProviders.Embedded")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Embedded.dll", display: "Microsoft.Extensions.FileProviders.Embedded (aspnet80)");
                 }
                 return _MicrosoftExtensionsFileProvidersEmbedded;
             }
@@ -6475,7 +6475,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsFileProvidersPhysical is null)
                 {
-                    _MicrosoftExtensionsFileProvidersPhysical = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersPhysical).GetReference(filePath: "Microsoft.Extensions.FileProviders.Physical.dll", display: "Microsoft.Extensions.FileProviders.Physical (aspnet80)");
+                    _MicrosoftExtensionsFileProvidersPhysical = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.FileProviders.Physical")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Physical.dll", display: "Microsoft.Extensions.FileProviders.Physical (aspnet80)");
                 }
                 return _MicrosoftExtensionsFileProvidersPhysical;
             }
@@ -6492,7 +6492,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsFileSystemGlobbing is null)
                 {
-                    _MicrosoftExtensionsFileSystemGlobbing = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileSystemGlobbing).GetReference(filePath: "Microsoft.Extensions.FileSystemGlobbing.dll", display: "Microsoft.Extensions.FileSystemGlobbing (aspnet80)");
+                    _MicrosoftExtensionsFileSystemGlobbing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.FileSystemGlobbing")).GetReference(filePath: "Microsoft.Extensions.FileSystemGlobbing.dll", display: "Microsoft.Extensions.FileSystemGlobbing (aspnet80)");
                 }
                 return _MicrosoftExtensionsFileSystemGlobbing;
             }
@@ -6509,7 +6509,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsHostingAbstractions is null)
                 {
-                    _MicrosoftExtensionsHostingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsHostingAbstractions).GetReference(filePath: "Microsoft.Extensions.Hosting.Abstractions.dll", display: "Microsoft.Extensions.Hosting.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsHostingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Hosting.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Hosting.Abstractions.dll", display: "Microsoft.Extensions.Hosting.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsHostingAbstractions;
             }
@@ -6526,7 +6526,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsHosting is null)
                 {
-                    _MicrosoftExtensionsHosting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsHosting).GetReference(filePath: "Microsoft.Extensions.Hosting.dll", display: "Microsoft.Extensions.Hosting (aspnet80)");
+                    _MicrosoftExtensionsHosting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Hosting")).GetReference(filePath: "Microsoft.Extensions.Hosting.dll", display: "Microsoft.Extensions.Hosting (aspnet80)");
                 }
                 return _MicrosoftExtensionsHosting;
             }
@@ -6543,7 +6543,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsHttp is null)
                 {
-                    _MicrosoftExtensionsHttp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsHttp).GetReference(filePath: "Microsoft.Extensions.Http.dll", display: "Microsoft.Extensions.Http (aspnet80)");
+                    _MicrosoftExtensionsHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Http")).GetReference(filePath: "Microsoft.Extensions.Http.dll", display: "Microsoft.Extensions.Http (aspnet80)");
                 }
                 return _MicrosoftExtensionsHttp;
             }
@@ -6560,7 +6560,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsIdentityCore is null)
                 {
-                    _MicrosoftExtensionsIdentityCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsIdentityCore).GetReference(filePath: "Microsoft.Extensions.Identity.Core.dll", display: "Microsoft.Extensions.Identity.Core (aspnet80)");
+                    _MicrosoftExtensionsIdentityCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Identity.Core")).GetReference(filePath: "Microsoft.Extensions.Identity.Core.dll", display: "Microsoft.Extensions.Identity.Core (aspnet80)");
                 }
                 return _MicrosoftExtensionsIdentityCore;
             }
@@ -6577,7 +6577,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsIdentityStores is null)
                 {
-                    _MicrosoftExtensionsIdentityStores = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsIdentityStores).GetReference(filePath: "Microsoft.Extensions.Identity.Stores.dll", display: "Microsoft.Extensions.Identity.Stores (aspnet80)");
+                    _MicrosoftExtensionsIdentityStores = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Identity.Stores")).GetReference(filePath: "Microsoft.Extensions.Identity.Stores.dll", display: "Microsoft.Extensions.Identity.Stores (aspnet80)");
                 }
                 return _MicrosoftExtensionsIdentityStores;
             }
@@ -6594,7 +6594,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLocalizationAbstractions is null)
                 {
-                    _MicrosoftExtensionsLocalizationAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLocalizationAbstractions).GetReference(filePath: "Microsoft.Extensions.Localization.Abstractions.dll", display: "Microsoft.Extensions.Localization.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsLocalizationAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Localization.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Localization.Abstractions.dll", display: "Microsoft.Extensions.Localization.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsLocalizationAbstractions;
             }
@@ -6611,7 +6611,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLocalization is null)
                 {
-                    _MicrosoftExtensionsLocalization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLocalization).GetReference(filePath: "Microsoft.Extensions.Localization.dll", display: "Microsoft.Extensions.Localization (aspnet80)");
+                    _MicrosoftExtensionsLocalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Localization")).GetReference(filePath: "Microsoft.Extensions.Localization.dll", display: "Microsoft.Extensions.Localization (aspnet80)");
                 }
                 return _MicrosoftExtensionsLocalization;
             }
@@ -6628,7 +6628,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLoggingAbstractions is null)
                 {
-                    _MicrosoftExtensionsLoggingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingAbstractions).GetReference(filePath: "Microsoft.Extensions.Logging.Abstractions.dll", display: "Microsoft.Extensions.Logging.Abstractions (aspnet80)");
+                    _MicrosoftExtensionsLoggingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Logging.Abstractions.dll", display: "Microsoft.Extensions.Logging.Abstractions (aspnet80)");
                 }
                 return _MicrosoftExtensionsLoggingAbstractions;
             }
@@ -6645,7 +6645,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLoggingConfiguration is null)
                 {
-                    _MicrosoftExtensionsLoggingConfiguration = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingConfiguration).GetReference(filePath: "Microsoft.Extensions.Logging.Configuration.dll", display: "Microsoft.Extensions.Logging.Configuration (aspnet80)");
+                    _MicrosoftExtensionsLoggingConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging.Configuration")).GetReference(filePath: "Microsoft.Extensions.Logging.Configuration.dll", display: "Microsoft.Extensions.Logging.Configuration (aspnet80)");
                 }
                 return _MicrosoftExtensionsLoggingConfiguration;
             }
@@ -6662,7 +6662,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLoggingConsole is null)
                 {
-                    _MicrosoftExtensionsLoggingConsole = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingConsole).GetReference(filePath: "Microsoft.Extensions.Logging.Console.dll", display: "Microsoft.Extensions.Logging.Console (aspnet80)");
+                    _MicrosoftExtensionsLoggingConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging.Console")).GetReference(filePath: "Microsoft.Extensions.Logging.Console.dll", display: "Microsoft.Extensions.Logging.Console (aspnet80)");
                 }
                 return _MicrosoftExtensionsLoggingConsole;
             }
@@ -6679,7 +6679,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLoggingDebug is null)
                 {
-                    _MicrosoftExtensionsLoggingDebug = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingDebug).GetReference(filePath: "Microsoft.Extensions.Logging.Debug.dll", display: "Microsoft.Extensions.Logging.Debug (aspnet80)");
+                    _MicrosoftExtensionsLoggingDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging.Debug")).GetReference(filePath: "Microsoft.Extensions.Logging.Debug.dll", display: "Microsoft.Extensions.Logging.Debug (aspnet80)");
                 }
                 return _MicrosoftExtensionsLoggingDebug;
             }
@@ -6696,7 +6696,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLogging is null)
                 {
-                    _MicrosoftExtensionsLogging = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLogging).GetReference(filePath: "Microsoft.Extensions.Logging.dll", display: "Microsoft.Extensions.Logging (aspnet80)");
+                    _MicrosoftExtensionsLogging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging")).GetReference(filePath: "Microsoft.Extensions.Logging.dll", display: "Microsoft.Extensions.Logging (aspnet80)");
                 }
                 return _MicrosoftExtensionsLogging;
             }
@@ -6713,7 +6713,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLoggingEventLog is null)
                 {
-                    _MicrosoftExtensionsLoggingEventLog = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingEventLog).GetReference(filePath: "Microsoft.Extensions.Logging.EventLog.dll", display: "Microsoft.Extensions.Logging.EventLog (aspnet80)");
+                    _MicrosoftExtensionsLoggingEventLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging.EventLog")).GetReference(filePath: "Microsoft.Extensions.Logging.EventLog.dll", display: "Microsoft.Extensions.Logging.EventLog (aspnet80)");
                 }
                 return _MicrosoftExtensionsLoggingEventLog;
             }
@@ -6730,7 +6730,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLoggingEventSource is null)
                 {
-                    _MicrosoftExtensionsLoggingEventSource = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingEventSource).GetReference(filePath: "Microsoft.Extensions.Logging.EventSource.dll", display: "Microsoft.Extensions.Logging.EventSource (aspnet80)");
+                    _MicrosoftExtensionsLoggingEventSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging.EventSource")).GetReference(filePath: "Microsoft.Extensions.Logging.EventSource.dll", display: "Microsoft.Extensions.Logging.EventSource (aspnet80)");
                 }
                 return _MicrosoftExtensionsLoggingEventSource;
             }
@@ -6747,7 +6747,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsLoggingTraceSource is null)
                 {
-                    _MicrosoftExtensionsLoggingTraceSource = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingTraceSource).GetReference(filePath: "Microsoft.Extensions.Logging.TraceSource.dll", display: "Microsoft.Extensions.Logging.TraceSource (aspnet80)");
+                    _MicrosoftExtensionsLoggingTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Logging.TraceSource")).GetReference(filePath: "Microsoft.Extensions.Logging.TraceSource.dll", display: "Microsoft.Extensions.Logging.TraceSource (aspnet80)");
                 }
                 return _MicrosoftExtensionsLoggingTraceSource;
             }
@@ -6764,7 +6764,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsObjectPool is null)
                 {
-                    _MicrosoftExtensionsObjectPool = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsObjectPool).GetReference(filePath: "Microsoft.Extensions.ObjectPool.dll", display: "Microsoft.Extensions.ObjectPool (aspnet80)");
+                    _MicrosoftExtensionsObjectPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.ObjectPool")).GetReference(filePath: "Microsoft.Extensions.ObjectPool.dll", display: "Microsoft.Extensions.ObjectPool (aspnet80)");
                 }
                 return _MicrosoftExtensionsObjectPool;
             }
@@ -6781,7 +6781,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsOptionsConfigurationExtensions is null)
                 {
-                    _MicrosoftExtensionsOptionsConfigurationExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsOptionsConfigurationExtensions).GetReference(filePath: "Microsoft.Extensions.Options.ConfigurationExtensions.dll", display: "Microsoft.Extensions.Options.ConfigurationExtensions (aspnet80)");
+                    _MicrosoftExtensionsOptionsConfigurationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Options.ConfigurationExtensions")).GetReference(filePath: "Microsoft.Extensions.Options.ConfigurationExtensions.dll", display: "Microsoft.Extensions.Options.ConfigurationExtensions (aspnet80)");
                 }
                 return _MicrosoftExtensionsOptionsConfigurationExtensions;
             }
@@ -6798,7 +6798,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsOptionsDataAnnotations is null)
                 {
-                    _MicrosoftExtensionsOptionsDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsOptionsDataAnnotations).GetReference(filePath: "Microsoft.Extensions.Options.DataAnnotations.dll", display: "Microsoft.Extensions.Options.DataAnnotations (aspnet80)");
+                    _MicrosoftExtensionsOptionsDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Options.DataAnnotations")).GetReference(filePath: "Microsoft.Extensions.Options.DataAnnotations.dll", display: "Microsoft.Extensions.Options.DataAnnotations (aspnet80)");
                 }
                 return _MicrosoftExtensionsOptionsDataAnnotations;
             }
@@ -6815,7 +6815,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsOptions is null)
                 {
-                    _MicrosoftExtensionsOptions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsOptions).GetReference(filePath: "Microsoft.Extensions.Options.dll", display: "Microsoft.Extensions.Options (aspnet80)");
+                    _MicrosoftExtensionsOptions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Options")).GetReference(filePath: "Microsoft.Extensions.Options.dll", display: "Microsoft.Extensions.Options (aspnet80)");
                 }
                 return _MicrosoftExtensionsOptions;
             }
@@ -6832,7 +6832,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsPrimitives is null)
                 {
-                    _MicrosoftExtensionsPrimitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsPrimitives).GetReference(filePath: "Microsoft.Extensions.Primitives.dll", display: "Microsoft.Extensions.Primitives (aspnet80)");
+                    _MicrosoftExtensionsPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.Primitives")).GetReference(filePath: "Microsoft.Extensions.Primitives.dll", display: "Microsoft.Extensions.Primitives (aspnet80)");
                 }
                 return _MicrosoftExtensionsPrimitives;
             }
@@ -6849,7 +6849,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftExtensionsWebEncoders is null)
                 {
-                    _MicrosoftExtensionsWebEncoders = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsWebEncoders).GetReference(filePath: "Microsoft.Extensions.WebEncoders.dll", display: "Microsoft.Extensions.WebEncoders (aspnet80)");
+                    _MicrosoftExtensionsWebEncoders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Extensions.WebEncoders")).GetReference(filePath: "Microsoft.Extensions.WebEncoders.dll", display: "Microsoft.Extensions.WebEncoders (aspnet80)");
                 }
                 return _MicrosoftExtensionsWebEncoders;
             }
@@ -6866,7 +6866,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftJSInterop is null)
                 {
-                    _MicrosoftJSInterop = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJSInterop).GetReference(filePath: "Microsoft.JSInterop.dll", display: "Microsoft.JSInterop (aspnet80)");
+                    _MicrosoftJSInterop = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.JSInterop")).GetReference(filePath: "Microsoft.JSInterop.dll", display: "Microsoft.JSInterop (aspnet80)");
                 }
                 return _MicrosoftJSInterop;
             }
@@ -6883,7 +6883,7 @@ public static partial class AspNet80
             {
                 if (_MicrosoftNetHttpHeaders is null)
                 {
-                    _MicrosoftNetHttpHeaders = AssemblyMetadata.CreateFromImage(Resources.MicrosoftNetHttpHeaders).GetReference(filePath: "Microsoft.Net.Http.Headers.dll", display: "Microsoft.Net.Http.Headers (aspnet80)");
+                    _MicrosoftNetHttpHeaders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.Microsoft.Net.Http.Headers")).GetReference(filePath: "Microsoft.Net.Http.Headers.dll", display: "Microsoft.Net.Http.Headers (aspnet80)");
                 }
                 return _MicrosoftNetHttpHeaders;
             }
@@ -6900,7 +6900,7 @@ public static partial class AspNet80
             {
                 if (_SystemDiagnosticsEventLog is null)
                 {
-                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsEventLog).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (aspnet80)");
+                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Diagnostics.EventLog")).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (aspnet80)");
                 }
                 return _SystemDiagnosticsEventLog;
             }
@@ -6917,7 +6917,7 @@ public static partial class AspNet80
             {
                 if (_SystemIOPipelines is null)
                 {
-                    _SystemIOPipelines = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipelines).GetReference(filePath: "System.IO.Pipelines.dll", display: "System.IO.Pipelines (aspnet80)");
+                    _SystemIOPipelines = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.IO.Pipelines")).GetReference(filePath: "System.IO.Pipelines.dll", display: "System.IO.Pipelines (aspnet80)");
                 }
                 return _SystemIOPipelines;
             }
@@ -6934,7 +6934,7 @@ public static partial class AspNet80
             {
                 if (_SystemSecurityCryptographyXml is null)
                 {
-                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyXml).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (aspnet80)");
+                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Security.Cryptography.Xml")).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (aspnet80)");
                 }
                 return _SystemSecurityCryptographyXml;
             }
@@ -6951,7 +6951,7 @@ public static partial class AspNet80
             {
                 if (_SystemThreadingRateLimiting is null)
                 {
-                    _SystemThreadingRateLimiting = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingRateLimiting).GetReference(filePath: "System.Threading.RateLimiting.dll", display: "System.Threading.RateLimiting (aspnet80)");
+                    _SystemThreadingRateLimiting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet80.System.Threading.RateLimiting")).GetReference(filePath: "System.Threading.RateLimiting.dll", display: "System.Threading.RateLimiting (aspnet80)");
                 }
                 return _SystemThreadingRateLimiting;
             }

--- a/Src/Basic.Reference.Assemblies.AspNet90/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.AspNet90/Generated.cs
@@ -1857,7 +1857,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (aspnet90)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (aspnet90)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1874,7 +1874,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (aspnet90)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (aspnet90)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -1891,7 +1891,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (aspnet90)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (aspnet90)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1908,7 +1908,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (aspnet90)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (aspnet90)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1925,7 +1925,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftWin32Registry is null)
                 {
-                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Registry).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (aspnet90)");
+                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Win32.Registry")).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (aspnet90)");
                 }
                 return _MicrosoftWin32Registry;
             }
@@ -1942,7 +1942,7 @@ public static partial class AspNet90
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (aspnet90)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (aspnet90)");
                 }
                 return _mscorlib;
             }
@@ -1959,7 +1959,7 @@ public static partial class AspNet90
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (aspnet90)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (aspnet90)");
                 }
                 return _netstandard;
             }
@@ -1976,7 +1976,7 @@ public static partial class AspNet90
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (aspnet90)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (aspnet90)");
                 }
                 return _SystemAppContext;
             }
@@ -1993,7 +1993,7 @@ public static partial class AspNet90
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (aspnet90)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (aspnet90)");
                 }
                 return _SystemBuffers;
             }
@@ -2010,7 +2010,7 @@ public static partial class AspNet90
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (aspnet90)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (aspnet90)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -2027,7 +2027,7 @@ public static partial class AspNet90
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (aspnet90)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (aspnet90)");
                 }
                 return _SystemCollections;
             }
@@ -2044,7 +2044,7 @@ public static partial class AspNet90
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (aspnet90)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (aspnet90)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -2061,7 +2061,7 @@ public static partial class AspNet90
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (aspnet90)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (aspnet90)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -2078,7 +2078,7 @@ public static partial class AspNet90
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (aspnet90)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (aspnet90)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -2095,7 +2095,7 @@ public static partial class AspNet90
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (aspnet90)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (aspnet90)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -2112,7 +2112,7 @@ public static partial class AspNet90
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (aspnet90)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (aspnet90)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -2129,7 +2129,7 @@ public static partial class AspNet90
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (aspnet90)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (aspnet90)");
                 }
                 return _SystemComponentModel;
             }
@@ -2146,7 +2146,7 @@ public static partial class AspNet90
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (aspnet90)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (aspnet90)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -2163,7 +2163,7 @@ public static partial class AspNet90
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (aspnet90)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (aspnet90)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -2180,7 +2180,7 @@ public static partial class AspNet90
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (aspnet90)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (aspnet90)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -2197,7 +2197,7 @@ public static partial class AspNet90
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (aspnet90)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (aspnet90)");
                 }
                 return _SystemConfiguration;
             }
@@ -2214,7 +2214,7 @@ public static partial class AspNet90
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (aspnet90)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (aspnet90)");
                 }
                 return _SystemConsole;
             }
@@ -2231,7 +2231,7 @@ public static partial class AspNet90
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (aspnet90)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (aspnet90)");
                 }
                 return _SystemCore;
             }
@@ -2248,7 +2248,7 @@ public static partial class AspNet90
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (aspnet90)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (aspnet90)");
                 }
                 return _SystemDataCommon;
             }
@@ -2265,7 +2265,7 @@ public static partial class AspNet90
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (aspnet90)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (aspnet90)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -2282,7 +2282,7 @@ public static partial class AspNet90
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (aspnet90)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (aspnet90)");
                 }
                 return _SystemData;
             }
@@ -2299,7 +2299,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (aspnet90)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (aspnet90)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -2316,7 +2316,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (aspnet90)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (aspnet90)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -2333,7 +2333,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (aspnet90)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (aspnet90)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -2350,7 +2350,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (aspnet90)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (aspnet90)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -2367,7 +2367,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (aspnet90)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (aspnet90)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -2384,7 +2384,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (aspnet90)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (aspnet90)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -2401,7 +2401,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (aspnet90)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (aspnet90)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -2418,7 +2418,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (aspnet90)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (aspnet90)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -2435,7 +2435,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (aspnet90)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (aspnet90)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -2452,7 +2452,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (aspnet90)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (aspnet90)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -2469,7 +2469,7 @@ public static partial class AspNet90
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (aspnet90)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System")).GetReference(filePath: "System.dll", display: "System (aspnet90)");
                 }
                 return _System;
             }
@@ -2486,7 +2486,7 @@ public static partial class AspNet90
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (aspnet90)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (aspnet90)");
                 }
                 return _SystemDrawing;
             }
@@ -2503,7 +2503,7 @@ public static partial class AspNet90
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (aspnet90)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (aspnet90)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -2520,7 +2520,7 @@ public static partial class AspNet90
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (aspnet90)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (aspnet90)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -2537,7 +2537,7 @@ public static partial class AspNet90
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (aspnet90)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (aspnet90)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -2554,7 +2554,7 @@ public static partial class AspNet90
             {
                 if (_SystemFormatsTar is null)
                 {
-                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsTar).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (aspnet90)");
+                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Formats.Tar")).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (aspnet90)");
                 }
                 return _SystemFormatsTar;
             }
@@ -2571,7 +2571,7 @@ public static partial class AspNet90
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (aspnet90)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (aspnet90)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -2588,7 +2588,7 @@ public static partial class AspNet90
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (aspnet90)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (aspnet90)");
                 }
                 return _SystemGlobalization;
             }
@@ -2605,7 +2605,7 @@ public static partial class AspNet90
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (aspnet90)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (aspnet90)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -2622,7 +2622,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (aspnet90)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (aspnet90)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -2639,7 +2639,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (aspnet90)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (aspnet90)");
                 }
                 return _SystemIOCompression;
             }
@@ -2656,7 +2656,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (aspnet90)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (aspnet90)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -2673,7 +2673,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (aspnet90)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (aspnet90)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -2690,7 +2690,7 @@ public static partial class AspNet90
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (aspnet90)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (aspnet90)");
                 }
                 return _SystemIO;
             }
@@ -2707,7 +2707,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOFileSystemAccessControl is null)
                 {
-                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemAccessControl).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (aspnet90)");
+                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.FileSystem.AccessControl")).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (aspnet90)");
                 }
                 return _SystemIOFileSystemAccessControl;
             }
@@ -2724,7 +2724,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (aspnet90)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (aspnet90)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -2741,7 +2741,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (aspnet90)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (aspnet90)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -2758,7 +2758,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (aspnet90)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (aspnet90)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -2775,7 +2775,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (aspnet90)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (aspnet90)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -2792,7 +2792,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (aspnet90)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (aspnet90)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -2809,7 +2809,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (aspnet90)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (aspnet90)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -2826,7 +2826,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOPipelines is null)
                 {
-                    _SystemIOPipelines = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipelines).GetReference(filePath: "System.IO.Pipelines.dll", display: "System.IO.Pipelines (aspnet90)");
+                    _SystemIOPipelines = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.Pipelines")).GetReference(filePath: "System.IO.Pipelines.dll", display: "System.IO.Pipelines (aspnet90)");
                 }
                 return _SystemIOPipelines;
             }
@@ -2843,7 +2843,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOPipesAccessControl is null)
                 {
-                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipesAccessControl).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (aspnet90)");
+                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.Pipes.AccessControl")).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (aspnet90)");
                 }
                 return _SystemIOPipesAccessControl;
             }
@@ -2860,7 +2860,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (aspnet90)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (aspnet90)");
                 }
                 return _SystemIOPipes;
             }
@@ -2877,7 +2877,7 @@ public static partial class AspNet90
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (aspnet90)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (aspnet90)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -2894,7 +2894,7 @@ public static partial class AspNet90
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (aspnet90)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (aspnet90)");
                 }
                 return _SystemLinq;
             }
@@ -2911,7 +2911,7 @@ public static partial class AspNet90
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (aspnet90)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (aspnet90)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -2928,7 +2928,7 @@ public static partial class AspNet90
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (aspnet90)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (aspnet90)");
                 }
                 return _SystemLinqParallel;
             }
@@ -2945,7 +2945,7 @@ public static partial class AspNet90
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (aspnet90)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (aspnet90)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -2962,7 +2962,7 @@ public static partial class AspNet90
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (aspnet90)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (aspnet90)");
                 }
                 return _SystemMemory;
             }
@@ -2979,7 +2979,7 @@ public static partial class AspNet90
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (aspnet90)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (aspnet90)");
                 }
                 return _SystemNet;
             }
@@ -2996,7 +2996,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (aspnet90)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (aspnet90)");
                 }
                 return _SystemNetHttp;
             }
@@ -3013,7 +3013,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (aspnet90)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (aspnet90)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -3030,7 +3030,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (aspnet90)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (aspnet90)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -3047,7 +3047,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (aspnet90)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (aspnet90)");
                 }
                 return _SystemNetMail;
             }
@@ -3064,7 +3064,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (aspnet90)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (aspnet90)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -3081,7 +3081,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (aspnet90)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (aspnet90)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -3098,7 +3098,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (aspnet90)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (aspnet90)");
                 }
                 return _SystemNetPing;
             }
@@ -3115,7 +3115,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (aspnet90)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (aspnet90)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -3132,7 +3132,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetQuic is null)
                 {
-                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(Resources.SystemNetQuic).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (aspnet90)");
+                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Quic")).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (aspnet90)");
                 }
                 return _SystemNetQuic;
             }
@@ -3149,7 +3149,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (aspnet90)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (aspnet90)");
                 }
                 return _SystemNetRequests;
             }
@@ -3166,7 +3166,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (aspnet90)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (aspnet90)");
                 }
                 return _SystemNetSecurity;
             }
@@ -3183,7 +3183,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (aspnet90)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (aspnet90)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -3200,7 +3200,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (aspnet90)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (aspnet90)");
                 }
                 return _SystemNetSockets;
             }
@@ -3217,7 +3217,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (aspnet90)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (aspnet90)");
                 }
                 return _SystemNetWebClient;
             }
@@ -3234,7 +3234,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (aspnet90)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (aspnet90)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -3251,7 +3251,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (aspnet90)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (aspnet90)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -3268,7 +3268,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (aspnet90)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (aspnet90)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -3285,7 +3285,7 @@ public static partial class AspNet90
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (aspnet90)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (aspnet90)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -3302,7 +3302,7 @@ public static partial class AspNet90
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (aspnet90)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (aspnet90)");
                 }
                 return _SystemNumerics;
             }
@@ -3319,7 +3319,7 @@ public static partial class AspNet90
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (aspnet90)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (aspnet90)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -3336,7 +3336,7 @@ public static partial class AspNet90
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (aspnet90)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (aspnet90)");
                 }
                 return _SystemObjectModel;
             }
@@ -3353,7 +3353,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (aspnet90)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (aspnet90)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -3370,7 +3370,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (aspnet90)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (aspnet90)");
                 }
                 return _SystemReflection;
             }
@@ -3387,7 +3387,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (aspnet90)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (aspnet90)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -3404,7 +3404,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (aspnet90)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (aspnet90)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -3421,7 +3421,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (aspnet90)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (aspnet90)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -3438,7 +3438,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (aspnet90)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (aspnet90)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -3455,7 +3455,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (aspnet90)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (aspnet90)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -3472,7 +3472,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (aspnet90)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (aspnet90)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -3489,7 +3489,7 @@ public static partial class AspNet90
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (aspnet90)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (aspnet90)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -3506,7 +3506,7 @@ public static partial class AspNet90
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (aspnet90)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (aspnet90)");
                 }
                 return _SystemResourcesReader;
             }
@@ -3523,7 +3523,7 @@ public static partial class AspNet90
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (aspnet90)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (aspnet90)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -3540,7 +3540,7 @@ public static partial class AspNet90
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (aspnet90)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (aspnet90)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -3557,7 +3557,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (aspnet90)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (aspnet90)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -3574,7 +3574,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (aspnet90)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (aspnet90)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -3591,7 +3591,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (aspnet90)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (aspnet90)");
                 }
                 return _SystemRuntime;
             }
@@ -3608,7 +3608,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (aspnet90)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (aspnet90)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -3625,7 +3625,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (aspnet90)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (aspnet90)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -3642,7 +3642,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (aspnet90)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (aspnet90)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -3659,7 +3659,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeInteropServicesJavaScript is null)
                 {
-                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesJavaScript).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (aspnet90)");
+                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.InteropServices.JavaScript")).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (aspnet90)");
                 }
                 return _SystemRuntimeInteropServicesJavaScript;
             }
@@ -3676,7 +3676,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (aspnet90)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (aspnet90)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -3693,7 +3693,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (aspnet90)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (aspnet90)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -3710,7 +3710,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (aspnet90)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (aspnet90)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -3727,7 +3727,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (aspnet90)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (aspnet90)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -3744,7 +3744,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (aspnet90)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (aspnet90)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -3761,7 +3761,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (aspnet90)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (aspnet90)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -3778,7 +3778,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (aspnet90)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (aspnet90)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -3795,7 +3795,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (aspnet90)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (aspnet90)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -3812,7 +3812,7 @@ public static partial class AspNet90
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (aspnet90)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (aspnet90)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -3829,7 +3829,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (aspnet90)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (aspnet90)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -3846,7 +3846,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (aspnet90)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (aspnet90)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -3863,7 +3863,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (aspnet90)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (aspnet90)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -3880,7 +3880,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyCng is null)
                 {
-                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCng).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (aspnet90)");
+                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.Cng")).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (aspnet90)");
                 }
                 return _SystemSecurityCryptographyCng;
             }
@@ -3897,7 +3897,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (aspnet90)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (aspnet90)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -3914,7 +3914,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptography is null)
                 {
-                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptography).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (aspnet90)");
+                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography")).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (aspnet90)");
                 }
                 return _SystemSecurityCryptography;
             }
@@ -3931,7 +3931,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (aspnet90)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (aspnet90)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -3948,7 +3948,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyOpenSsl is null)
                 {
-                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyOpenSsl).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (aspnet90)");
+                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.OpenSsl")).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (aspnet90)");
                 }
                 return _SystemSecurityCryptographyOpenSsl;
             }
@@ -3965,7 +3965,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (aspnet90)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (aspnet90)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -3982,7 +3982,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (aspnet90)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (aspnet90)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -3999,7 +3999,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (aspnet90)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (aspnet90)");
                 }
                 return _SystemSecurity;
             }
@@ -4016,7 +4016,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (aspnet90)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (aspnet90)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -4033,7 +4033,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (aspnet90)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (aspnet90)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -4050,7 +4050,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (aspnet90)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (aspnet90)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -4067,7 +4067,7 @@ public static partial class AspNet90
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (aspnet90)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (aspnet90)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -4084,7 +4084,7 @@ public static partial class AspNet90
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (aspnet90)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (aspnet90)");
                 }
                 return _SystemServiceProcess;
             }
@@ -4101,7 +4101,7 @@ public static partial class AspNet90
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (aspnet90)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (aspnet90)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -4118,7 +4118,7 @@ public static partial class AspNet90
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (aspnet90)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (aspnet90)");
                 }
                 return _SystemTextEncoding;
             }
@@ -4135,7 +4135,7 @@ public static partial class AspNet90
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (aspnet90)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (aspnet90)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -4152,7 +4152,7 @@ public static partial class AspNet90
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (aspnet90)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (aspnet90)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -4169,7 +4169,7 @@ public static partial class AspNet90
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (aspnet90)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (aspnet90)");
                 }
                 return _SystemTextJson;
             }
@@ -4186,7 +4186,7 @@ public static partial class AspNet90
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (aspnet90)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (aspnet90)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -4203,7 +4203,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (aspnet90)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (aspnet90)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -4220,7 +4220,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (aspnet90)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (aspnet90)");
                 }
                 return _SystemThreading;
             }
@@ -4237,7 +4237,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (aspnet90)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (aspnet90)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -4254,7 +4254,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (aspnet90)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (aspnet90)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -4271,7 +4271,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (aspnet90)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (aspnet90)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -4288,7 +4288,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (aspnet90)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (aspnet90)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -4305,7 +4305,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (aspnet90)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (aspnet90)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -4322,7 +4322,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (aspnet90)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (aspnet90)");
                 }
                 return _SystemThreadingThread;
             }
@@ -4339,7 +4339,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (aspnet90)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (aspnet90)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -4356,7 +4356,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (aspnet90)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (aspnet90)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -4373,7 +4373,7 @@ public static partial class AspNet90
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (aspnet90)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (aspnet90)");
                 }
                 return _SystemTransactions;
             }
@@ -4390,7 +4390,7 @@ public static partial class AspNet90
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (aspnet90)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (aspnet90)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -4407,7 +4407,7 @@ public static partial class AspNet90
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (aspnet90)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (aspnet90)");
                 }
                 return _SystemValueTuple;
             }
@@ -4424,7 +4424,7 @@ public static partial class AspNet90
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (aspnet90)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (aspnet90)");
                 }
                 return _SystemWeb;
             }
@@ -4441,7 +4441,7 @@ public static partial class AspNet90
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (aspnet90)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (aspnet90)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -4458,7 +4458,7 @@ public static partial class AspNet90
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (aspnet90)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (aspnet90)");
                 }
                 return _SystemWindows;
             }
@@ -4475,7 +4475,7 @@ public static partial class AspNet90
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (aspnet90)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (aspnet90)");
                 }
                 return _SystemXml;
             }
@@ -4492,7 +4492,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (aspnet90)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (aspnet90)");
                 }
                 return _SystemXmlLinq;
             }
@@ -4509,7 +4509,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (aspnet90)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (aspnet90)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -4526,7 +4526,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (aspnet90)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (aspnet90)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -4543,7 +4543,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (aspnet90)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (aspnet90)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -4560,7 +4560,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (aspnet90)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (aspnet90)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -4577,7 +4577,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (aspnet90)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (aspnet90)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -4594,7 +4594,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (aspnet90)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (aspnet90)");
                 }
                 return _SystemXmlXPath;
             }
@@ -4611,7 +4611,7 @@ public static partial class AspNet90
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (aspnet90)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (aspnet90)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -4628,7 +4628,7 @@ public static partial class AspNet90
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (aspnet90)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (aspnet90)");
                 }
                 return _WindowsBase;
             }
@@ -4645,7 +4645,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAntiforgery is null)
                 {
-                    _MicrosoftAspNetCoreAntiforgery = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAntiforgery).GetReference(filePath: "Microsoft.AspNetCore.Antiforgery.dll", display: "Microsoft.AspNetCore.Antiforgery (aspnet90)");
+                    _MicrosoftAspNetCoreAntiforgery = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Antiforgery")).GetReference(filePath: "Microsoft.AspNetCore.Antiforgery.dll", display: "Microsoft.AspNetCore.Antiforgery (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAntiforgery;
             }
@@ -4662,7 +4662,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthenticationAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Abstractions.dll", display: "Microsoft.AspNetCore.Authentication.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreAuthenticationAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authentication.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Abstractions.dll", display: "Microsoft.AspNetCore.Authentication.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationAbstractions;
             }
@@ -4679,7 +4679,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthenticationBearerToken is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationBearerToken = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationBearerToken).GetReference(filePath: "Microsoft.AspNetCore.Authentication.BearerToken.dll", display: "Microsoft.AspNetCore.Authentication.BearerToken (aspnet90)");
+                    _MicrosoftAspNetCoreAuthenticationBearerToken = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authentication.BearerToken")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.BearerToken.dll", display: "Microsoft.AspNetCore.Authentication.BearerToken (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationBearerToken;
             }
@@ -4696,7 +4696,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthenticationCookies is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationCookies = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationCookies).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Cookies.dll", display: "Microsoft.AspNetCore.Authentication.Cookies (aspnet90)");
+                    _MicrosoftAspNetCoreAuthenticationCookies = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authentication.Cookies")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Cookies.dll", display: "Microsoft.AspNetCore.Authentication.Cookies (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationCookies;
             }
@@ -4713,7 +4713,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthenticationCore is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationCore).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Core.dll", display: "Microsoft.AspNetCore.Authentication.Core (aspnet90)");
+                    _MicrosoftAspNetCoreAuthenticationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authentication.Core")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.Core.dll", display: "Microsoft.AspNetCore.Authentication.Core (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationCore;
             }
@@ -4730,7 +4730,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthentication is null)
                 {
-                    _MicrosoftAspNetCoreAuthentication = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthentication).GetReference(filePath: "Microsoft.AspNetCore.Authentication.dll", display: "Microsoft.AspNetCore.Authentication (aspnet90)");
+                    _MicrosoftAspNetCoreAuthentication = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authentication")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.dll", display: "Microsoft.AspNetCore.Authentication (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthentication;
             }
@@ -4747,7 +4747,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthenticationOAuth is null)
                 {
-                    _MicrosoftAspNetCoreAuthenticationOAuth = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthenticationOAuth).GetReference(filePath: "Microsoft.AspNetCore.Authentication.OAuth.dll", display: "Microsoft.AspNetCore.Authentication.OAuth (aspnet90)");
+                    _MicrosoftAspNetCoreAuthenticationOAuth = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authentication.OAuth")).GetReference(filePath: "Microsoft.AspNetCore.Authentication.OAuth.dll", display: "Microsoft.AspNetCore.Authentication.OAuth (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthenticationOAuth;
             }
@@ -4764,7 +4764,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthorization is null)
                 {
-                    _MicrosoftAspNetCoreAuthorization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthorization).GetReference(filePath: "Microsoft.AspNetCore.Authorization.dll", display: "Microsoft.AspNetCore.Authorization (aspnet90)");
+                    _MicrosoftAspNetCoreAuthorization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authorization")).GetReference(filePath: "Microsoft.AspNetCore.Authorization.dll", display: "Microsoft.AspNetCore.Authorization (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthorization;
             }
@@ -4781,7 +4781,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreAuthorizationPolicy is null)
                 {
-                    _MicrosoftAspNetCoreAuthorizationPolicy = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreAuthorizationPolicy).GetReference(filePath: "Microsoft.AspNetCore.Authorization.Policy.dll", display: "Microsoft.AspNetCore.Authorization.Policy (aspnet90)");
+                    _MicrosoftAspNetCoreAuthorizationPolicy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Authorization.Policy")).GetReference(filePath: "Microsoft.AspNetCore.Authorization.Policy.dll", display: "Microsoft.AspNetCore.Authorization.Policy (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreAuthorizationPolicy;
             }
@@ -4798,7 +4798,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreComponentsAuthorization is null)
                 {
-                    _MicrosoftAspNetCoreComponentsAuthorization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsAuthorization).GetReference(filePath: "Microsoft.AspNetCore.Components.Authorization.dll", display: "Microsoft.AspNetCore.Components.Authorization (aspnet90)");
+                    _MicrosoftAspNetCoreComponentsAuthorization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Components.Authorization")).GetReference(filePath: "Microsoft.AspNetCore.Components.Authorization.dll", display: "Microsoft.AspNetCore.Components.Authorization (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreComponentsAuthorization;
             }
@@ -4815,7 +4815,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreComponents is null)
                 {
-                    _MicrosoftAspNetCoreComponents = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponents).GetReference(filePath: "Microsoft.AspNetCore.Components.dll", display: "Microsoft.AspNetCore.Components (aspnet90)");
+                    _MicrosoftAspNetCoreComponents = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Components")).GetReference(filePath: "Microsoft.AspNetCore.Components.dll", display: "Microsoft.AspNetCore.Components (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreComponents;
             }
@@ -4832,7 +4832,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreComponentsEndpoints is null)
                 {
-                    _MicrosoftAspNetCoreComponentsEndpoints = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsEndpoints).GetReference(filePath: "Microsoft.AspNetCore.Components.Endpoints.dll", display: "Microsoft.AspNetCore.Components.Endpoints (aspnet90)");
+                    _MicrosoftAspNetCoreComponentsEndpoints = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Components.Endpoints")).GetReference(filePath: "Microsoft.AspNetCore.Components.Endpoints.dll", display: "Microsoft.AspNetCore.Components.Endpoints (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreComponentsEndpoints;
             }
@@ -4849,7 +4849,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreComponentsForms is null)
                 {
-                    _MicrosoftAspNetCoreComponentsForms = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsForms).GetReference(filePath: "Microsoft.AspNetCore.Components.Forms.dll", display: "Microsoft.AspNetCore.Components.Forms (aspnet90)");
+                    _MicrosoftAspNetCoreComponentsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Components.Forms")).GetReference(filePath: "Microsoft.AspNetCore.Components.Forms.dll", display: "Microsoft.AspNetCore.Components.Forms (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreComponentsForms;
             }
@@ -4866,7 +4866,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreComponentsServer is null)
                 {
-                    _MicrosoftAspNetCoreComponentsServer = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsServer).GetReference(filePath: "Microsoft.AspNetCore.Components.Server.dll", display: "Microsoft.AspNetCore.Components.Server (aspnet90)");
+                    _MicrosoftAspNetCoreComponentsServer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Components.Server")).GetReference(filePath: "Microsoft.AspNetCore.Components.Server.dll", display: "Microsoft.AspNetCore.Components.Server (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreComponentsServer;
             }
@@ -4883,7 +4883,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreComponentsWeb is null)
                 {
-                    _MicrosoftAspNetCoreComponentsWeb = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreComponentsWeb).GetReference(filePath: "Microsoft.AspNetCore.Components.Web.dll", display: "Microsoft.AspNetCore.Components.Web (aspnet90)");
+                    _MicrosoftAspNetCoreComponentsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Components.Web")).GetReference(filePath: "Microsoft.AspNetCore.Components.Web.dll", display: "Microsoft.AspNetCore.Components.Web (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreComponentsWeb;
             }
@@ -4900,7 +4900,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreConnectionsAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreConnectionsAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreConnectionsAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Connections.Abstractions.dll", display: "Microsoft.AspNetCore.Connections.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreConnectionsAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Connections.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Connections.Abstractions.dll", display: "Microsoft.AspNetCore.Connections.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreConnectionsAbstractions;
             }
@@ -4917,7 +4917,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreCookiePolicy is null)
                 {
-                    _MicrosoftAspNetCoreCookiePolicy = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCookiePolicy).GetReference(filePath: "Microsoft.AspNetCore.CookiePolicy.dll", display: "Microsoft.AspNetCore.CookiePolicy (aspnet90)");
+                    _MicrosoftAspNetCoreCookiePolicy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.CookiePolicy")).GetReference(filePath: "Microsoft.AspNetCore.CookiePolicy.dll", display: "Microsoft.AspNetCore.CookiePolicy (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreCookiePolicy;
             }
@@ -4934,7 +4934,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreCors is null)
                 {
-                    _MicrosoftAspNetCoreCors = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCors).GetReference(filePath: "Microsoft.AspNetCore.Cors.dll", display: "Microsoft.AspNetCore.Cors (aspnet90)");
+                    _MicrosoftAspNetCoreCors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Cors")).GetReference(filePath: "Microsoft.AspNetCore.Cors.dll", display: "Microsoft.AspNetCore.Cors (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreCors;
             }
@@ -4951,7 +4951,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreCryptographyInternal is null)
                 {
-                    _MicrosoftAspNetCoreCryptographyInternal = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCryptographyInternal).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.Internal.dll", display: "Microsoft.AspNetCore.Cryptography.Internal (aspnet90)");
+                    _MicrosoftAspNetCoreCryptographyInternal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Cryptography.Internal")).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.Internal.dll", display: "Microsoft.AspNetCore.Cryptography.Internal (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreCryptographyInternal;
             }
@@ -4968,7 +4968,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreCryptographyKeyDerivation is null)
                 {
-                    _MicrosoftAspNetCoreCryptographyKeyDerivation = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreCryptographyKeyDerivation).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.KeyDerivation.dll", display: "Microsoft.AspNetCore.Cryptography.KeyDerivation (aspnet90)");
+                    _MicrosoftAspNetCoreCryptographyKeyDerivation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Cryptography.KeyDerivation")).GetReference(filePath: "Microsoft.AspNetCore.Cryptography.KeyDerivation.dll", display: "Microsoft.AspNetCore.Cryptography.KeyDerivation (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreCryptographyKeyDerivation;
             }
@@ -4985,7 +4985,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreDataProtectionAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreDataProtectionAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDataProtectionAbstractions).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Abstractions.dll", display: "Microsoft.AspNetCore.DataProtection.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreDataProtectionAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.DataProtection.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Abstractions.dll", display: "Microsoft.AspNetCore.DataProtection.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreDataProtectionAbstractions;
             }
@@ -5002,7 +5002,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreDataProtection is null)
                 {
-                    _MicrosoftAspNetCoreDataProtection = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDataProtection).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.dll", display: "Microsoft.AspNetCore.DataProtection (aspnet90)");
+                    _MicrosoftAspNetCoreDataProtection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.DataProtection")).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.dll", display: "Microsoft.AspNetCore.DataProtection (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreDataProtection;
             }
@@ -5019,7 +5019,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreDataProtectionExtensions is null)
                 {
-                    _MicrosoftAspNetCoreDataProtectionExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDataProtectionExtensions).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Extensions.dll", display: "Microsoft.AspNetCore.DataProtection.Extensions (aspnet90)");
+                    _MicrosoftAspNetCoreDataProtectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.DataProtection.Extensions")).GetReference(filePath: "Microsoft.AspNetCore.DataProtection.Extensions.dll", display: "Microsoft.AspNetCore.DataProtection.Extensions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreDataProtectionExtensions;
             }
@@ -5036,7 +5036,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreDiagnosticsAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDiagnosticsAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.Abstractions.dll", display: "Microsoft.AspNetCore.Diagnostics.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Diagnostics.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.Abstractions.dll", display: "Microsoft.AspNetCore.Diagnostics.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreDiagnosticsAbstractions;
             }
@@ -5053,7 +5053,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreDiagnostics is null)
                 {
-                    _MicrosoftAspNetCoreDiagnostics = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDiagnostics).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.dll", display: "Microsoft.AspNetCore.Diagnostics (aspnet90)");
+                    _MicrosoftAspNetCoreDiagnostics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Diagnostics")).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.dll", display: "Microsoft.AspNetCore.Diagnostics (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreDiagnostics;
             }
@@ -5070,7 +5070,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreDiagnosticsHealthChecks is null)
                 {
-                    _MicrosoftAspNetCoreDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreDiagnosticsHealthChecks).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.HealthChecks.dll", display: "Microsoft.AspNetCore.Diagnostics.HealthChecks (aspnet90)");
+                    _MicrosoftAspNetCoreDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Diagnostics.HealthChecks")).GetReference(filePath: "Microsoft.AspNetCore.Diagnostics.HealthChecks.dll", display: "Microsoft.AspNetCore.Diagnostics.HealthChecks (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreDiagnosticsHealthChecks;
             }
@@ -5087,7 +5087,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCore is null)
                 {
-                    _MicrosoftAspNetCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCore).GetReference(filePath: "Microsoft.AspNetCore.dll", display: "Microsoft.AspNetCore (aspnet90)");
+                    _MicrosoftAspNetCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore")).GetReference(filePath: "Microsoft.AspNetCore.dll", display: "Microsoft.AspNetCore (aspnet90)");
                 }
                 return _MicrosoftAspNetCore;
             }
@@ -5104,7 +5104,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHostFiltering is null)
                 {
-                    _MicrosoftAspNetCoreHostFiltering = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHostFiltering).GetReference(filePath: "Microsoft.AspNetCore.HostFiltering.dll", display: "Microsoft.AspNetCore.HostFiltering (aspnet90)");
+                    _MicrosoftAspNetCoreHostFiltering = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.HostFiltering")).GetReference(filePath: "Microsoft.AspNetCore.HostFiltering.dll", display: "Microsoft.AspNetCore.HostFiltering (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHostFiltering;
             }
@@ -5121,7 +5121,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHostingAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHostingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHostingAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreHostingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Hosting.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHostingAbstractions;
             }
@@ -5138,7 +5138,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHosting is null)
                 {
-                    _MicrosoftAspNetCoreHosting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHosting).GetReference(filePath: "Microsoft.AspNetCore.Hosting.dll", display: "Microsoft.AspNetCore.Hosting (aspnet90)");
+                    _MicrosoftAspNetCoreHosting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Hosting")).GetReference(filePath: "Microsoft.AspNetCore.Hosting.dll", display: "Microsoft.AspNetCore.Hosting (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHosting;
             }
@@ -5155,7 +5155,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHostingServerAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHostingServerAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHostingServerAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Server.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Server.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreHostingServerAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Hosting.Server.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Hosting.Server.Abstractions.dll", display: "Microsoft.AspNetCore.Hosting.Server.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHostingServerAbstractions;
             }
@@ -5172,7 +5172,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHtmlAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHtmlAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHtmlAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Html.Abstractions.dll", display: "Microsoft.AspNetCore.Html.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreHtmlAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Html.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Html.Abstractions.dll", display: "Microsoft.AspNetCore.Html.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHtmlAbstractions;
             }
@@ -5189,7 +5189,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreHttpAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Http.Abstractions.dll", display: "Microsoft.AspNetCore.Http.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreHttpAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Http.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Http.Abstractions.dll", display: "Microsoft.AspNetCore.Http.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpAbstractions;
             }
@@ -5206,7 +5206,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpConnectionsCommon is null)
                 {
-                    _MicrosoftAspNetCoreHttpConnectionsCommon = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpConnectionsCommon).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.Common.dll", display: "Microsoft.AspNetCore.Http.Connections.Common (aspnet90)");
+                    _MicrosoftAspNetCoreHttpConnectionsCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Http.Connections.Common")).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.Common.dll", display: "Microsoft.AspNetCore.Http.Connections.Common (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpConnectionsCommon;
             }
@@ -5223,7 +5223,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpConnections is null)
                 {
-                    _MicrosoftAspNetCoreHttpConnections = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpConnections).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.dll", display: "Microsoft.AspNetCore.Http.Connections (aspnet90)");
+                    _MicrosoftAspNetCoreHttpConnections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Http.Connections")).GetReference(filePath: "Microsoft.AspNetCore.Http.Connections.dll", display: "Microsoft.AspNetCore.Http.Connections (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpConnections;
             }
@@ -5240,7 +5240,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttp is null)
                 {
-                    _MicrosoftAspNetCoreHttp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttp).GetReference(filePath: "Microsoft.AspNetCore.Http.dll", display: "Microsoft.AspNetCore.Http (aspnet90)");
+                    _MicrosoftAspNetCoreHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Http")).GetReference(filePath: "Microsoft.AspNetCore.Http.dll", display: "Microsoft.AspNetCore.Http (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttp;
             }
@@ -5257,7 +5257,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpExtensions is null)
                 {
-                    _MicrosoftAspNetCoreHttpExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpExtensions).GetReference(filePath: "Microsoft.AspNetCore.Http.Extensions.dll", display: "Microsoft.AspNetCore.Http.Extensions (aspnet90)");
+                    _MicrosoftAspNetCoreHttpExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Http.Extensions")).GetReference(filePath: "Microsoft.AspNetCore.Http.Extensions.dll", display: "Microsoft.AspNetCore.Http.Extensions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpExtensions;
             }
@@ -5274,7 +5274,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpFeatures is null)
                 {
-                    _MicrosoftAspNetCoreHttpFeatures = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpFeatures).GetReference(filePath: "Microsoft.AspNetCore.Http.Features.dll", display: "Microsoft.AspNetCore.Http.Features (aspnet90)");
+                    _MicrosoftAspNetCoreHttpFeatures = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Http.Features")).GetReference(filePath: "Microsoft.AspNetCore.Http.Features.dll", display: "Microsoft.AspNetCore.Http.Features (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpFeatures;
             }
@@ -5291,7 +5291,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpResults is null)
                 {
-                    _MicrosoftAspNetCoreHttpResults = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpResults).GetReference(filePath: "Microsoft.AspNetCore.Http.Results.dll", display: "Microsoft.AspNetCore.Http.Results (aspnet90)");
+                    _MicrosoftAspNetCoreHttpResults = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Http.Results")).GetReference(filePath: "Microsoft.AspNetCore.Http.Results.dll", display: "Microsoft.AspNetCore.Http.Results (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpResults;
             }
@@ -5308,7 +5308,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpLogging is null)
                 {
-                    _MicrosoftAspNetCoreHttpLogging = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpLogging).GetReference(filePath: "Microsoft.AspNetCore.HttpLogging.dll", display: "Microsoft.AspNetCore.HttpLogging (aspnet90)");
+                    _MicrosoftAspNetCoreHttpLogging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.HttpLogging")).GetReference(filePath: "Microsoft.AspNetCore.HttpLogging.dll", display: "Microsoft.AspNetCore.HttpLogging (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpLogging;
             }
@@ -5325,7 +5325,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpOverrides is null)
                 {
-                    _MicrosoftAspNetCoreHttpOverrides = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpOverrides).GetReference(filePath: "Microsoft.AspNetCore.HttpOverrides.dll", display: "Microsoft.AspNetCore.HttpOverrides (aspnet90)");
+                    _MicrosoftAspNetCoreHttpOverrides = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.HttpOverrides")).GetReference(filePath: "Microsoft.AspNetCore.HttpOverrides.dll", display: "Microsoft.AspNetCore.HttpOverrides (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpOverrides;
             }
@@ -5342,7 +5342,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreHttpsPolicy is null)
                 {
-                    _MicrosoftAspNetCoreHttpsPolicy = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreHttpsPolicy).GetReference(filePath: "Microsoft.AspNetCore.HttpsPolicy.dll", display: "Microsoft.AspNetCore.HttpsPolicy (aspnet90)");
+                    _MicrosoftAspNetCoreHttpsPolicy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.HttpsPolicy")).GetReference(filePath: "Microsoft.AspNetCore.HttpsPolicy.dll", display: "Microsoft.AspNetCore.HttpsPolicy (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreHttpsPolicy;
             }
@@ -5359,7 +5359,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreIdentity is null)
                 {
-                    _MicrosoftAspNetCoreIdentity = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreIdentity).GetReference(filePath: "Microsoft.AspNetCore.Identity.dll", display: "Microsoft.AspNetCore.Identity (aspnet90)");
+                    _MicrosoftAspNetCoreIdentity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Identity")).GetReference(filePath: "Microsoft.AspNetCore.Identity.dll", display: "Microsoft.AspNetCore.Identity (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreIdentity;
             }
@@ -5376,7 +5376,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreLocalization is null)
                 {
-                    _MicrosoftAspNetCoreLocalization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreLocalization).GetReference(filePath: "Microsoft.AspNetCore.Localization.dll", display: "Microsoft.AspNetCore.Localization (aspnet90)");
+                    _MicrosoftAspNetCoreLocalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Localization")).GetReference(filePath: "Microsoft.AspNetCore.Localization.dll", display: "Microsoft.AspNetCore.Localization (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreLocalization;
             }
@@ -5393,7 +5393,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreLocalizationRouting is null)
                 {
-                    _MicrosoftAspNetCoreLocalizationRouting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreLocalizationRouting).GetReference(filePath: "Microsoft.AspNetCore.Localization.Routing.dll", display: "Microsoft.AspNetCore.Localization.Routing (aspnet90)");
+                    _MicrosoftAspNetCoreLocalizationRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Localization.Routing")).GetReference(filePath: "Microsoft.AspNetCore.Localization.Routing.dll", display: "Microsoft.AspNetCore.Localization.Routing (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreLocalizationRouting;
             }
@@ -5410,7 +5410,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMetadata is null)
                 {
-                    _MicrosoftAspNetCoreMetadata = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMetadata).GetReference(filePath: "Microsoft.AspNetCore.Metadata.dll", display: "Microsoft.AspNetCore.Metadata (aspnet90)");
+                    _MicrosoftAspNetCoreMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Metadata")).GetReference(filePath: "Microsoft.AspNetCore.Metadata.dll", display: "Microsoft.AspNetCore.Metadata (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMetadata;
             }
@@ -5427,7 +5427,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreMvcAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Abstractions.dll", display: "Microsoft.AspNetCore.Mvc.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreMvcAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Abstractions.dll", display: "Microsoft.AspNetCore.Mvc.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcAbstractions;
             }
@@ -5444,7 +5444,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcApiExplorer is null)
                 {
-                    _MicrosoftAspNetCoreMvcApiExplorer = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcApiExplorer).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ApiExplorer.dll", display: "Microsoft.AspNetCore.Mvc.ApiExplorer (aspnet90)");
+                    _MicrosoftAspNetCoreMvcApiExplorer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.ApiExplorer")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ApiExplorer.dll", display: "Microsoft.AspNetCore.Mvc.ApiExplorer (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcApiExplorer;
             }
@@ -5461,7 +5461,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcCore is null)
                 {
-                    _MicrosoftAspNetCoreMvcCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcCore).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Core.dll", display: "Microsoft.AspNetCore.Mvc.Core (aspnet90)");
+                    _MicrosoftAspNetCoreMvcCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.Core")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Core.dll", display: "Microsoft.AspNetCore.Mvc.Core (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcCore;
             }
@@ -5478,7 +5478,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcCors is null)
                 {
-                    _MicrosoftAspNetCoreMvcCors = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcCors).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Cors.dll", display: "Microsoft.AspNetCore.Mvc.Cors (aspnet90)");
+                    _MicrosoftAspNetCoreMvcCors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.Cors")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Cors.dll", display: "Microsoft.AspNetCore.Mvc.Cors (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcCors;
             }
@@ -5495,7 +5495,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcDataAnnotations is null)
                 {
-                    _MicrosoftAspNetCoreMvcDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcDataAnnotations).GetReference(filePath: "Microsoft.AspNetCore.Mvc.DataAnnotations.dll", display: "Microsoft.AspNetCore.Mvc.DataAnnotations (aspnet90)");
+                    _MicrosoftAspNetCoreMvcDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.DataAnnotations")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.DataAnnotations.dll", display: "Microsoft.AspNetCore.Mvc.DataAnnotations (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcDataAnnotations;
             }
@@ -5512,7 +5512,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvc is null)
                 {
-                    _MicrosoftAspNetCoreMvc = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvc).GetReference(filePath: "Microsoft.AspNetCore.Mvc.dll", display: "Microsoft.AspNetCore.Mvc (aspnet90)");
+                    _MicrosoftAspNetCoreMvc = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.dll", display: "Microsoft.AspNetCore.Mvc (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvc;
             }
@@ -5529,7 +5529,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcFormattersJson is null)
                 {
-                    _MicrosoftAspNetCoreMvcFormattersJson = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcFormattersJson).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Json.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Json (aspnet90)");
+                    _MicrosoftAspNetCoreMvcFormattersJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.Formatters.Json")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Json.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Json (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcFormattersJson;
             }
@@ -5546,7 +5546,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcFormattersXml is null)
                 {
-                    _MicrosoftAspNetCoreMvcFormattersXml = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcFormattersXml).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Xml.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Xml (aspnet90)");
+                    _MicrosoftAspNetCoreMvcFormattersXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.Formatters.Xml")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Formatters.Xml.dll", display: "Microsoft.AspNetCore.Mvc.Formatters.Xml (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcFormattersXml;
             }
@@ -5563,7 +5563,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcLocalization is null)
                 {
-                    _MicrosoftAspNetCoreMvcLocalization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcLocalization).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Localization.dll", display: "Microsoft.AspNetCore.Mvc.Localization (aspnet90)");
+                    _MicrosoftAspNetCoreMvcLocalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.Localization")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Localization.dll", display: "Microsoft.AspNetCore.Mvc.Localization (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcLocalization;
             }
@@ -5580,7 +5580,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcRazor is null)
                 {
-                    _MicrosoftAspNetCoreMvcRazor = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcRazor).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Razor.dll", display: "Microsoft.AspNetCore.Mvc.Razor (aspnet90)");
+                    _MicrosoftAspNetCoreMvcRazor = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.Razor")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.Razor.dll", display: "Microsoft.AspNetCore.Mvc.Razor (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcRazor;
             }
@@ -5597,7 +5597,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcRazorPages is null)
                 {
-                    _MicrosoftAspNetCoreMvcRazorPages = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcRazorPages).GetReference(filePath: "Microsoft.AspNetCore.Mvc.RazorPages.dll", display: "Microsoft.AspNetCore.Mvc.RazorPages (aspnet90)");
+                    _MicrosoftAspNetCoreMvcRazorPages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.RazorPages")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.RazorPages.dll", display: "Microsoft.AspNetCore.Mvc.RazorPages (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcRazorPages;
             }
@@ -5614,7 +5614,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcTagHelpers is null)
                 {
-                    _MicrosoftAspNetCoreMvcTagHelpers = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcTagHelpers).GetReference(filePath: "Microsoft.AspNetCore.Mvc.TagHelpers.dll", display: "Microsoft.AspNetCore.Mvc.TagHelpers (aspnet90)");
+                    _MicrosoftAspNetCoreMvcTagHelpers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.TagHelpers")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.TagHelpers.dll", display: "Microsoft.AspNetCore.Mvc.TagHelpers (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcTagHelpers;
             }
@@ -5631,7 +5631,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreMvcViewFeatures is null)
                 {
-                    _MicrosoftAspNetCoreMvcViewFeatures = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreMvcViewFeatures).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ViewFeatures.dll", display: "Microsoft.AspNetCore.Mvc.ViewFeatures (aspnet90)");
+                    _MicrosoftAspNetCoreMvcViewFeatures = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Mvc.ViewFeatures")).GetReference(filePath: "Microsoft.AspNetCore.Mvc.ViewFeatures.dll", display: "Microsoft.AspNetCore.Mvc.ViewFeatures (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreMvcViewFeatures;
             }
@@ -5648,7 +5648,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreOutputCaching is null)
                 {
-                    _MicrosoftAspNetCoreOutputCaching = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreOutputCaching).GetReference(filePath: "Microsoft.AspNetCore.OutputCaching.dll", display: "Microsoft.AspNetCore.OutputCaching (aspnet90)");
+                    _MicrosoftAspNetCoreOutputCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.OutputCaching")).GetReference(filePath: "Microsoft.AspNetCore.OutputCaching.dll", display: "Microsoft.AspNetCore.OutputCaching (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreOutputCaching;
             }
@@ -5665,7 +5665,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreRateLimiting is null)
                 {
-                    _MicrosoftAspNetCoreRateLimiting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRateLimiting).GetReference(filePath: "Microsoft.AspNetCore.RateLimiting.dll", display: "Microsoft.AspNetCore.RateLimiting (aspnet90)");
+                    _MicrosoftAspNetCoreRateLimiting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.RateLimiting")).GetReference(filePath: "Microsoft.AspNetCore.RateLimiting.dll", display: "Microsoft.AspNetCore.RateLimiting (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreRateLimiting;
             }
@@ -5682,7 +5682,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreRazor is null)
                 {
-                    _MicrosoftAspNetCoreRazor = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRazor).GetReference(filePath: "Microsoft.AspNetCore.Razor.dll", display: "Microsoft.AspNetCore.Razor (aspnet90)");
+                    _MicrosoftAspNetCoreRazor = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Razor")).GetReference(filePath: "Microsoft.AspNetCore.Razor.dll", display: "Microsoft.AspNetCore.Razor (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreRazor;
             }
@@ -5699,7 +5699,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreRazorRuntime is null)
                 {
-                    _MicrosoftAspNetCoreRazorRuntime = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRazorRuntime).GetReference(filePath: "Microsoft.AspNetCore.Razor.Runtime.dll", display: "Microsoft.AspNetCore.Razor.Runtime (aspnet90)");
+                    _MicrosoftAspNetCoreRazorRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Razor.Runtime")).GetReference(filePath: "Microsoft.AspNetCore.Razor.Runtime.dll", display: "Microsoft.AspNetCore.Razor.Runtime (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreRazorRuntime;
             }
@@ -5716,7 +5716,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreRequestDecompression is null)
                 {
-                    _MicrosoftAspNetCoreRequestDecompression = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRequestDecompression).GetReference(filePath: "Microsoft.AspNetCore.RequestDecompression.dll", display: "Microsoft.AspNetCore.RequestDecompression (aspnet90)");
+                    _MicrosoftAspNetCoreRequestDecompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.RequestDecompression")).GetReference(filePath: "Microsoft.AspNetCore.RequestDecompression.dll", display: "Microsoft.AspNetCore.RequestDecompression (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreRequestDecompression;
             }
@@ -5733,7 +5733,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreResponseCachingAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreResponseCachingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreResponseCachingAbstractions).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.Abstractions.dll", display: "Microsoft.AspNetCore.ResponseCaching.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreResponseCachingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.ResponseCaching.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.Abstractions.dll", display: "Microsoft.AspNetCore.ResponseCaching.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreResponseCachingAbstractions;
             }
@@ -5750,7 +5750,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreResponseCaching is null)
                 {
-                    _MicrosoftAspNetCoreResponseCaching = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreResponseCaching).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.dll", display: "Microsoft.AspNetCore.ResponseCaching (aspnet90)");
+                    _MicrosoftAspNetCoreResponseCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.ResponseCaching")).GetReference(filePath: "Microsoft.AspNetCore.ResponseCaching.dll", display: "Microsoft.AspNetCore.ResponseCaching (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreResponseCaching;
             }
@@ -5767,7 +5767,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreResponseCompression is null)
                 {
-                    _MicrosoftAspNetCoreResponseCompression = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreResponseCompression).GetReference(filePath: "Microsoft.AspNetCore.ResponseCompression.dll", display: "Microsoft.AspNetCore.ResponseCompression (aspnet90)");
+                    _MicrosoftAspNetCoreResponseCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.ResponseCompression")).GetReference(filePath: "Microsoft.AspNetCore.ResponseCompression.dll", display: "Microsoft.AspNetCore.ResponseCompression (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreResponseCompression;
             }
@@ -5784,7 +5784,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreRewrite is null)
                 {
-                    _MicrosoftAspNetCoreRewrite = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRewrite).GetReference(filePath: "Microsoft.AspNetCore.Rewrite.dll", display: "Microsoft.AspNetCore.Rewrite (aspnet90)");
+                    _MicrosoftAspNetCoreRewrite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Rewrite")).GetReference(filePath: "Microsoft.AspNetCore.Rewrite.dll", display: "Microsoft.AspNetCore.Rewrite (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreRewrite;
             }
@@ -5801,7 +5801,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreRoutingAbstractions is null)
                 {
-                    _MicrosoftAspNetCoreRoutingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRoutingAbstractions).GetReference(filePath: "Microsoft.AspNetCore.Routing.Abstractions.dll", display: "Microsoft.AspNetCore.Routing.Abstractions (aspnet90)");
+                    _MicrosoftAspNetCoreRoutingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Routing.Abstractions")).GetReference(filePath: "Microsoft.AspNetCore.Routing.Abstractions.dll", display: "Microsoft.AspNetCore.Routing.Abstractions (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreRoutingAbstractions;
             }
@@ -5818,7 +5818,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreRouting is null)
                 {
-                    _MicrosoftAspNetCoreRouting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreRouting).GetReference(filePath: "Microsoft.AspNetCore.Routing.dll", display: "Microsoft.AspNetCore.Routing (aspnet90)");
+                    _MicrosoftAspNetCoreRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Routing")).GetReference(filePath: "Microsoft.AspNetCore.Routing.dll", display: "Microsoft.AspNetCore.Routing (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreRouting;
             }
@@ -5835,7 +5835,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerHttpSys is null)
                 {
-                    _MicrosoftAspNetCoreServerHttpSys = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerHttpSys).GetReference(filePath: "Microsoft.AspNetCore.Server.HttpSys.dll", display: "Microsoft.AspNetCore.Server.HttpSys (aspnet90)");
+                    _MicrosoftAspNetCoreServerHttpSys = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.HttpSys")).GetReference(filePath: "Microsoft.AspNetCore.Server.HttpSys.dll", display: "Microsoft.AspNetCore.Server.HttpSys (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerHttpSys;
             }
@@ -5852,7 +5852,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerIIS is null)
                 {
-                    _MicrosoftAspNetCoreServerIIS = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerIIS).GetReference(filePath: "Microsoft.AspNetCore.Server.IIS.dll", display: "Microsoft.AspNetCore.Server.IIS (aspnet90)");
+                    _MicrosoftAspNetCoreServerIIS = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.IIS")).GetReference(filePath: "Microsoft.AspNetCore.Server.IIS.dll", display: "Microsoft.AspNetCore.Server.IIS (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerIIS;
             }
@@ -5869,7 +5869,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerIISIntegration is null)
                 {
-                    _MicrosoftAspNetCoreServerIISIntegration = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerIISIntegration).GetReference(filePath: "Microsoft.AspNetCore.Server.IISIntegration.dll", display: "Microsoft.AspNetCore.Server.IISIntegration (aspnet90)");
+                    _MicrosoftAspNetCoreServerIISIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.IISIntegration")).GetReference(filePath: "Microsoft.AspNetCore.Server.IISIntegration.dll", display: "Microsoft.AspNetCore.Server.IISIntegration (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerIISIntegration;
             }
@@ -5886,7 +5886,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerKestrelCore is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelCore).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Core.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Core (aspnet90)");
+                    _MicrosoftAspNetCoreServerKestrelCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.Kestrel.Core")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Core.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Core (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelCore;
             }
@@ -5903,7 +5903,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerKestrel is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrel = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrel).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.dll", display: "Microsoft.AspNetCore.Server.Kestrel (aspnet90)");
+                    _MicrosoftAspNetCoreServerKestrel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.Kestrel")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.dll", display: "Microsoft.AspNetCore.Server.Kestrel (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerKestrel;
             }
@@ -5920,7 +5920,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerKestrelTransportNamedPipes is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelTransportNamedPipes = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelTransportNamedPipes).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes (aspnet90)");
+                    _MicrosoftAspNetCoreServerKestrelTransportNamedPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelTransportNamedPipes;
             }
@@ -5937,7 +5937,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerKestrelTransportQuic is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelTransportQuic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelTransportQuic).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic (aspnet90)");
+                    _MicrosoftAspNetCoreServerKestrelTransportQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.Quic")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Quic (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelTransportQuic;
             }
@@ -5954,7 +5954,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreServerKestrelTransportSockets is null)
                 {
-                    _MicrosoftAspNetCoreServerKestrelTransportSockets = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreServerKestrelTransportSockets).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (aspnet90)");
+                    _MicrosoftAspNetCoreServerKestrelTransportSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets")).GetReference(filePath: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll", display: "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreServerKestrelTransportSockets;
             }
@@ -5971,7 +5971,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreSession is null)
                 {
-                    _MicrosoftAspNetCoreSession = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSession).GetReference(filePath: "Microsoft.AspNetCore.Session.dll", display: "Microsoft.AspNetCore.Session (aspnet90)");
+                    _MicrosoftAspNetCoreSession = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.Session")).GetReference(filePath: "Microsoft.AspNetCore.Session.dll", display: "Microsoft.AspNetCore.Session (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreSession;
             }
@@ -5988,7 +5988,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreSignalRCommon is null)
                 {
-                    _MicrosoftAspNetCoreSignalRCommon = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalRCommon).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Common.dll", display: "Microsoft.AspNetCore.SignalR.Common (aspnet90)");
+                    _MicrosoftAspNetCoreSignalRCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.SignalR.Common")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Common.dll", display: "Microsoft.AspNetCore.SignalR.Common (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreSignalRCommon;
             }
@@ -6005,7 +6005,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreSignalRCore is null)
                 {
-                    _MicrosoftAspNetCoreSignalRCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalRCore).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Core.dll", display: "Microsoft.AspNetCore.SignalR.Core (aspnet90)");
+                    _MicrosoftAspNetCoreSignalRCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.SignalR.Core")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Core.dll", display: "Microsoft.AspNetCore.SignalR.Core (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreSignalRCore;
             }
@@ -6022,7 +6022,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreSignalR is null)
                 {
-                    _MicrosoftAspNetCoreSignalR = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalR).GetReference(filePath: "Microsoft.AspNetCore.SignalR.dll", display: "Microsoft.AspNetCore.SignalR (aspnet90)");
+                    _MicrosoftAspNetCoreSignalR = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.SignalR")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.dll", display: "Microsoft.AspNetCore.SignalR (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreSignalR;
             }
@@ -6039,7 +6039,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreSignalRProtocolsJson is null)
                 {
-                    _MicrosoftAspNetCoreSignalRProtocolsJson = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreSignalRProtocolsJson).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Protocols.Json.dll", display: "Microsoft.AspNetCore.SignalR.Protocols.Json (aspnet90)");
+                    _MicrosoftAspNetCoreSignalRProtocolsJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.SignalR.Protocols.Json")).GetReference(filePath: "Microsoft.AspNetCore.SignalR.Protocols.Json.dll", display: "Microsoft.AspNetCore.SignalR.Protocols.Json (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreSignalRProtocolsJson;
             }
@@ -6056,7 +6056,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreStaticAssets is null)
                 {
-                    _MicrosoftAspNetCoreStaticAssets = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreStaticAssets).GetReference(filePath: "Microsoft.AspNetCore.StaticAssets.dll", display: "Microsoft.AspNetCore.StaticAssets (aspnet90)");
+                    _MicrosoftAspNetCoreStaticAssets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.StaticAssets")).GetReference(filePath: "Microsoft.AspNetCore.StaticAssets.dll", display: "Microsoft.AspNetCore.StaticAssets (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreStaticAssets;
             }
@@ -6073,7 +6073,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreStaticFiles is null)
                 {
-                    _MicrosoftAspNetCoreStaticFiles = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreStaticFiles).GetReference(filePath: "Microsoft.AspNetCore.StaticFiles.dll", display: "Microsoft.AspNetCore.StaticFiles (aspnet90)");
+                    _MicrosoftAspNetCoreStaticFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.StaticFiles")).GetReference(filePath: "Microsoft.AspNetCore.StaticFiles.dll", display: "Microsoft.AspNetCore.StaticFiles (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreStaticFiles;
             }
@@ -6090,7 +6090,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreWebSockets is null)
                 {
-                    _MicrosoftAspNetCoreWebSockets = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreWebSockets).GetReference(filePath: "Microsoft.AspNetCore.WebSockets.dll", display: "Microsoft.AspNetCore.WebSockets (aspnet90)");
+                    _MicrosoftAspNetCoreWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.WebSockets")).GetReference(filePath: "Microsoft.AspNetCore.WebSockets.dll", display: "Microsoft.AspNetCore.WebSockets (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreWebSockets;
             }
@@ -6107,7 +6107,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftAspNetCoreWebUtilities is null)
                 {
-                    _MicrosoftAspNetCoreWebUtilities = AssemblyMetadata.CreateFromImage(Resources.MicrosoftAspNetCoreWebUtilities).GetReference(filePath: "Microsoft.AspNetCore.WebUtilities.dll", display: "Microsoft.AspNetCore.WebUtilities (aspnet90)");
+                    _MicrosoftAspNetCoreWebUtilities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.AspNetCore.WebUtilities")).GetReference(filePath: "Microsoft.AspNetCore.WebUtilities.dll", display: "Microsoft.AspNetCore.WebUtilities (aspnet90)");
                 }
                 return _MicrosoftAspNetCoreWebUtilities;
             }
@@ -6124,7 +6124,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsCachingAbstractions is null)
                 {
-                    _MicrosoftExtensionsCachingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsCachingAbstractions).GetReference(filePath: "Microsoft.Extensions.Caching.Abstractions.dll", display: "Microsoft.Extensions.Caching.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsCachingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Caching.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Caching.Abstractions.dll", display: "Microsoft.Extensions.Caching.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsCachingAbstractions;
             }
@@ -6141,7 +6141,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsCachingMemory is null)
                 {
-                    _MicrosoftExtensionsCachingMemory = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsCachingMemory).GetReference(filePath: "Microsoft.Extensions.Caching.Memory.dll", display: "Microsoft.Extensions.Caching.Memory (aspnet90)");
+                    _MicrosoftExtensionsCachingMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Caching.Memory")).GetReference(filePath: "Microsoft.Extensions.Caching.Memory.dll", display: "Microsoft.Extensions.Caching.Memory (aspnet90)");
                 }
                 return _MicrosoftExtensionsCachingMemory;
             }
@@ -6158,7 +6158,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationAbstractions is null)
                 {
-                    _MicrosoftExtensionsConfigurationAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationAbstractions).GetReference(filePath: "Microsoft.Extensions.Configuration.Abstractions.dll", display: "Microsoft.Extensions.Configuration.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsConfigurationAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Configuration.Abstractions.dll", display: "Microsoft.Extensions.Configuration.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationAbstractions;
             }
@@ -6175,7 +6175,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationBinder is null)
                 {
-                    _MicrosoftExtensionsConfigurationBinder = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationBinder).GetReference(filePath: "Microsoft.Extensions.Configuration.Binder.dll", display: "Microsoft.Extensions.Configuration.Binder (aspnet90)");
+                    _MicrosoftExtensionsConfigurationBinder = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.Binder")).GetReference(filePath: "Microsoft.Extensions.Configuration.Binder.dll", display: "Microsoft.Extensions.Configuration.Binder (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationBinder;
             }
@@ -6192,7 +6192,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationCommandLine is null)
                 {
-                    _MicrosoftExtensionsConfigurationCommandLine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationCommandLine).GetReference(filePath: "Microsoft.Extensions.Configuration.CommandLine.dll", display: "Microsoft.Extensions.Configuration.CommandLine (aspnet90)");
+                    _MicrosoftExtensionsConfigurationCommandLine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.CommandLine")).GetReference(filePath: "Microsoft.Extensions.Configuration.CommandLine.dll", display: "Microsoft.Extensions.Configuration.CommandLine (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationCommandLine;
             }
@@ -6209,7 +6209,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfiguration is null)
                 {
-                    _MicrosoftExtensionsConfiguration = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfiguration).GetReference(filePath: "Microsoft.Extensions.Configuration.dll", display: "Microsoft.Extensions.Configuration (aspnet90)");
+                    _MicrosoftExtensionsConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration")).GetReference(filePath: "Microsoft.Extensions.Configuration.dll", display: "Microsoft.Extensions.Configuration (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfiguration;
             }
@@ -6226,7 +6226,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationEnvironmentVariables is null)
                 {
-                    _MicrosoftExtensionsConfigurationEnvironmentVariables = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationEnvironmentVariables).GetReference(filePath: "Microsoft.Extensions.Configuration.EnvironmentVariables.dll", display: "Microsoft.Extensions.Configuration.EnvironmentVariables (aspnet90)");
+                    _MicrosoftExtensionsConfigurationEnvironmentVariables = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.EnvironmentVariables")).GetReference(filePath: "Microsoft.Extensions.Configuration.EnvironmentVariables.dll", display: "Microsoft.Extensions.Configuration.EnvironmentVariables (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationEnvironmentVariables;
             }
@@ -6243,7 +6243,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationFileExtensions is null)
                 {
-                    _MicrosoftExtensionsConfigurationFileExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationFileExtensions).GetReference(filePath: "Microsoft.Extensions.Configuration.FileExtensions.dll", display: "Microsoft.Extensions.Configuration.FileExtensions (aspnet90)");
+                    _MicrosoftExtensionsConfigurationFileExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.FileExtensions")).GetReference(filePath: "Microsoft.Extensions.Configuration.FileExtensions.dll", display: "Microsoft.Extensions.Configuration.FileExtensions (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationFileExtensions;
             }
@@ -6260,7 +6260,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationIni is null)
                 {
-                    _MicrosoftExtensionsConfigurationIni = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationIni).GetReference(filePath: "Microsoft.Extensions.Configuration.Ini.dll", display: "Microsoft.Extensions.Configuration.Ini (aspnet90)");
+                    _MicrosoftExtensionsConfigurationIni = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.Ini")).GetReference(filePath: "Microsoft.Extensions.Configuration.Ini.dll", display: "Microsoft.Extensions.Configuration.Ini (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationIni;
             }
@@ -6277,7 +6277,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationJson is null)
                 {
-                    _MicrosoftExtensionsConfigurationJson = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationJson).GetReference(filePath: "Microsoft.Extensions.Configuration.Json.dll", display: "Microsoft.Extensions.Configuration.Json (aspnet90)");
+                    _MicrosoftExtensionsConfigurationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.Json")).GetReference(filePath: "Microsoft.Extensions.Configuration.Json.dll", display: "Microsoft.Extensions.Configuration.Json (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationJson;
             }
@@ -6294,7 +6294,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationKeyPerFile is null)
                 {
-                    _MicrosoftExtensionsConfigurationKeyPerFile = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationKeyPerFile).GetReference(filePath: "Microsoft.Extensions.Configuration.KeyPerFile.dll", display: "Microsoft.Extensions.Configuration.KeyPerFile (aspnet90)");
+                    _MicrosoftExtensionsConfigurationKeyPerFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.KeyPerFile")).GetReference(filePath: "Microsoft.Extensions.Configuration.KeyPerFile.dll", display: "Microsoft.Extensions.Configuration.KeyPerFile (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationKeyPerFile;
             }
@@ -6311,7 +6311,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationUserSecrets is null)
                 {
-                    _MicrosoftExtensionsConfigurationUserSecrets = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationUserSecrets).GetReference(filePath: "Microsoft.Extensions.Configuration.UserSecrets.dll", display: "Microsoft.Extensions.Configuration.UserSecrets (aspnet90)");
+                    _MicrosoftExtensionsConfigurationUserSecrets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.UserSecrets")).GetReference(filePath: "Microsoft.Extensions.Configuration.UserSecrets.dll", display: "Microsoft.Extensions.Configuration.UserSecrets (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationUserSecrets;
             }
@@ -6328,7 +6328,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsConfigurationXml is null)
                 {
-                    _MicrosoftExtensionsConfigurationXml = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsConfigurationXml).GetReference(filePath: "Microsoft.Extensions.Configuration.Xml.dll", display: "Microsoft.Extensions.Configuration.Xml (aspnet90)");
+                    _MicrosoftExtensionsConfigurationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Configuration.Xml")).GetReference(filePath: "Microsoft.Extensions.Configuration.Xml.dll", display: "Microsoft.Extensions.Configuration.Xml (aspnet90)");
                 }
                 return _MicrosoftExtensionsConfigurationXml;
             }
@@ -6345,7 +6345,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsDependencyInjectionAbstractions is null)
                 {
-                    _MicrosoftExtensionsDependencyInjectionAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDependencyInjectionAbstractions).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.Abstractions.dll", display: "Microsoft.Extensions.DependencyInjection.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsDependencyInjectionAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.DependencyInjection.Abstractions")).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.Abstractions.dll", display: "Microsoft.Extensions.DependencyInjection.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsDependencyInjectionAbstractions;
             }
@@ -6362,7 +6362,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsDependencyInjection is null)
                 {
-                    _MicrosoftExtensionsDependencyInjection = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDependencyInjection).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.dll", display: "Microsoft.Extensions.DependencyInjection (aspnet90)");
+                    _MicrosoftExtensionsDependencyInjection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.DependencyInjection")).GetReference(filePath: "Microsoft.Extensions.DependencyInjection.dll", display: "Microsoft.Extensions.DependencyInjection (aspnet90)");
                 }
                 return _MicrosoftExtensionsDependencyInjection;
             }
@@ -6379,7 +6379,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsDiagnosticsAbstractions is null)
                 {
-                    _MicrosoftExtensionsDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnosticsAbstractions).GetReference(filePath: "Microsoft.Extensions.Diagnostics.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsDiagnosticsAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Diagnostics.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsDiagnosticsAbstractions;
             }
@@ -6396,7 +6396,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsDiagnostics is null)
                 {
-                    _MicrosoftExtensionsDiagnostics = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnostics).GetReference(filePath: "Microsoft.Extensions.Diagnostics.dll", display: "Microsoft.Extensions.Diagnostics (aspnet90)");
+                    _MicrosoftExtensionsDiagnostics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Diagnostics")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.dll", display: "Microsoft.Extensions.Diagnostics (aspnet90)");
                 }
                 return _MicrosoftExtensionsDiagnostics;
             }
@@ -6413,7 +6413,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsDiagnosticsHealthChecksAbstractions is null)
                 {
-                    _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnosticsHealthChecksAbstractions).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsDiagnosticsHealthChecksAbstractions;
             }
@@ -6430,7 +6430,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsDiagnosticsHealthChecks is null)
                 {
-                    _MicrosoftExtensionsDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsDiagnosticsHealthChecks).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks (aspnet90)");
+                    _MicrosoftExtensionsDiagnosticsHealthChecks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Diagnostics.HealthChecks")).GetReference(filePath: "Microsoft.Extensions.Diagnostics.HealthChecks.dll", display: "Microsoft.Extensions.Diagnostics.HealthChecks (aspnet90)");
                 }
                 return _MicrosoftExtensionsDiagnosticsHealthChecks;
             }
@@ -6447,7 +6447,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsFeatures is null)
                 {
-                    _MicrosoftExtensionsFeatures = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFeatures).GetReference(filePath: "Microsoft.Extensions.Features.dll", display: "Microsoft.Extensions.Features (aspnet90)");
+                    _MicrosoftExtensionsFeatures = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Features")).GetReference(filePath: "Microsoft.Extensions.Features.dll", display: "Microsoft.Extensions.Features (aspnet90)");
                 }
                 return _MicrosoftExtensionsFeatures;
             }
@@ -6464,7 +6464,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsFileProvidersAbstractions is null)
                 {
-                    _MicrosoftExtensionsFileProvidersAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersAbstractions).GetReference(filePath: "Microsoft.Extensions.FileProviders.Abstractions.dll", display: "Microsoft.Extensions.FileProviders.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsFileProvidersAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.FileProviders.Abstractions")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Abstractions.dll", display: "Microsoft.Extensions.FileProviders.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsFileProvidersAbstractions;
             }
@@ -6481,7 +6481,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsFileProvidersComposite is null)
                 {
-                    _MicrosoftExtensionsFileProvidersComposite = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersComposite).GetReference(filePath: "Microsoft.Extensions.FileProviders.Composite.dll", display: "Microsoft.Extensions.FileProviders.Composite (aspnet90)");
+                    _MicrosoftExtensionsFileProvidersComposite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.FileProviders.Composite")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Composite.dll", display: "Microsoft.Extensions.FileProviders.Composite (aspnet90)");
                 }
                 return _MicrosoftExtensionsFileProvidersComposite;
             }
@@ -6498,7 +6498,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsFileProvidersEmbedded is null)
                 {
-                    _MicrosoftExtensionsFileProvidersEmbedded = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersEmbedded).GetReference(filePath: "Microsoft.Extensions.FileProviders.Embedded.dll", display: "Microsoft.Extensions.FileProviders.Embedded (aspnet90)");
+                    _MicrosoftExtensionsFileProvidersEmbedded = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.FileProviders.Embedded")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Embedded.dll", display: "Microsoft.Extensions.FileProviders.Embedded (aspnet90)");
                 }
                 return _MicrosoftExtensionsFileProvidersEmbedded;
             }
@@ -6515,7 +6515,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsFileProvidersPhysical is null)
                 {
-                    _MicrosoftExtensionsFileProvidersPhysical = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileProvidersPhysical).GetReference(filePath: "Microsoft.Extensions.FileProviders.Physical.dll", display: "Microsoft.Extensions.FileProviders.Physical (aspnet90)");
+                    _MicrosoftExtensionsFileProvidersPhysical = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.FileProviders.Physical")).GetReference(filePath: "Microsoft.Extensions.FileProviders.Physical.dll", display: "Microsoft.Extensions.FileProviders.Physical (aspnet90)");
                 }
                 return _MicrosoftExtensionsFileProvidersPhysical;
             }
@@ -6532,7 +6532,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsFileSystemGlobbing is null)
                 {
-                    _MicrosoftExtensionsFileSystemGlobbing = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsFileSystemGlobbing).GetReference(filePath: "Microsoft.Extensions.FileSystemGlobbing.dll", display: "Microsoft.Extensions.FileSystemGlobbing (aspnet90)");
+                    _MicrosoftExtensionsFileSystemGlobbing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.FileSystemGlobbing")).GetReference(filePath: "Microsoft.Extensions.FileSystemGlobbing.dll", display: "Microsoft.Extensions.FileSystemGlobbing (aspnet90)");
                 }
                 return _MicrosoftExtensionsFileSystemGlobbing;
             }
@@ -6549,7 +6549,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsHostingAbstractions is null)
                 {
-                    _MicrosoftExtensionsHostingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsHostingAbstractions).GetReference(filePath: "Microsoft.Extensions.Hosting.Abstractions.dll", display: "Microsoft.Extensions.Hosting.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsHostingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Hosting.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Hosting.Abstractions.dll", display: "Microsoft.Extensions.Hosting.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsHostingAbstractions;
             }
@@ -6566,7 +6566,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsHosting is null)
                 {
-                    _MicrosoftExtensionsHosting = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsHosting).GetReference(filePath: "Microsoft.Extensions.Hosting.dll", display: "Microsoft.Extensions.Hosting (aspnet90)");
+                    _MicrosoftExtensionsHosting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Hosting")).GetReference(filePath: "Microsoft.Extensions.Hosting.dll", display: "Microsoft.Extensions.Hosting (aspnet90)");
                 }
                 return _MicrosoftExtensionsHosting;
             }
@@ -6583,7 +6583,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsHttp is null)
                 {
-                    _MicrosoftExtensionsHttp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsHttp).GetReference(filePath: "Microsoft.Extensions.Http.dll", display: "Microsoft.Extensions.Http (aspnet90)");
+                    _MicrosoftExtensionsHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Http")).GetReference(filePath: "Microsoft.Extensions.Http.dll", display: "Microsoft.Extensions.Http (aspnet90)");
                 }
                 return _MicrosoftExtensionsHttp;
             }
@@ -6600,7 +6600,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsIdentityCore is null)
                 {
-                    _MicrosoftExtensionsIdentityCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsIdentityCore).GetReference(filePath: "Microsoft.Extensions.Identity.Core.dll", display: "Microsoft.Extensions.Identity.Core (aspnet90)");
+                    _MicrosoftExtensionsIdentityCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Identity.Core")).GetReference(filePath: "Microsoft.Extensions.Identity.Core.dll", display: "Microsoft.Extensions.Identity.Core (aspnet90)");
                 }
                 return _MicrosoftExtensionsIdentityCore;
             }
@@ -6617,7 +6617,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsIdentityStores is null)
                 {
-                    _MicrosoftExtensionsIdentityStores = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsIdentityStores).GetReference(filePath: "Microsoft.Extensions.Identity.Stores.dll", display: "Microsoft.Extensions.Identity.Stores (aspnet90)");
+                    _MicrosoftExtensionsIdentityStores = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Identity.Stores")).GetReference(filePath: "Microsoft.Extensions.Identity.Stores.dll", display: "Microsoft.Extensions.Identity.Stores (aspnet90)");
                 }
                 return _MicrosoftExtensionsIdentityStores;
             }
@@ -6634,7 +6634,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLocalizationAbstractions is null)
                 {
-                    _MicrosoftExtensionsLocalizationAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLocalizationAbstractions).GetReference(filePath: "Microsoft.Extensions.Localization.Abstractions.dll", display: "Microsoft.Extensions.Localization.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsLocalizationAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Localization.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Localization.Abstractions.dll", display: "Microsoft.Extensions.Localization.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsLocalizationAbstractions;
             }
@@ -6651,7 +6651,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLocalization is null)
                 {
-                    _MicrosoftExtensionsLocalization = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLocalization).GetReference(filePath: "Microsoft.Extensions.Localization.dll", display: "Microsoft.Extensions.Localization (aspnet90)");
+                    _MicrosoftExtensionsLocalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Localization")).GetReference(filePath: "Microsoft.Extensions.Localization.dll", display: "Microsoft.Extensions.Localization (aspnet90)");
                 }
                 return _MicrosoftExtensionsLocalization;
             }
@@ -6668,7 +6668,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLoggingAbstractions is null)
                 {
-                    _MicrosoftExtensionsLoggingAbstractions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingAbstractions).GetReference(filePath: "Microsoft.Extensions.Logging.Abstractions.dll", display: "Microsoft.Extensions.Logging.Abstractions (aspnet90)");
+                    _MicrosoftExtensionsLoggingAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging.Abstractions")).GetReference(filePath: "Microsoft.Extensions.Logging.Abstractions.dll", display: "Microsoft.Extensions.Logging.Abstractions (aspnet90)");
                 }
                 return _MicrosoftExtensionsLoggingAbstractions;
             }
@@ -6685,7 +6685,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLoggingConfiguration is null)
                 {
-                    _MicrosoftExtensionsLoggingConfiguration = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingConfiguration).GetReference(filePath: "Microsoft.Extensions.Logging.Configuration.dll", display: "Microsoft.Extensions.Logging.Configuration (aspnet90)");
+                    _MicrosoftExtensionsLoggingConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging.Configuration")).GetReference(filePath: "Microsoft.Extensions.Logging.Configuration.dll", display: "Microsoft.Extensions.Logging.Configuration (aspnet90)");
                 }
                 return _MicrosoftExtensionsLoggingConfiguration;
             }
@@ -6702,7 +6702,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLoggingConsole is null)
                 {
-                    _MicrosoftExtensionsLoggingConsole = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingConsole).GetReference(filePath: "Microsoft.Extensions.Logging.Console.dll", display: "Microsoft.Extensions.Logging.Console (aspnet90)");
+                    _MicrosoftExtensionsLoggingConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging.Console")).GetReference(filePath: "Microsoft.Extensions.Logging.Console.dll", display: "Microsoft.Extensions.Logging.Console (aspnet90)");
                 }
                 return _MicrosoftExtensionsLoggingConsole;
             }
@@ -6719,7 +6719,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLoggingDebug is null)
                 {
-                    _MicrosoftExtensionsLoggingDebug = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingDebug).GetReference(filePath: "Microsoft.Extensions.Logging.Debug.dll", display: "Microsoft.Extensions.Logging.Debug (aspnet90)");
+                    _MicrosoftExtensionsLoggingDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging.Debug")).GetReference(filePath: "Microsoft.Extensions.Logging.Debug.dll", display: "Microsoft.Extensions.Logging.Debug (aspnet90)");
                 }
                 return _MicrosoftExtensionsLoggingDebug;
             }
@@ -6736,7 +6736,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLogging is null)
                 {
-                    _MicrosoftExtensionsLogging = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLogging).GetReference(filePath: "Microsoft.Extensions.Logging.dll", display: "Microsoft.Extensions.Logging (aspnet90)");
+                    _MicrosoftExtensionsLogging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging")).GetReference(filePath: "Microsoft.Extensions.Logging.dll", display: "Microsoft.Extensions.Logging (aspnet90)");
                 }
                 return _MicrosoftExtensionsLogging;
             }
@@ -6753,7 +6753,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLoggingEventLog is null)
                 {
-                    _MicrosoftExtensionsLoggingEventLog = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingEventLog).GetReference(filePath: "Microsoft.Extensions.Logging.EventLog.dll", display: "Microsoft.Extensions.Logging.EventLog (aspnet90)");
+                    _MicrosoftExtensionsLoggingEventLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging.EventLog")).GetReference(filePath: "Microsoft.Extensions.Logging.EventLog.dll", display: "Microsoft.Extensions.Logging.EventLog (aspnet90)");
                 }
                 return _MicrosoftExtensionsLoggingEventLog;
             }
@@ -6770,7 +6770,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLoggingEventSource is null)
                 {
-                    _MicrosoftExtensionsLoggingEventSource = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingEventSource).GetReference(filePath: "Microsoft.Extensions.Logging.EventSource.dll", display: "Microsoft.Extensions.Logging.EventSource (aspnet90)");
+                    _MicrosoftExtensionsLoggingEventSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging.EventSource")).GetReference(filePath: "Microsoft.Extensions.Logging.EventSource.dll", display: "Microsoft.Extensions.Logging.EventSource (aspnet90)");
                 }
                 return _MicrosoftExtensionsLoggingEventSource;
             }
@@ -6787,7 +6787,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsLoggingTraceSource is null)
                 {
-                    _MicrosoftExtensionsLoggingTraceSource = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsLoggingTraceSource).GetReference(filePath: "Microsoft.Extensions.Logging.TraceSource.dll", display: "Microsoft.Extensions.Logging.TraceSource (aspnet90)");
+                    _MicrosoftExtensionsLoggingTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Logging.TraceSource")).GetReference(filePath: "Microsoft.Extensions.Logging.TraceSource.dll", display: "Microsoft.Extensions.Logging.TraceSource (aspnet90)");
                 }
                 return _MicrosoftExtensionsLoggingTraceSource;
             }
@@ -6804,7 +6804,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsObjectPool is null)
                 {
-                    _MicrosoftExtensionsObjectPool = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsObjectPool).GetReference(filePath: "Microsoft.Extensions.ObjectPool.dll", display: "Microsoft.Extensions.ObjectPool (aspnet90)");
+                    _MicrosoftExtensionsObjectPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.ObjectPool")).GetReference(filePath: "Microsoft.Extensions.ObjectPool.dll", display: "Microsoft.Extensions.ObjectPool (aspnet90)");
                 }
                 return _MicrosoftExtensionsObjectPool;
             }
@@ -6821,7 +6821,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsOptionsConfigurationExtensions is null)
                 {
-                    _MicrosoftExtensionsOptionsConfigurationExtensions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsOptionsConfigurationExtensions).GetReference(filePath: "Microsoft.Extensions.Options.ConfigurationExtensions.dll", display: "Microsoft.Extensions.Options.ConfigurationExtensions (aspnet90)");
+                    _MicrosoftExtensionsOptionsConfigurationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Options.ConfigurationExtensions")).GetReference(filePath: "Microsoft.Extensions.Options.ConfigurationExtensions.dll", display: "Microsoft.Extensions.Options.ConfigurationExtensions (aspnet90)");
                 }
                 return _MicrosoftExtensionsOptionsConfigurationExtensions;
             }
@@ -6838,7 +6838,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsOptionsDataAnnotations is null)
                 {
-                    _MicrosoftExtensionsOptionsDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsOptionsDataAnnotations).GetReference(filePath: "Microsoft.Extensions.Options.DataAnnotations.dll", display: "Microsoft.Extensions.Options.DataAnnotations (aspnet90)");
+                    _MicrosoftExtensionsOptionsDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Options.DataAnnotations")).GetReference(filePath: "Microsoft.Extensions.Options.DataAnnotations.dll", display: "Microsoft.Extensions.Options.DataAnnotations (aspnet90)");
                 }
                 return _MicrosoftExtensionsOptionsDataAnnotations;
             }
@@ -6855,7 +6855,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsOptions is null)
                 {
-                    _MicrosoftExtensionsOptions = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsOptions).GetReference(filePath: "Microsoft.Extensions.Options.dll", display: "Microsoft.Extensions.Options (aspnet90)");
+                    _MicrosoftExtensionsOptions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Options")).GetReference(filePath: "Microsoft.Extensions.Options.dll", display: "Microsoft.Extensions.Options (aspnet90)");
                 }
                 return _MicrosoftExtensionsOptions;
             }
@@ -6872,7 +6872,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsPrimitives is null)
                 {
-                    _MicrosoftExtensionsPrimitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsPrimitives).GetReference(filePath: "Microsoft.Extensions.Primitives.dll", display: "Microsoft.Extensions.Primitives (aspnet90)");
+                    _MicrosoftExtensionsPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.Primitives")).GetReference(filePath: "Microsoft.Extensions.Primitives.dll", display: "Microsoft.Extensions.Primitives (aspnet90)");
                 }
                 return _MicrosoftExtensionsPrimitives;
             }
@@ -6889,7 +6889,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftExtensionsWebEncoders is null)
                 {
-                    _MicrosoftExtensionsWebEncoders = AssemblyMetadata.CreateFromImage(Resources.MicrosoftExtensionsWebEncoders).GetReference(filePath: "Microsoft.Extensions.WebEncoders.dll", display: "Microsoft.Extensions.WebEncoders (aspnet90)");
+                    _MicrosoftExtensionsWebEncoders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Extensions.WebEncoders")).GetReference(filePath: "Microsoft.Extensions.WebEncoders.dll", display: "Microsoft.Extensions.WebEncoders (aspnet90)");
                 }
                 return _MicrosoftExtensionsWebEncoders;
             }
@@ -6906,7 +6906,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftJSInterop is null)
                 {
-                    _MicrosoftJSInterop = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJSInterop).GetReference(filePath: "Microsoft.JSInterop.dll", display: "Microsoft.JSInterop (aspnet90)");
+                    _MicrosoftJSInterop = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.JSInterop")).GetReference(filePath: "Microsoft.JSInterop.dll", display: "Microsoft.JSInterop (aspnet90)");
                 }
                 return _MicrosoftJSInterop;
             }
@@ -6923,7 +6923,7 @@ public static partial class AspNet90
             {
                 if (_MicrosoftNetHttpHeaders is null)
                 {
-                    _MicrosoftNetHttpHeaders = AssemblyMetadata.CreateFromImage(Resources.MicrosoftNetHttpHeaders).GetReference(filePath: "Microsoft.Net.Http.Headers.dll", display: "Microsoft.Net.Http.Headers (aspnet90)");
+                    _MicrosoftNetHttpHeaders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.Microsoft.Net.Http.Headers")).GetReference(filePath: "Microsoft.Net.Http.Headers.dll", display: "Microsoft.Net.Http.Headers (aspnet90)");
                 }
                 return _MicrosoftNetHttpHeaders;
             }
@@ -6940,7 +6940,7 @@ public static partial class AspNet90
             {
                 if (_SystemDiagnosticsEventLog is null)
                 {
-                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsEventLog).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (aspnet90)");
+                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Diagnostics.EventLog")).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (aspnet90)");
                 }
                 return _SystemDiagnosticsEventLog;
             }
@@ -6957,7 +6957,7 @@ public static partial class AspNet90
             {
                 if (_SystemSecurityCryptographyXml is null)
                 {
-                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyXml).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (aspnet90)");
+                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Security.Cryptography.Xml")).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (aspnet90)");
                 }
                 return _SystemSecurityCryptographyXml;
             }
@@ -6974,7 +6974,7 @@ public static partial class AspNet90
             {
                 if (_SystemThreadingRateLimiting is null)
                 {
-                    _SystemThreadingRateLimiting = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingRateLimiting).GetReference(filePath: "System.Threading.RateLimiting.dll", display: "System.Threading.RateLimiting (aspnet90)");
+                    _SystemThreadingRateLimiting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("aspnet90.System.Threading.RateLimiting")).GetReference(filePath: "System.Threading.RateLimiting.dll", display: "System.Threading.RateLimiting (aspnet90)");
                 }
                 return _SystemThreadingRateLimiting;
             }

--- a/Src/Basic.Reference.Assemblies.Net20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net20/Generated.cs
@@ -339,7 +339,7 @@ public static partial class Net20
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net20)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net20)");
                 }
                 return _Accessibility;
             }
@@ -356,7 +356,7 @@ public static partial class Net20
             {
                 if (_AspNetMMCExt is null)
                 {
-                    _AspNetMMCExt = AssemblyMetadata.CreateFromImage(Resources.AspNetMMCExt).GetReference(filePath: "AspNetMMCExt.dll", display: "AspNetMMCExt (net20)");
+                    _AspNetMMCExt = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.AspNetMMCExt")).GetReference(filePath: "AspNetMMCExt.dll", display: "AspNetMMCExt (net20)");
                 }
                 return _AspNetMMCExt;
             }
@@ -373,7 +373,7 @@ public static partial class Net20
             {
                 if (_cscompmgd is null)
                 {
-                    _cscompmgd = AssemblyMetadata.CreateFromImage(Resources.cscompmgd).GetReference(filePath: "cscompmgd.dll", display: "cscompmgd (net20)");
+                    _cscompmgd = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.cscompmgd")).GetReference(filePath: "cscompmgd.dll", display: "cscompmgd (net20)");
                 }
                 return _cscompmgd;
             }
@@ -390,7 +390,7 @@ public static partial class Net20
             {
                 if (_CustomMarshalers is null)
                 {
-                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(Resources.CustomMarshalers).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net20)");
+                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.CustomMarshalers")).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net20)");
                 }
                 return _CustomMarshalers;
             }
@@ -407,7 +407,7 @@ public static partial class Net20
             {
                 if (_IEExecRemote is null)
                 {
-                    _IEExecRemote = AssemblyMetadata.CreateFromImage(Resources.IEExecRemote).GetReference(filePath: "IEExecRemote.dll", display: "IEExecRemote (net20)");
+                    _IEExecRemote = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.IEExecRemote")).GetReference(filePath: "IEExecRemote.dll", display: "IEExecRemote (net20)");
                 }
                 return _IEExecRemote;
             }
@@ -424,7 +424,7 @@ public static partial class Net20
             {
                 if (_IEHost is null)
                 {
-                    _IEHost = AssemblyMetadata.CreateFromImage(Resources.IEHost).GetReference(filePath: "IEHost.dll", display: "IEHost (net20)");
+                    _IEHost = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.IEHost")).GetReference(filePath: "IEHost.dll", display: "IEHost (net20)");
                 }
                 return _IEHost;
             }
@@ -441,7 +441,7 @@ public static partial class Net20
             {
                 if (_IIEHost is null)
                 {
-                    _IIEHost = AssemblyMetadata.CreateFromImage(Resources.IIEHost).GetReference(filePath: "IIEHost.dll", display: "IIEHost (net20)");
+                    _IIEHost = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.IIEHost")).GetReference(filePath: "IIEHost.dll", display: "IIEHost (net20)");
                 }
                 return _IIEHost;
             }
@@ -458,7 +458,7 @@ public static partial class Net20
             {
                 if (_ISymWrapper is null)
                 {
-                    _ISymWrapper = AssemblyMetadata.CreateFromImage(Resources.ISymWrapper).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net20)");
+                    _ISymWrapper = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.ISymWrapper")).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net20)");
                 }
                 return _ISymWrapper;
             }
@@ -475,7 +475,7 @@ public static partial class Net20
             {
                 if (_MicrosoftBuildEngine is null)
                 {
-                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildEngine).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net20)");
+                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.Build.Engine")).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net20)");
                 }
                 return _MicrosoftBuildEngine;
             }
@@ -492,7 +492,7 @@ public static partial class Net20
             {
                 if (_MicrosoftBuildFramework is null)
                 {
-                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildFramework).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net20)");
+                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.Build.Framework")).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net20)");
                 }
                 return _MicrosoftBuildFramework;
             }
@@ -509,7 +509,7 @@ public static partial class Net20
             {
                 if (_MicrosoftBuildTasks is null)
                 {
-                    _MicrosoftBuildTasks = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildTasks).GetReference(filePath: "Microsoft.Build.Tasks.dll", display: "Microsoft.Build.Tasks (net20)");
+                    _MicrosoftBuildTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.Build.Tasks")).GetReference(filePath: "Microsoft.Build.Tasks.dll", display: "Microsoft.Build.Tasks (net20)");
                 }
                 return _MicrosoftBuildTasks;
             }
@@ -526,7 +526,7 @@ public static partial class Net20
             {
                 if (_MicrosoftBuildUtilities is null)
                 {
-                    _MicrosoftBuildUtilities = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildUtilities).GetReference(filePath: "Microsoft.Build.Utilities.dll", display: "Microsoft.Build.Utilities (net20)");
+                    _MicrosoftBuildUtilities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.Build.Utilities")).GetReference(filePath: "Microsoft.Build.Utilities.dll", display: "Microsoft.Build.Utilities (net20)");
                 }
                 return _MicrosoftBuildUtilities;
             }
@@ -543,7 +543,7 @@ public static partial class Net20
             {
                 if (_MicrosoftJScript is null)
                 {
-                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJScript).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net20)");
+                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.JScript")).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net20)");
                 }
                 return _MicrosoftJScript;
             }
@@ -560,7 +560,7 @@ public static partial class Net20
             {
                 if (_MicrosoftVisualBasicCompatibilityData is null)
                 {
-                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibilityData).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net20)");
+                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.VisualBasic.Compatibility.Data")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net20)");
                 }
                 return _MicrosoftVisualBasicCompatibilityData;
             }
@@ -577,7 +577,7 @@ public static partial class Net20
             {
                 if (_MicrosoftVisualBasicCompatibility is null)
                 {
-                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibility).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net20)");
+                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.VisualBasic.Compatibility")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net20)");
                 }
                 return _MicrosoftVisualBasicCompatibility;
             }
@@ -594,7 +594,7 @@ public static partial class Net20
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net20)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net20)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -611,7 +611,7 @@ public static partial class Net20
             {
                 if (_MicrosoftVisualBasicVsa is null)
                 {
-                    _MicrosoftVisualBasicVsa = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicVsa).GetReference(filePath: "Microsoft.VisualBasic.Vsa.dll", display: "Microsoft.VisualBasic.Vsa (net20)");
+                    _MicrosoftVisualBasicVsa = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.VisualBasic.Vsa")).GetReference(filePath: "Microsoft.VisualBasic.Vsa.dll", display: "Microsoft.VisualBasic.Vsa (net20)");
                 }
                 return _MicrosoftVisualBasicVsa;
             }
@@ -628,7 +628,7 @@ public static partial class Net20
             {
                 if (_MicrosoftVisualC is null)
                 {
-                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualC).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net20)");
+                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.VisualC")).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net20)");
                 }
                 return _MicrosoftVisualC;
             }
@@ -645,7 +645,7 @@ public static partial class Net20
             {
                 if (_MicrosoftVsa is null)
                 {
-                    _MicrosoftVsa = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVsa).GetReference(filePath: "Microsoft.Vsa.dll", display: "Microsoft.Vsa (net20)");
+                    _MicrosoftVsa = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.Vsa")).GetReference(filePath: "Microsoft.Vsa.dll", display: "Microsoft.Vsa (net20)");
                 }
                 return _MicrosoftVsa;
             }
@@ -662,7 +662,7 @@ public static partial class Net20
             {
                 if (_MicrosoftVsaVbCodeDOMProcessor is null)
                 {
-                    _MicrosoftVsaVbCodeDOMProcessor = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVsaVbCodeDOMProcessor).GetReference(filePath: "Microsoft.Vsa.Vb.CodeDOMProcessor.dll", display: "Microsoft.Vsa.Vb.CodeDOMProcessor (net20)");
+                    _MicrosoftVsaVbCodeDOMProcessor = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft.Vsa.Vb.CodeDOMProcessor")).GetReference(filePath: "Microsoft.Vsa.Vb.CodeDOMProcessor.dll", display: "Microsoft.Vsa.Vb.CodeDOMProcessor (net20)");
                 }
                 return _MicrosoftVsaVbCodeDOMProcessor;
             }
@@ -679,7 +679,7 @@ public static partial class Net20
             {
                 if (_Microsoft_VsaVb is null)
                 {
-                    _Microsoft_VsaVb = AssemblyMetadata.CreateFromImage(Resources.Microsoft_VsaVb).GetReference(filePath: "Microsoft_VsaVb.dll", display: "Microsoft_VsaVb (net20)");
+                    _Microsoft_VsaVb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.Microsoft_VsaVb")).GetReference(filePath: "Microsoft_VsaVb.dll", display: "Microsoft_VsaVb (net20)");
                 }
                 return _Microsoft_VsaVb;
             }
@@ -696,7 +696,7 @@ public static partial class Net20
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net20)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net20)");
                 }
                 return _mscorlib;
             }
@@ -713,7 +713,7 @@ public static partial class Net20
             {
                 if (_sysglobl is null)
                 {
-                    _sysglobl = AssemblyMetadata.CreateFromImage(Resources.sysglobl).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net20)");
+                    _sysglobl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.sysglobl")).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net20)");
                 }
                 return _sysglobl;
             }
@@ -730,7 +730,7 @@ public static partial class Net20
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net20)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net20)");
                 }
                 return _SystemConfiguration;
             }
@@ -747,7 +747,7 @@ public static partial class Net20
             {
                 if (_SystemConfigurationInstall is null)
                 {
-                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationInstall).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net20)");
+                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Configuration.Install")).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net20)");
                 }
                 return _SystemConfigurationInstall;
             }
@@ -764,7 +764,7 @@ public static partial class Net20
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net20)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net20)");
                 }
                 return _SystemData;
             }
@@ -781,7 +781,7 @@ public static partial class Net20
             {
                 if (_SystemDataOracleClient is null)
                 {
-                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataOracleClient).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net20)");
+                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Data.OracleClient")).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net20)");
                 }
                 return _SystemDataOracleClient;
             }
@@ -798,7 +798,7 @@ public static partial class Net20
             {
                 if (_SystemDataSqlXml is null)
                 {
-                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(Resources.SystemDataSqlXml).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net20)");
+                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Data.SqlXml")).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net20)");
                 }
                 return _SystemDataSqlXml;
             }
@@ -815,7 +815,7 @@ public static partial class Net20
             {
                 if (_SystemDeployment is null)
                 {
-                    _SystemDeployment = AssemblyMetadata.CreateFromImage(Resources.SystemDeployment).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net20)");
+                    _SystemDeployment = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Deployment")).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net20)");
                 }
                 return _SystemDeployment;
             }
@@ -832,7 +832,7 @@ public static partial class Net20
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net20)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net20)");
                 }
                 return _SystemDesign;
             }
@@ -849,7 +849,7 @@ public static partial class Net20
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net20)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net20)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -866,7 +866,7 @@ public static partial class Net20
             {
                 if (_SystemDirectoryServicesProtocols is null)
                 {
-                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesProtocols).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net20)");
+                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.DirectoryServices.Protocols")).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net20)");
                 }
                 return _SystemDirectoryServicesProtocols;
             }
@@ -883,7 +883,7 @@ public static partial class Net20
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net20)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System")).GetReference(filePath: "System.dll", display: "System (net20)");
                 }
                 return _System;
             }
@@ -900,7 +900,7 @@ public static partial class Net20
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net20)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net20)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -917,7 +917,7 @@ public static partial class Net20
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net20)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net20)");
                 }
                 return _SystemDrawing;
             }
@@ -934,7 +934,7 @@ public static partial class Net20
             {
                 if (_SystemEnterpriseServices is null)
                 {
-                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(Resources.SystemEnterpriseServices).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net20)");
+                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.EnterpriseServices")).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net20)");
                 }
                 return _SystemEnterpriseServices;
             }
@@ -951,7 +951,7 @@ public static partial class Net20
             {
                 if (_SystemManagement is null)
                 {
-                    _SystemManagement = AssemblyMetadata.CreateFromImage(Resources.SystemManagement).GetReference(filePath: "System.Management.dll", display: "System.Management (net20)");
+                    _SystemManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Management")).GetReference(filePath: "System.Management.dll", display: "System.Management (net20)");
                 }
                 return _SystemManagement;
             }
@@ -968,7 +968,7 @@ public static partial class Net20
             {
                 if (_SystemMessaging is null)
                 {
-                    _SystemMessaging = AssemblyMetadata.CreateFromImage(Resources.SystemMessaging).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net20)");
+                    _SystemMessaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Messaging")).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net20)");
                 }
                 return _SystemMessaging;
             }
@@ -985,7 +985,7 @@ public static partial class Net20
             {
                 if (_SystemRuntimeRemoting is null)
                 {
-                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeRemoting).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net20)");
+                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Runtime.Remoting")).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net20)");
                 }
                 return _SystemRuntimeRemoting;
             }
@@ -1002,7 +1002,7 @@ public static partial class Net20
             {
                 if (_SystemRuntimeSerializationFormattersSoap is null)
                 {
-                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormattersSoap).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net20)");
+                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Runtime.Serialization.Formatters.Soap")).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net20)");
                 }
                 return _SystemRuntimeSerializationFormattersSoap;
             }
@@ -1019,7 +1019,7 @@ public static partial class Net20
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net20)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net20)");
                 }
                 return _SystemSecurity;
             }
@@ -1036,7 +1036,7 @@ public static partial class Net20
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net20)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net20)");
                 }
                 return _SystemServiceProcess;
             }
@@ -1053,7 +1053,7 @@ public static partial class Net20
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net20)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net20)");
                 }
                 return _SystemTransactions;
             }
@@ -1070,7 +1070,7 @@ public static partial class Net20
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net20)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net20)");
                 }
                 return _SystemWeb;
             }
@@ -1087,7 +1087,7 @@ public static partial class Net20
             {
                 if (_SystemWebMobile is null)
                 {
-                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(Resources.SystemWebMobile).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net20)");
+                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Web.Mobile")).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net20)");
                 }
                 return _SystemWebMobile;
             }
@@ -1104,7 +1104,7 @@ public static partial class Net20
             {
                 if (_SystemWebRegularExpressions is null)
                 {
-                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemWebRegularExpressions).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net20)");
+                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Web.RegularExpressions")).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net20)");
                 }
                 return _SystemWebRegularExpressions;
             }
@@ -1121,7 +1121,7 @@ public static partial class Net20
             {
                 if (_SystemWebServices is null)
                 {
-                    _SystemWebServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebServices).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net20)");
+                    _SystemWebServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Web.Services")).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net20)");
                 }
                 return _SystemWebServices;
             }
@@ -1138,7 +1138,7 @@ public static partial class Net20
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net20)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net20)");
                 }
                 return _SystemWindowsForms;
             }
@@ -1155,7 +1155,7 @@ public static partial class Net20
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net20)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net20.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net20)");
                 }
                 return _SystemXml;
             }

--- a/Src/Basic.Reference.Assemblies.Net35/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net35/Generated.cs
@@ -657,7 +657,7 @@ public static partial class Net35
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net35)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net35)");
                 }
                 return _Accessibility;
             }
@@ -674,7 +674,7 @@ public static partial class Net35
             {
                 if (_AspNetMMCExt is null)
                 {
-                    _AspNetMMCExt = AssemblyMetadata.CreateFromImage(Resources.AspNetMMCExt).GetReference(filePath: "AspNetMMCExt.dll", display: "AspNetMMCExt (net35)");
+                    _AspNetMMCExt = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.AspNetMMCExt")).GetReference(filePath: "AspNetMMCExt.dll", display: "AspNetMMCExt (net35)");
                 }
                 return _AspNetMMCExt;
             }
@@ -691,7 +691,7 @@ public static partial class Net35
             {
                 if (_cscompmgd is null)
                 {
-                    _cscompmgd = AssemblyMetadata.CreateFromImage(Resources.cscompmgd).GetReference(filePath: "cscompmgd.dll", display: "cscompmgd (net35)");
+                    _cscompmgd = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.cscompmgd")).GetReference(filePath: "cscompmgd.dll", display: "cscompmgd (net35)");
                 }
                 return _cscompmgd;
             }
@@ -708,7 +708,7 @@ public static partial class Net35
             {
                 if (_CustomMarshalers is null)
                 {
-                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(Resources.CustomMarshalers).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net35)");
+                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.CustomMarshalers")).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net35)");
                 }
                 return _CustomMarshalers;
             }
@@ -725,7 +725,7 @@ public static partial class Net35
             {
                 if (_IEExecRemote is null)
                 {
-                    _IEExecRemote = AssemblyMetadata.CreateFromImage(Resources.IEExecRemote).GetReference(filePath: "IEExecRemote.dll", display: "IEExecRemote (net35)");
+                    _IEExecRemote = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.IEExecRemote")).GetReference(filePath: "IEExecRemote.dll", display: "IEExecRemote (net35)");
                 }
                 return _IEExecRemote;
             }
@@ -742,7 +742,7 @@ public static partial class Net35
             {
                 if (_IEHost is null)
                 {
-                    _IEHost = AssemblyMetadata.CreateFromImage(Resources.IEHost).GetReference(filePath: "IEHost.dll", display: "IEHost (net35)");
+                    _IEHost = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.IEHost")).GetReference(filePath: "IEHost.dll", display: "IEHost (net35)");
                 }
                 return _IEHost;
             }
@@ -759,7 +759,7 @@ public static partial class Net35
             {
                 if (_IIEHost is null)
                 {
-                    _IIEHost = AssemblyMetadata.CreateFromImage(Resources.IIEHost).GetReference(filePath: "IIEHost.dll", display: "IIEHost (net35)");
+                    _IIEHost = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.IIEHost")).GetReference(filePath: "IIEHost.dll", display: "IIEHost (net35)");
                 }
                 return _IIEHost;
             }
@@ -776,7 +776,7 @@ public static partial class Net35
             {
                 if (_ISymWrapper is null)
                 {
-                    _ISymWrapper = AssemblyMetadata.CreateFromImage(Resources.ISymWrapper).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net35)");
+                    _ISymWrapper = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.ISymWrapper")).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net35)");
                 }
                 return _ISymWrapper;
             }
@@ -793,7 +793,7 @@ public static partial class Net35
             {
                 if (_MicrosoftBuildConversionv35 is null)
                 {
-                    _MicrosoftBuildConversionv35 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildConversionv35).GetReference(filePath: "Microsoft.Build.Conversion.v3.5.dll", display: "Microsoft.Build.Conversion.v3.5 (net35)");
+                    _MicrosoftBuildConversionv35 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Build.Conversion.v3.5")).GetReference(filePath: "Microsoft.Build.Conversion.v3.5.dll", display: "Microsoft.Build.Conversion.v3.5 (net35)");
                 }
                 return _MicrosoftBuildConversionv35;
             }
@@ -810,7 +810,7 @@ public static partial class Net35
             {
                 if (_MicrosoftBuildEngine is null)
                 {
-                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildEngine).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net35)");
+                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Build.Engine")).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net35)");
                 }
                 return _MicrosoftBuildEngine;
             }
@@ -827,7 +827,7 @@ public static partial class Net35
             {
                 if (_MicrosoftBuildFramework is null)
                 {
-                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildFramework).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net35)");
+                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Build.Framework")).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net35)");
                 }
                 return _MicrosoftBuildFramework;
             }
@@ -844,7 +844,7 @@ public static partial class Net35
             {
                 if (_MicrosoftBuildTasks is null)
                 {
-                    _MicrosoftBuildTasks = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildTasks).GetReference(filePath: "Microsoft.Build.Tasks.dll", display: "Microsoft.Build.Tasks (net35)");
+                    _MicrosoftBuildTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Build.Tasks")).GetReference(filePath: "Microsoft.Build.Tasks.dll", display: "Microsoft.Build.Tasks (net35)");
                 }
                 return _MicrosoftBuildTasks;
             }
@@ -861,7 +861,7 @@ public static partial class Net35
             {
                 if (_MicrosoftBuildUtilities is null)
                 {
-                    _MicrosoftBuildUtilities = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildUtilities).GetReference(filePath: "Microsoft.Build.Utilities.dll", display: "Microsoft.Build.Utilities (net35)");
+                    _MicrosoftBuildUtilities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Build.Utilities")).GetReference(filePath: "Microsoft.Build.Utilities.dll", display: "Microsoft.Build.Utilities (net35)");
                 }
                 return _MicrosoftBuildUtilities;
             }
@@ -878,7 +878,7 @@ public static partial class Net35
             {
                 if (_MicrosoftBuildUtilitiesv35 is null)
                 {
-                    _MicrosoftBuildUtilitiesv35 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildUtilitiesv35).GetReference(filePath: "Microsoft.Build.Utilities.v3.5.dll", display: "Microsoft.Build.Utilities.v3.5 (net35)");
+                    _MicrosoftBuildUtilitiesv35 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Build.Utilities.v3.5")).GetReference(filePath: "Microsoft.Build.Utilities.v3.5.dll", display: "Microsoft.Build.Utilities.v3.5 (net35)");
                 }
                 return _MicrosoftBuildUtilitiesv35;
             }
@@ -895,7 +895,7 @@ public static partial class Net35
             {
                 if (_MicrosoftJScript is null)
                 {
-                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJScript).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net35)");
+                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.JScript")).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net35)");
                 }
                 return _MicrosoftJScript;
             }
@@ -912,7 +912,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVisualBasicCompatibilityData is null)
                 {
-                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibilityData).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net35)");
+                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.VisualBasic.Compatibility.Data")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net35)");
                 }
                 return _MicrosoftVisualBasicCompatibilityData;
             }
@@ -929,7 +929,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVisualBasicCompatibility is null)
                 {
-                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibility).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net35)");
+                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.VisualBasic.Compatibility")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net35)");
                 }
                 return _MicrosoftVisualBasicCompatibility;
             }
@@ -946,7 +946,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net35)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net35)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -963,7 +963,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVisualBasicVsa is null)
                 {
-                    _MicrosoftVisualBasicVsa = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicVsa).GetReference(filePath: "Microsoft.VisualBasic.Vsa.dll", display: "Microsoft.VisualBasic.Vsa (net35)");
+                    _MicrosoftVisualBasicVsa = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.VisualBasic.Vsa")).GetReference(filePath: "Microsoft.VisualBasic.Vsa.dll", display: "Microsoft.VisualBasic.Vsa (net35)");
                 }
                 return _MicrosoftVisualBasicVsa;
             }
@@ -980,7 +980,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVisualC is null)
                 {
-                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualC).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net35)");
+                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.VisualC")).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net35)");
                 }
                 return _MicrosoftVisualC;
             }
@@ -997,7 +997,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVisualCSTLCLR is null)
                 {
-                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualCSTLCLR).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net35)");
+                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.VisualC.STLCLR")).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net35)");
                 }
                 return _MicrosoftVisualCSTLCLR;
             }
@@ -1014,7 +1014,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVsa is null)
                 {
-                    _MicrosoftVsa = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVsa).GetReference(filePath: "Microsoft.Vsa.dll", display: "Microsoft.Vsa (net35)");
+                    _MicrosoftVsa = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Vsa")).GetReference(filePath: "Microsoft.Vsa.dll", display: "Microsoft.Vsa (net35)");
                 }
                 return _MicrosoftVsa;
             }
@@ -1031,7 +1031,7 @@ public static partial class Net35
             {
                 if (_MicrosoftVsaVbCodeDOMProcessor is null)
                 {
-                    _MicrosoftVsaVbCodeDOMProcessor = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVsaVbCodeDOMProcessor).GetReference(filePath: "Microsoft.Vsa.Vb.CodeDOMProcessor.dll", display: "Microsoft.Vsa.Vb.CodeDOMProcessor (net35)");
+                    _MicrosoftVsaVbCodeDOMProcessor = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft.Vsa.Vb.CodeDOMProcessor")).GetReference(filePath: "Microsoft.Vsa.Vb.CodeDOMProcessor.dll", display: "Microsoft.Vsa.Vb.CodeDOMProcessor (net35)");
                 }
                 return _MicrosoftVsaVbCodeDOMProcessor;
             }
@@ -1048,7 +1048,7 @@ public static partial class Net35
             {
                 if (_Microsoft_VsaVb is null)
                 {
-                    _Microsoft_VsaVb = AssemblyMetadata.CreateFromImage(Resources.Microsoft_VsaVb).GetReference(filePath: "Microsoft_VsaVb.dll", display: "Microsoft_VsaVb (net35)");
+                    _Microsoft_VsaVb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.Microsoft_VsaVb")).GetReference(filePath: "Microsoft_VsaVb.dll", display: "Microsoft_VsaVb (net35)");
                 }
                 return _Microsoft_VsaVb;
             }
@@ -1065,7 +1065,7 @@ public static partial class Net35
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net35)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net35)");
                 }
                 return _mscorlib;
             }
@@ -1082,7 +1082,7 @@ public static partial class Net35
             {
                 if (_PresentationBuildTasks is null)
                 {
-                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(Resources.PresentationBuildTasks).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net35)");
+                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.PresentationBuildTasks")).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net35)");
                 }
                 return _PresentationBuildTasks;
             }
@@ -1099,7 +1099,7 @@ public static partial class Net35
             {
                 if (_PresentationCore is null)
                 {
-                    _PresentationCore = AssemblyMetadata.CreateFromImage(Resources.PresentationCore).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net35)");
+                    _PresentationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.PresentationCore")).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net35)");
                 }
                 return _PresentationCore;
             }
@@ -1116,7 +1116,7 @@ public static partial class Net35
             {
                 if (_PresentationFrameworkAero is null)
                 {
-                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net35)");
+                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.PresentationFramework.Aero")).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net35)");
                 }
                 return _PresentationFrameworkAero;
             }
@@ -1133,7 +1133,7 @@ public static partial class Net35
             {
                 if (_PresentationFrameworkClassic is null)
                 {
-                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkClassic).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net35)");
+                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.PresentationFramework.Classic")).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net35)");
                 }
                 return _PresentationFrameworkClassic;
             }
@@ -1150,7 +1150,7 @@ public static partial class Net35
             {
                 if (_PresentationFramework is null)
                 {
-                    _PresentationFramework = AssemblyMetadata.CreateFromImage(Resources.PresentationFramework).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net35)");
+                    _PresentationFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.PresentationFramework")).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net35)");
                 }
                 return _PresentationFramework;
             }
@@ -1167,7 +1167,7 @@ public static partial class Net35
             {
                 if (_PresentationFrameworkLuna is null)
                 {
-                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkLuna).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net35)");
+                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.PresentationFramework.Luna")).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net35)");
                 }
                 return _PresentationFrameworkLuna;
             }
@@ -1184,7 +1184,7 @@ public static partial class Net35
             {
                 if (_PresentationFrameworkRoyale is null)
                 {
-                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkRoyale).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net35)");
+                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.PresentationFramework.Royale")).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net35)");
                 }
                 return _PresentationFrameworkRoyale;
             }
@@ -1201,7 +1201,7 @@ public static partial class Net35
             {
                 if (_ReachFramework is null)
                 {
-                    _ReachFramework = AssemblyMetadata.CreateFromImage(Resources.ReachFramework).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net35)");
+                    _ReachFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.ReachFramework")).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net35)");
                 }
                 return _ReachFramework;
             }
@@ -1218,7 +1218,7 @@ public static partial class Net35
             {
                 if (_sysglobl is null)
                 {
-                    _sysglobl = AssemblyMetadata.CreateFromImage(Resources.sysglobl).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net35)");
+                    _sysglobl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.sysglobl")).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net35)");
                 }
                 return _sysglobl;
             }
@@ -1235,7 +1235,7 @@ public static partial class Net35
             {
                 if (_SystemAddInContract is null)
                 {
-                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(Resources.SystemAddInContract).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net35)");
+                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.AddIn.Contract")).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net35)");
                 }
                 return _SystemAddInContract;
             }
@@ -1252,7 +1252,7 @@ public static partial class Net35
             {
                 if (_SystemAddIn is null)
                 {
-                    _SystemAddIn = AssemblyMetadata.CreateFromImage(Resources.SystemAddIn).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net35)");
+                    _SystemAddIn = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.AddIn")).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net35)");
                 }
                 return _SystemAddIn;
             }
@@ -1269,7 +1269,7 @@ public static partial class Net35
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net35)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net35)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1286,7 +1286,7 @@ public static partial class Net35
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net35)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net35)");
                 }
                 return _SystemConfiguration;
             }
@@ -1303,7 +1303,7 @@ public static partial class Net35
             {
                 if (_SystemConfigurationInstall is null)
                 {
-                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationInstall).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net35)");
+                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Configuration.Install")).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net35)");
                 }
                 return _SystemConfigurationInstall;
             }
@@ -1320,7 +1320,7 @@ public static partial class Net35
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net35)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net35)");
                 }
                 return _SystemCore;
             }
@@ -1337,7 +1337,7 @@ public static partial class Net35
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net35)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net35)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1354,7 +1354,7 @@ public static partial class Net35
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net35)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net35)");
                 }
                 return _SystemData;
             }
@@ -1371,7 +1371,7 @@ public static partial class Net35
             {
                 if (_SystemDataEntityDesign is null)
                 {
-                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntityDesign).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net35)");
+                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.Entity.Design")).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net35)");
                 }
                 return _SystemDataEntityDesign;
             }
@@ -1388,7 +1388,7 @@ public static partial class Net35
             {
                 if (_SystemDataEntity is null)
                 {
-                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntity).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net35)");
+                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.Entity")).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net35)");
                 }
                 return _SystemDataEntity;
             }
@@ -1405,7 +1405,7 @@ public static partial class Net35
             {
                 if (_SystemDataLinq is null)
                 {
-                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(Resources.SystemDataLinq).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net35)");
+                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.Linq")).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net35)");
                 }
                 return _SystemDataLinq;
             }
@@ -1422,7 +1422,7 @@ public static partial class Net35
             {
                 if (_SystemDataOracleClient is null)
                 {
-                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataOracleClient).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net35)");
+                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.OracleClient")).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net35)");
                 }
                 return _SystemDataOracleClient;
             }
@@ -1439,7 +1439,7 @@ public static partial class Net35
             {
                 if (_SystemDataServicesClient is null)
                 {
-                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesClient).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net35)");
+                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.Services.Client")).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net35)");
                 }
                 return _SystemDataServicesClient;
             }
@@ -1456,7 +1456,7 @@ public static partial class Net35
             {
                 if (_SystemDataServicesDesign is null)
                 {
-                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesDesign).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net35)");
+                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.Services.Design")).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net35)");
                 }
                 return _SystemDataServicesDesign;
             }
@@ -1473,7 +1473,7 @@ public static partial class Net35
             {
                 if (_SystemDataServices is null)
                 {
-                    _SystemDataServices = AssemblyMetadata.CreateFromImage(Resources.SystemDataServices).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net35)");
+                    _SystemDataServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.Services")).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net35)");
                 }
                 return _SystemDataServices;
             }
@@ -1490,7 +1490,7 @@ public static partial class Net35
             {
                 if (_SystemDataSqlXml is null)
                 {
-                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(Resources.SystemDataSqlXml).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net35)");
+                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Data.SqlXml")).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net35)");
                 }
                 return _SystemDataSqlXml;
             }
@@ -1507,7 +1507,7 @@ public static partial class Net35
             {
                 if (_SystemDeployment is null)
                 {
-                    _SystemDeployment = AssemblyMetadata.CreateFromImage(Resources.SystemDeployment).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net35)");
+                    _SystemDeployment = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Deployment")).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net35)");
                 }
                 return _SystemDeployment;
             }
@@ -1524,7 +1524,7 @@ public static partial class Net35
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net35)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net35)");
                 }
                 return _SystemDesign;
             }
@@ -1541,7 +1541,7 @@ public static partial class Net35
             {
                 if (_SystemDirectoryServicesAccountManagement is null)
                 {
-                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesAccountManagement).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net35)");
+                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.DirectoryServices.AccountManagement")).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net35)");
                 }
                 return _SystemDirectoryServicesAccountManagement;
             }
@@ -1558,7 +1558,7 @@ public static partial class Net35
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net35)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net35)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -1575,7 +1575,7 @@ public static partial class Net35
             {
                 if (_SystemDirectoryServicesProtocols is null)
                 {
-                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesProtocols).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net35)");
+                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.DirectoryServices.Protocols")).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net35)");
                 }
                 return _SystemDirectoryServicesProtocols;
             }
@@ -1592,7 +1592,7 @@ public static partial class Net35
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net35)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System")).GetReference(filePath: "System.dll", display: "System (net35)");
                 }
                 return _System;
             }
@@ -1609,7 +1609,7 @@ public static partial class Net35
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net35)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net35)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -1626,7 +1626,7 @@ public static partial class Net35
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net35)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net35)");
                 }
                 return _SystemDrawing;
             }
@@ -1643,7 +1643,7 @@ public static partial class Net35
             {
                 if (_SystemEnterpriseServices is null)
                 {
-                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(Resources.SystemEnterpriseServices).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net35)");
+                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.EnterpriseServices")).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net35)");
                 }
                 return _SystemEnterpriseServices;
             }
@@ -1660,7 +1660,7 @@ public static partial class Net35
             {
                 if (_SystemIdentityModel is null)
                 {
-                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModel).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net35)");
+                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.IdentityModel")).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net35)");
                 }
                 return _SystemIdentityModel;
             }
@@ -1677,7 +1677,7 @@ public static partial class Net35
             {
                 if (_SystemIdentityModelSelectors is null)
                 {
-                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelSelectors).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net35)");
+                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.IdentityModel.Selectors")).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net35)");
                 }
                 return _SystemIdentityModelSelectors;
             }
@@ -1694,7 +1694,7 @@ public static partial class Net35
             {
                 if (_SystemIOLog is null)
                 {
-                    _SystemIOLog = AssemblyMetadata.CreateFromImage(Resources.SystemIOLog).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net35)");
+                    _SystemIOLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.IO.Log")).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net35)");
                 }
                 return _SystemIOLog;
             }
@@ -1711,7 +1711,7 @@ public static partial class Net35
             {
                 if (_SystemManagement is null)
                 {
-                    _SystemManagement = AssemblyMetadata.CreateFromImage(Resources.SystemManagement).GetReference(filePath: "System.Management.dll", display: "System.Management (net35)");
+                    _SystemManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Management")).GetReference(filePath: "System.Management.dll", display: "System.Management (net35)");
                 }
                 return _SystemManagement;
             }
@@ -1728,7 +1728,7 @@ public static partial class Net35
             {
                 if (_SystemManagementInstrumentation is null)
                 {
-                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(Resources.SystemManagementInstrumentation).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net35)");
+                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Management.Instrumentation")).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net35)");
                 }
                 return _SystemManagementInstrumentation;
             }
@@ -1745,7 +1745,7 @@ public static partial class Net35
             {
                 if (_SystemMessaging is null)
                 {
-                    _SystemMessaging = AssemblyMetadata.CreateFromImage(Resources.SystemMessaging).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net35)");
+                    _SystemMessaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Messaging")).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net35)");
                 }
                 return _SystemMessaging;
             }
@@ -1762,7 +1762,7 @@ public static partial class Net35
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net35)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net35)");
                 }
                 return _SystemNet;
             }
@@ -1779,7 +1779,7 @@ public static partial class Net35
             {
                 if (_SystemPrinting is null)
                 {
-                    _SystemPrinting = AssemblyMetadata.CreateFromImage(Resources.SystemPrinting).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net35)");
+                    _SystemPrinting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Printing")).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net35)");
                 }
                 return _SystemPrinting;
             }
@@ -1796,7 +1796,7 @@ public static partial class Net35
             {
                 if (_SystemRuntimeRemoting is null)
                 {
-                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeRemoting).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net35)");
+                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Runtime.Remoting")).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net35)");
                 }
                 return _SystemRuntimeRemoting;
             }
@@ -1813,7 +1813,7 @@ public static partial class Net35
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net35)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net35)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -1830,7 +1830,7 @@ public static partial class Net35
             {
                 if (_SystemRuntimeSerializationFormattersSoap is null)
                 {
-                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormattersSoap).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net35)");
+                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Runtime.Serialization.Formatters.Soap")).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net35)");
                 }
                 return _SystemRuntimeSerializationFormattersSoap;
             }
@@ -1847,7 +1847,7 @@ public static partial class Net35
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net35)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net35)");
                 }
                 return _SystemSecurity;
             }
@@ -1864,7 +1864,7 @@ public static partial class Net35
             {
                 if (_SystemServiceModel is null)
                 {
-                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModel).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net35)");
+                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.ServiceModel")).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net35)");
                 }
                 return _SystemServiceModel;
             }
@@ -1881,7 +1881,7 @@ public static partial class Net35
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net35)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net35)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -1898,7 +1898,7 @@ public static partial class Net35
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net35)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net35)");
                 }
                 return _SystemServiceProcess;
             }
@@ -1915,7 +1915,7 @@ public static partial class Net35
             {
                 if (_SystemSpeech is null)
                 {
-                    _SystemSpeech = AssemblyMetadata.CreateFromImage(Resources.SystemSpeech).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net35)");
+                    _SystemSpeech = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Speech")).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net35)");
                 }
                 return _SystemSpeech;
             }
@@ -1932,7 +1932,7 @@ public static partial class Net35
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net35)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net35)");
                 }
                 return _SystemTransactions;
             }
@@ -1949,7 +1949,7 @@ public static partial class Net35
             {
                 if (_SystemWebAbstractions is null)
                 {
-                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(Resources.SystemWebAbstractions).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net35)");
+                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Abstractions")).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net35)");
                 }
                 return _SystemWebAbstractions;
             }
@@ -1966,7 +1966,7 @@ public static partial class Net35
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net35)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net35)");
                 }
                 return _SystemWeb;
             }
@@ -1983,7 +1983,7 @@ public static partial class Net35
             {
                 if (_SystemWebDynamicDataDesign is null)
                 {
-                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicDataDesign).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net35)");
+                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.DynamicData.Design")).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net35)");
                 }
                 return _SystemWebDynamicDataDesign;
             }
@@ -2000,7 +2000,7 @@ public static partial class Net35
             {
                 if (_SystemWebDynamicData is null)
                 {
-                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicData).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net35)");
+                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.DynamicData")).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net35)");
                 }
                 return _SystemWebDynamicData;
             }
@@ -2017,7 +2017,7 @@ public static partial class Net35
             {
                 if (_SystemWebEntityDesign is null)
                 {
-                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntityDesign).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net35)");
+                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Entity.Design")).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net35)");
                 }
                 return _SystemWebEntityDesign;
             }
@@ -2034,7 +2034,7 @@ public static partial class Net35
             {
                 if (_SystemWebEntity is null)
                 {
-                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntity).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net35)");
+                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Entity")).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net35)");
                 }
                 return _SystemWebEntity;
             }
@@ -2051,7 +2051,7 @@ public static partial class Net35
             {
                 if (_SystemWebExtensionsDesign is null)
                 {
-                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensionsDesign).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net35)");
+                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Extensions.Design")).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net35)");
                 }
                 return _SystemWebExtensionsDesign;
             }
@@ -2068,7 +2068,7 @@ public static partial class Net35
             {
                 if (_SystemWebExtensions is null)
                 {
-                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensions).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net35)");
+                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Extensions")).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net35)");
                 }
                 return _SystemWebExtensions;
             }
@@ -2085,7 +2085,7 @@ public static partial class Net35
             {
                 if (_SystemWebMobile is null)
                 {
-                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(Resources.SystemWebMobile).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net35)");
+                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Mobile")).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net35)");
                 }
                 return _SystemWebMobile;
             }
@@ -2102,7 +2102,7 @@ public static partial class Net35
             {
                 if (_SystemWebRegularExpressions is null)
                 {
-                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemWebRegularExpressions).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net35)");
+                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.RegularExpressions")).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net35)");
                 }
                 return _SystemWebRegularExpressions;
             }
@@ -2119,7 +2119,7 @@ public static partial class Net35
             {
                 if (_SystemWebRouting is null)
                 {
-                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(Resources.SystemWebRouting).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net35)");
+                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Routing")).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net35)");
                 }
                 return _SystemWebRouting;
             }
@@ -2136,7 +2136,7 @@ public static partial class Net35
             {
                 if (_SystemWebServices is null)
                 {
-                    _SystemWebServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebServices).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net35)");
+                    _SystemWebServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Web.Services")).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net35)");
                 }
                 return _SystemWebServices;
             }
@@ -2153,7 +2153,7 @@ public static partial class Net35
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net35)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net35)");
                 }
                 return _SystemWindowsForms;
             }
@@ -2170,7 +2170,7 @@ public static partial class Net35
             {
                 if (_SystemWindowsPresentation is null)
                 {
-                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsPresentation).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net35)");
+                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Windows.Presentation")).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net35)");
                 }
                 return _SystemWindowsPresentation;
             }
@@ -2187,7 +2187,7 @@ public static partial class Net35
             {
                 if (_SystemWorkflowActivities is null)
                 {
-                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowActivities).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net35)");
+                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Workflow.Activities")).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net35)");
                 }
                 return _SystemWorkflowActivities;
             }
@@ -2204,7 +2204,7 @@ public static partial class Net35
             {
                 if (_SystemWorkflowComponentModel is null)
                 {
-                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowComponentModel).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net35)");
+                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Workflow.ComponentModel")).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net35)");
                 }
                 return _SystemWorkflowComponentModel;
             }
@@ -2221,7 +2221,7 @@ public static partial class Net35
             {
                 if (_SystemWorkflowRuntime is null)
                 {
-                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowRuntime).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net35)");
+                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Workflow.Runtime")).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net35)");
                 }
                 return _SystemWorkflowRuntime;
             }
@@ -2238,7 +2238,7 @@ public static partial class Net35
             {
                 if (_SystemWorkflowServices is null)
                 {
-                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowServices).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net35)");
+                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.WorkflowServices")).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net35)");
                 }
                 return _SystemWorkflowServices;
             }
@@ -2255,7 +2255,7 @@ public static partial class Net35
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net35)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net35)");
                 }
                 return _SystemXml;
             }
@@ -2272,7 +2272,7 @@ public static partial class Net35
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net35)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net35)");
                 }
                 return _SystemXmlLinq;
             }
@@ -2289,7 +2289,7 @@ public static partial class Net35
             {
                 if (_UIAutomationClient is null)
                 {
-                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClient).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net35)");
+                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.UIAutomationClient")).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net35)");
                 }
                 return _UIAutomationClient;
             }
@@ -2306,7 +2306,7 @@ public static partial class Net35
             {
                 if (_UIAutomationClientsideProviders is null)
                 {
-                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClientsideProviders).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net35)");
+                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.UIAutomationClientsideProviders")).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net35)");
                 }
                 return _UIAutomationClientsideProviders;
             }
@@ -2323,7 +2323,7 @@ public static partial class Net35
             {
                 if (_UIAutomationProvider is null)
                 {
-                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(Resources.UIAutomationProvider).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net35)");
+                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.UIAutomationProvider")).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net35)");
                 }
                 return _UIAutomationProvider;
             }
@@ -2340,7 +2340,7 @@ public static partial class Net35
             {
                 if (_UIAutomationTypes is null)
                 {
-                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(Resources.UIAutomationTypes).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net35)");
+                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.UIAutomationTypes")).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net35)");
                 }
                 return _UIAutomationTypes;
             }
@@ -2357,7 +2357,7 @@ public static partial class Net35
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net35)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net35)");
                 }
                 return _WindowsBase;
             }
@@ -2374,7 +2374,7 @@ public static partial class Net35
             {
                 if (_WindowsFormsIntegration is null)
                 {
-                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(Resources.WindowsFormsIntegration).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net35)");
+                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net35.WindowsFormsIntegration")).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net35)");
                 }
                 return _WindowsFormsIntegration;
             }

--- a/Src/Basic.Reference.Assemblies.Net40/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net40/Generated.cs
@@ -741,7 +741,7 @@ public static partial class Net40
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net40)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net40)");
                 }
                 return _Accessibility;
             }
@@ -758,7 +758,7 @@ public static partial class Net40
             {
                 if (_CustomMarshalers is null)
                 {
-                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(Resources.CustomMarshalers).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net40)");
+                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.CustomMarshalers")).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net40)");
                 }
                 return _CustomMarshalers;
             }
@@ -775,7 +775,7 @@ public static partial class Net40
             {
                 if (_ISymWrapper is null)
                 {
-                    _ISymWrapper = AssemblyMetadata.CreateFromImage(Resources.ISymWrapper).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net40)");
+                    _ISymWrapper = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.ISymWrapper")).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net40)");
                 }
                 return _ISymWrapper;
             }
@@ -792,7 +792,7 @@ public static partial class Net40
             {
                 if (_MicrosoftBuildConversionv40 is null)
                 {
-                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildConversionv40).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net40)");
+                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.Build.Conversion.v4.0")).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net40)");
                 }
                 return _MicrosoftBuildConversionv40;
             }
@@ -809,7 +809,7 @@ public static partial class Net40
             {
                 if (_MicrosoftBuild is null)
                 {
-                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuild).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net40)");
+                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.Build")).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net40)");
                 }
                 return _MicrosoftBuild;
             }
@@ -826,7 +826,7 @@ public static partial class Net40
             {
                 if (_MicrosoftBuildEngine is null)
                 {
-                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildEngine).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net40)");
+                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.Build.Engine")).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net40)");
                 }
                 return _MicrosoftBuildEngine;
             }
@@ -843,7 +843,7 @@ public static partial class Net40
             {
                 if (_MicrosoftBuildFramework is null)
                 {
-                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildFramework).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net40)");
+                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.Build.Framework")).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net40)");
                 }
                 return _MicrosoftBuildFramework;
             }
@@ -860,7 +860,7 @@ public static partial class Net40
             {
                 if (_MicrosoftBuildTasksv40 is null)
                 {
-                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildTasksv40).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net40)");
+                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.Build.Tasks.v4.0")).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net40)");
                 }
                 return _MicrosoftBuildTasksv40;
             }
@@ -877,7 +877,7 @@ public static partial class Net40
             {
                 if (_MicrosoftBuildUtilitiesv40 is null)
                 {
-                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildUtilitiesv40).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net40)");
+                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.Build.Utilities.v4.0")).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net40)");
                 }
                 return _MicrosoftBuildUtilitiesv40;
             }
@@ -894,7 +894,7 @@ public static partial class Net40
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net40)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net40)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -911,7 +911,7 @@ public static partial class Net40
             {
                 if (_MicrosoftJScript is null)
                 {
-                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJScript).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net40)");
+                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.JScript")).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net40)");
                 }
                 return _MicrosoftJScript;
             }
@@ -928,7 +928,7 @@ public static partial class Net40
             {
                 if (_MicrosoftVisualBasicCompatibilityData is null)
                 {
-                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibilityData).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net40)");
+                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.VisualBasic.Compatibility.Data")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net40)");
                 }
                 return _MicrosoftVisualBasicCompatibilityData;
             }
@@ -945,7 +945,7 @@ public static partial class Net40
             {
                 if (_MicrosoftVisualBasicCompatibility is null)
                 {
-                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibility).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net40)");
+                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.VisualBasic.Compatibility")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net40)");
                 }
                 return _MicrosoftVisualBasicCompatibility;
             }
@@ -962,7 +962,7 @@ public static partial class Net40
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net40)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net40)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -979,7 +979,7 @@ public static partial class Net40
             {
                 if (_MicrosoftVisualC is null)
                 {
-                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualC).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net40)");
+                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.VisualC")).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net40)");
                 }
                 return _MicrosoftVisualC;
             }
@@ -996,7 +996,7 @@ public static partial class Net40
             {
                 if (_MicrosoftVisualCSTLCLR is null)
                 {
-                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualCSTLCLR).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net40)");
+                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.Microsoft.VisualC.STLCLR")).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net40)");
                 }
                 return _MicrosoftVisualCSTLCLR;
             }
@@ -1013,7 +1013,7 @@ public static partial class Net40
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net40)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net40)");
                 }
                 return _mscorlib;
             }
@@ -1030,7 +1030,7 @@ public static partial class Net40
             {
                 if (_PresentationBuildTasks is null)
                 {
-                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(Resources.PresentationBuildTasks).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net40)");
+                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.PresentationBuildTasks")).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net40)");
                 }
                 return _PresentationBuildTasks;
             }
@@ -1047,7 +1047,7 @@ public static partial class Net40
             {
                 if (_PresentationCore is null)
                 {
-                    _PresentationCore = AssemblyMetadata.CreateFromImage(Resources.PresentationCore).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net40)");
+                    _PresentationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.PresentationCore")).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net40)");
                 }
                 return _PresentationCore;
             }
@@ -1064,7 +1064,7 @@ public static partial class Net40
             {
                 if (_PresentationFrameworkAero is null)
                 {
-                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net40)");
+                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.PresentationFramework.Aero")).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net40)");
                 }
                 return _PresentationFrameworkAero;
             }
@@ -1081,7 +1081,7 @@ public static partial class Net40
             {
                 if (_PresentationFrameworkClassic is null)
                 {
-                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkClassic).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net40)");
+                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.PresentationFramework.Classic")).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net40)");
                 }
                 return _PresentationFrameworkClassic;
             }
@@ -1098,7 +1098,7 @@ public static partial class Net40
             {
                 if (_PresentationFramework is null)
                 {
-                    _PresentationFramework = AssemblyMetadata.CreateFromImage(Resources.PresentationFramework).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net40)");
+                    _PresentationFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.PresentationFramework")).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net40)");
                 }
                 return _PresentationFramework;
             }
@@ -1115,7 +1115,7 @@ public static partial class Net40
             {
                 if (_PresentationFrameworkLuna is null)
                 {
-                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkLuna).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net40)");
+                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.PresentationFramework.Luna")).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net40)");
                 }
                 return _PresentationFrameworkLuna;
             }
@@ -1132,7 +1132,7 @@ public static partial class Net40
             {
                 if (_PresentationFrameworkRoyale is null)
                 {
-                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkRoyale).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net40)");
+                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.PresentationFramework.Royale")).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net40)");
                 }
                 return _PresentationFrameworkRoyale;
             }
@@ -1149,7 +1149,7 @@ public static partial class Net40
             {
                 if (_ReachFramework is null)
                 {
-                    _ReachFramework = AssemblyMetadata.CreateFromImage(Resources.ReachFramework).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net40)");
+                    _ReachFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.ReachFramework")).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net40)");
                 }
                 return _ReachFramework;
             }
@@ -1166,7 +1166,7 @@ public static partial class Net40
             {
                 if (_sysglobl is null)
                 {
-                    _sysglobl = AssemblyMetadata.CreateFromImage(Resources.sysglobl).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net40)");
+                    _sysglobl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.sysglobl")).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net40)");
                 }
                 return _sysglobl;
             }
@@ -1183,7 +1183,7 @@ public static partial class Net40
             {
                 if (_SystemActivitiesCorePresentation is null)
                 {
-                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesCorePresentation).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net40)");
+                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Activities.Core.Presentation")).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net40)");
                 }
                 return _SystemActivitiesCorePresentation;
             }
@@ -1200,7 +1200,7 @@ public static partial class Net40
             {
                 if (_SystemActivities is null)
                 {
-                    _SystemActivities = AssemblyMetadata.CreateFromImage(Resources.SystemActivities).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net40)");
+                    _SystemActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Activities")).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net40)");
                 }
                 return _SystemActivities;
             }
@@ -1217,7 +1217,7 @@ public static partial class Net40
             {
                 if (_SystemActivitiesDurableInstancing is null)
                 {
-                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesDurableInstancing).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net40)");
+                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Activities.DurableInstancing")).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net40)");
                 }
                 return _SystemActivitiesDurableInstancing;
             }
@@ -1234,7 +1234,7 @@ public static partial class Net40
             {
                 if (_SystemActivitiesPresentation is null)
                 {
-                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesPresentation).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net40)");
+                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Activities.Presentation")).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net40)");
                 }
                 return _SystemActivitiesPresentation;
             }
@@ -1251,7 +1251,7 @@ public static partial class Net40
             {
                 if (_SystemAddInContract is null)
                 {
-                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(Resources.SystemAddInContract).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net40)");
+                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.AddIn.Contract")).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net40)");
                 }
                 return _SystemAddInContract;
             }
@@ -1268,7 +1268,7 @@ public static partial class Net40
             {
                 if (_SystemAddIn is null)
                 {
-                    _SystemAddIn = AssemblyMetadata.CreateFromImage(Resources.SystemAddIn).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net40)");
+                    _SystemAddIn = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.AddIn")).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net40)");
                 }
                 return _SystemAddIn;
             }
@@ -1285,7 +1285,7 @@ public static partial class Net40
             {
                 if (_SystemComponentModelComposition is null)
                 {
-                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelComposition).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net40)");
+                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ComponentModel.Composition")).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net40)");
                 }
                 return _SystemComponentModelComposition;
             }
@@ -1302,7 +1302,7 @@ public static partial class Net40
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net40)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net40)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1319,7 +1319,7 @@ public static partial class Net40
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net40)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net40)");
                 }
                 return _SystemConfiguration;
             }
@@ -1336,7 +1336,7 @@ public static partial class Net40
             {
                 if (_SystemConfigurationInstall is null)
                 {
-                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationInstall).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net40)");
+                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Configuration.Install")).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net40)");
                 }
                 return _SystemConfigurationInstall;
             }
@@ -1353,7 +1353,7 @@ public static partial class Net40
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net40)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net40)");
                 }
                 return _SystemCore;
             }
@@ -1370,7 +1370,7 @@ public static partial class Net40
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net40)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net40)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1387,7 +1387,7 @@ public static partial class Net40
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net40)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net40)");
                 }
                 return _SystemData;
             }
@@ -1404,7 +1404,7 @@ public static partial class Net40
             {
                 if (_SystemDataEntityDesign is null)
                 {
-                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntityDesign).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net40)");
+                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.Entity.Design")).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net40)");
                 }
                 return _SystemDataEntityDesign;
             }
@@ -1421,7 +1421,7 @@ public static partial class Net40
             {
                 if (_SystemDataEntity is null)
                 {
-                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntity).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net40)");
+                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.Entity")).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net40)");
                 }
                 return _SystemDataEntity;
             }
@@ -1438,7 +1438,7 @@ public static partial class Net40
             {
                 if (_SystemDataLinq is null)
                 {
-                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(Resources.SystemDataLinq).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net40)");
+                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.Linq")).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net40)");
                 }
                 return _SystemDataLinq;
             }
@@ -1455,7 +1455,7 @@ public static partial class Net40
             {
                 if (_SystemDataOracleClient is null)
                 {
-                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataOracleClient).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net40)");
+                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.OracleClient")).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net40)");
                 }
                 return _SystemDataOracleClient;
             }
@@ -1472,7 +1472,7 @@ public static partial class Net40
             {
                 if (_SystemDataServicesClient is null)
                 {
-                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesClient).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net40)");
+                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.Services.Client")).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net40)");
                 }
                 return _SystemDataServicesClient;
             }
@@ -1489,7 +1489,7 @@ public static partial class Net40
             {
                 if (_SystemDataServicesDesign is null)
                 {
-                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesDesign).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net40)");
+                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.Services.Design")).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net40)");
                 }
                 return _SystemDataServicesDesign;
             }
@@ -1506,7 +1506,7 @@ public static partial class Net40
             {
                 if (_SystemDataServices is null)
                 {
-                    _SystemDataServices = AssemblyMetadata.CreateFromImage(Resources.SystemDataServices).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net40)");
+                    _SystemDataServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.Services")).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net40)");
                 }
                 return _SystemDataServices;
             }
@@ -1523,7 +1523,7 @@ public static partial class Net40
             {
                 if (_SystemDataSqlXml is null)
                 {
-                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(Resources.SystemDataSqlXml).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net40)");
+                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Data.SqlXml")).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net40)");
                 }
                 return _SystemDataSqlXml;
             }
@@ -1540,7 +1540,7 @@ public static partial class Net40
             {
                 if (_SystemDeployment is null)
                 {
-                    _SystemDeployment = AssemblyMetadata.CreateFromImage(Resources.SystemDeployment).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net40)");
+                    _SystemDeployment = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Deployment")).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net40)");
                 }
                 return _SystemDeployment;
             }
@@ -1557,7 +1557,7 @@ public static partial class Net40
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net40)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net40)");
                 }
                 return _SystemDesign;
             }
@@ -1574,7 +1574,7 @@ public static partial class Net40
             {
                 if (_SystemDevice is null)
                 {
-                    _SystemDevice = AssemblyMetadata.CreateFromImage(Resources.SystemDevice).GetReference(filePath: "System.Device.dll", display: "System.Device (net40)");
+                    _SystemDevice = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Device")).GetReference(filePath: "System.Device.dll", display: "System.Device (net40)");
                 }
                 return _SystemDevice;
             }
@@ -1591,7 +1591,7 @@ public static partial class Net40
             {
                 if (_SystemDirectoryServicesAccountManagement is null)
                 {
-                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesAccountManagement).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net40)");
+                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.DirectoryServices.AccountManagement")).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net40)");
                 }
                 return _SystemDirectoryServicesAccountManagement;
             }
@@ -1608,7 +1608,7 @@ public static partial class Net40
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net40)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net40)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -1625,7 +1625,7 @@ public static partial class Net40
             {
                 if (_SystemDirectoryServicesProtocols is null)
                 {
-                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesProtocols).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net40)");
+                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.DirectoryServices.Protocols")).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net40)");
                 }
                 return _SystemDirectoryServicesProtocols;
             }
@@ -1642,7 +1642,7 @@ public static partial class Net40
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net40)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System")).GetReference(filePath: "System.dll", display: "System (net40)");
                 }
                 return _System;
             }
@@ -1659,7 +1659,7 @@ public static partial class Net40
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net40)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net40)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -1676,7 +1676,7 @@ public static partial class Net40
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net40)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net40)");
                 }
                 return _SystemDrawing;
             }
@@ -1693,7 +1693,7 @@ public static partial class Net40
             {
                 if (_SystemEnterpriseServices is null)
                 {
-                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(Resources.SystemEnterpriseServices).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net40)");
+                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.EnterpriseServices")).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net40)");
                 }
                 return _SystemEnterpriseServices;
             }
@@ -1710,7 +1710,7 @@ public static partial class Net40
             {
                 if (_SystemIdentityModel is null)
                 {
-                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModel).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net40)");
+                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.IdentityModel")).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net40)");
                 }
                 return _SystemIdentityModel;
             }
@@ -1727,7 +1727,7 @@ public static partial class Net40
             {
                 if (_SystemIdentityModelSelectors is null)
                 {
-                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelSelectors).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net40)");
+                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.IdentityModel.Selectors")).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net40)");
                 }
                 return _SystemIdentityModelSelectors;
             }
@@ -1744,7 +1744,7 @@ public static partial class Net40
             {
                 if (_SystemIOLog is null)
                 {
-                    _SystemIOLog = AssemblyMetadata.CreateFromImage(Resources.SystemIOLog).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net40)");
+                    _SystemIOLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.IO.Log")).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net40)");
                 }
                 return _SystemIOLog;
             }
@@ -1761,7 +1761,7 @@ public static partial class Net40
             {
                 if (_SystemManagement is null)
                 {
-                    _SystemManagement = AssemblyMetadata.CreateFromImage(Resources.SystemManagement).GetReference(filePath: "System.Management.dll", display: "System.Management (net40)");
+                    _SystemManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Management")).GetReference(filePath: "System.Management.dll", display: "System.Management (net40)");
                 }
                 return _SystemManagement;
             }
@@ -1778,7 +1778,7 @@ public static partial class Net40
             {
                 if (_SystemManagementInstrumentation is null)
                 {
-                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(Resources.SystemManagementInstrumentation).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net40)");
+                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Management.Instrumentation")).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net40)");
                 }
                 return _SystemManagementInstrumentation;
             }
@@ -1795,7 +1795,7 @@ public static partial class Net40
             {
                 if (_SystemMessaging is null)
                 {
-                    _SystemMessaging = AssemblyMetadata.CreateFromImage(Resources.SystemMessaging).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net40)");
+                    _SystemMessaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Messaging")).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net40)");
                 }
                 return _SystemMessaging;
             }
@@ -1812,7 +1812,7 @@ public static partial class Net40
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net40)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net40)");
                 }
                 return _SystemNet;
             }
@@ -1829,7 +1829,7 @@ public static partial class Net40
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net40)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net40)");
                 }
                 return _SystemNumerics;
             }
@@ -1846,7 +1846,7 @@ public static partial class Net40
             {
                 if (_SystemPrinting is null)
                 {
-                    _SystemPrinting = AssemblyMetadata.CreateFromImage(Resources.SystemPrinting).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net40)");
+                    _SystemPrinting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Printing")).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net40)");
                 }
                 return _SystemPrinting;
             }
@@ -1863,7 +1863,7 @@ public static partial class Net40
             {
                 if (_SystemRuntimeCaching is null)
                 {
-                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCaching).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net40)");
+                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Runtime.Caching")).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net40)");
                 }
                 return _SystemRuntimeCaching;
             }
@@ -1880,7 +1880,7 @@ public static partial class Net40
             {
                 if (_SystemRuntimeDurableInstancing is null)
                 {
-                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeDurableInstancing).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net40)");
+                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Runtime.DurableInstancing")).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net40)");
                 }
                 return _SystemRuntimeDurableInstancing;
             }
@@ -1897,7 +1897,7 @@ public static partial class Net40
             {
                 if (_SystemRuntimeRemoting is null)
                 {
-                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeRemoting).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net40)");
+                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Runtime.Remoting")).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net40)");
                 }
                 return _SystemRuntimeRemoting;
             }
@@ -1914,7 +1914,7 @@ public static partial class Net40
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net40)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net40)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -1931,7 +1931,7 @@ public static partial class Net40
             {
                 if (_SystemRuntimeSerializationFormattersSoap is null)
                 {
-                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormattersSoap).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net40)");
+                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Runtime.Serialization.Formatters.Soap")).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net40)");
                 }
                 return _SystemRuntimeSerializationFormattersSoap;
             }
@@ -1948,7 +1948,7 @@ public static partial class Net40
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net40)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net40)");
                 }
                 return _SystemSecurity;
             }
@@ -1965,7 +1965,7 @@ public static partial class Net40
             {
                 if (_SystemServiceModelActivation is null)
                 {
-                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivation).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net40)");
+                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceModel.Activation")).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net40)");
                 }
                 return _SystemServiceModelActivation;
             }
@@ -1982,7 +1982,7 @@ public static partial class Net40
             {
                 if (_SystemServiceModelActivities is null)
                 {
-                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivities).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net40)");
+                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceModel.Activities")).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net40)");
                 }
                 return _SystemServiceModelActivities;
             }
@@ -1999,7 +1999,7 @@ public static partial class Net40
             {
                 if (_SystemServiceModelChannels is null)
                 {
-                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelChannels).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net40)");
+                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceModel.Channels")).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net40)");
                 }
                 return _SystemServiceModelChannels;
             }
@@ -2016,7 +2016,7 @@ public static partial class Net40
             {
                 if (_SystemServiceModelDiscovery is null)
                 {
-                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelDiscovery).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net40)");
+                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceModel.Discovery")).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net40)");
                 }
                 return _SystemServiceModelDiscovery;
             }
@@ -2033,7 +2033,7 @@ public static partial class Net40
             {
                 if (_SystemServiceModel is null)
                 {
-                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModel).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net40)");
+                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceModel")).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net40)");
                 }
                 return _SystemServiceModel;
             }
@@ -2050,7 +2050,7 @@ public static partial class Net40
             {
                 if (_SystemServiceModelRouting is null)
                 {
-                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelRouting).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net40)");
+                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceModel.Routing")).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net40)");
                 }
                 return _SystemServiceModelRouting;
             }
@@ -2067,7 +2067,7 @@ public static partial class Net40
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net40)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net40)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -2084,7 +2084,7 @@ public static partial class Net40
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net40)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net40)");
                 }
                 return _SystemServiceProcess;
             }
@@ -2101,7 +2101,7 @@ public static partial class Net40
             {
                 if (_SystemSpeech is null)
                 {
-                    _SystemSpeech = AssemblyMetadata.CreateFromImage(Resources.SystemSpeech).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net40)");
+                    _SystemSpeech = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Speech")).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net40)");
                 }
                 return _SystemSpeech;
             }
@@ -2118,7 +2118,7 @@ public static partial class Net40
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net40)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net40)");
                 }
                 return _SystemTransactions;
             }
@@ -2135,7 +2135,7 @@ public static partial class Net40
             {
                 if (_SystemWebAbstractions is null)
                 {
-                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(Resources.SystemWebAbstractions).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net40)");
+                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Abstractions")).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net40)");
                 }
                 return _SystemWebAbstractions;
             }
@@ -2152,7 +2152,7 @@ public static partial class Net40
             {
                 if (_SystemWebApplicationServices is null)
                 {
-                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebApplicationServices).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net40)");
+                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.ApplicationServices")).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net40)");
                 }
                 return _SystemWebApplicationServices;
             }
@@ -2169,7 +2169,7 @@ public static partial class Net40
             {
                 if (_SystemWebDataVisualizationDesign is null)
                 {
-                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualizationDesign).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net40)");
+                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.DataVisualization.Design")).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net40)");
                 }
                 return _SystemWebDataVisualizationDesign;
             }
@@ -2186,7 +2186,7 @@ public static partial class Net40
             {
                 if (_SystemWebDataVisualization is null)
                 {
-                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualization).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net40)");
+                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.DataVisualization")).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net40)");
                 }
                 return _SystemWebDataVisualization;
             }
@@ -2203,7 +2203,7 @@ public static partial class Net40
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net40)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net40)");
                 }
                 return _SystemWeb;
             }
@@ -2220,7 +2220,7 @@ public static partial class Net40
             {
                 if (_SystemWebDynamicDataDesign is null)
                 {
-                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicDataDesign).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net40)");
+                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.DynamicData.Design")).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net40)");
                 }
                 return _SystemWebDynamicDataDesign;
             }
@@ -2237,7 +2237,7 @@ public static partial class Net40
             {
                 if (_SystemWebDynamicData is null)
                 {
-                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicData).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net40)");
+                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.DynamicData")).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net40)");
                 }
                 return _SystemWebDynamicData;
             }
@@ -2254,7 +2254,7 @@ public static partial class Net40
             {
                 if (_SystemWebEntityDesign is null)
                 {
-                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntityDesign).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net40)");
+                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Entity.Design")).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net40)");
                 }
                 return _SystemWebEntityDesign;
             }
@@ -2271,7 +2271,7 @@ public static partial class Net40
             {
                 if (_SystemWebEntity is null)
                 {
-                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntity).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net40)");
+                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Entity")).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net40)");
                 }
                 return _SystemWebEntity;
             }
@@ -2288,7 +2288,7 @@ public static partial class Net40
             {
                 if (_SystemWebExtensionsDesign is null)
                 {
-                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensionsDesign).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net40)");
+                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Extensions.Design")).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net40)");
                 }
                 return _SystemWebExtensionsDesign;
             }
@@ -2305,7 +2305,7 @@ public static partial class Net40
             {
                 if (_SystemWebExtensions is null)
                 {
-                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensions).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net40)");
+                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Extensions")).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net40)");
                 }
                 return _SystemWebExtensions;
             }
@@ -2322,7 +2322,7 @@ public static partial class Net40
             {
                 if (_SystemWebMobile is null)
                 {
-                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(Resources.SystemWebMobile).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net40)");
+                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Mobile")).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net40)");
                 }
                 return _SystemWebMobile;
             }
@@ -2339,7 +2339,7 @@ public static partial class Net40
             {
                 if (_SystemWebRegularExpressions is null)
                 {
-                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemWebRegularExpressions).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net40)");
+                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.RegularExpressions")).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net40)");
                 }
                 return _SystemWebRegularExpressions;
             }
@@ -2356,7 +2356,7 @@ public static partial class Net40
             {
                 if (_SystemWebRouting is null)
                 {
-                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(Resources.SystemWebRouting).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net40)");
+                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Routing")).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net40)");
                 }
                 return _SystemWebRouting;
             }
@@ -2373,7 +2373,7 @@ public static partial class Net40
             {
                 if (_SystemWebServices is null)
                 {
-                    _SystemWebServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebServices).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net40)");
+                    _SystemWebServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Web.Services")).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net40)");
                 }
                 return _SystemWebServices;
             }
@@ -2390,7 +2390,7 @@ public static partial class Net40
             {
                 if (_SystemWindowsFormsDataVisualizationDesign is null)
                 {
-                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualizationDesign).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net40)");
+                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Windows.Forms.DataVisualization.Design")).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net40)");
                 }
                 return _SystemWindowsFormsDataVisualizationDesign;
             }
@@ -2407,7 +2407,7 @@ public static partial class Net40
             {
                 if (_SystemWindowsFormsDataVisualization is null)
                 {
-                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualization).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net40)");
+                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Windows.Forms.DataVisualization")).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net40)");
                 }
                 return _SystemWindowsFormsDataVisualization;
             }
@@ -2424,7 +2424,7 @@ public static partial class Net40
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net40)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net40)");
                 }
                 return _SystemWindowsForms;
             }
@@ -2441,7 +2441,7 @@ public static partial class Net40
             {
                 if (_SystemWindowsInputManipulations is null)
                 {
-                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsInputManipulations).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net40)");
+                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Windows.Input.Manipulations")).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net40)");
                 }
                 return _SystemWindowsInputManipulations;
             }
@@ -2458,7 +2458,7 @@ public static partial class Net40
             {
                 if (_SystemWindowsPresentation is null)
                 {
-                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsPresentation).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net40)");
+                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Windows.Presentation")).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net40)");
                 }
                 return _SystemWindowsPresentation;
             }
@@ -2475,7 +2475,7 @@ public static partial class Net40
             {
                 if (_SystemWorkflowActivities is null)
                 {
-                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowActivities).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net40)");
+                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Workflow.Activities")).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net40)");
                 }
                 return _SystemWorkflowActivities;
             }
@@ -2492,7 +2492,7 @@ public static partial class Net40
             {
                 if (_SystemWorkflowComponentModel is null)
                 {
-                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowComponentModel).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net40)");
+                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Workflow.ComponentModel")).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net40)");
                 }
                 return _SystemWorkflowComponentModel;
             }
@@ -2509,7 +2509,7 @@ public static partial class Net40
             {
                 if (_SystemWorkflowRuntime is null)
                 {
-                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowRuntime).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net40)");
+                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Workflow.Runtime")).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net40)");
                 }
                 return _SystemWorkflowRuntime;
             }
@@ -2526,7 +2526,7 @@ public static partial class Net40
             {
                 if (_SystemWorkflowServices is null)
                 {
-                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowServices).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net40)");
+                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.WorkflowServices")).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net40)");
                 }
                 return _SystemWorkflowServices;
             }
@@ -2543,7 +2543,7 @@ public static partial class Net40
             {
                 if (_SystemXaml is null)
                 {
-                    _SystemXaml = AssemblyMetadata.CreateFromImage(Resources.SystemXaml).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net40)");
+                    _SystemXaml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Xaml")).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net40)");
                 }
                 return _SystemXaml;
             }
@@ -2560,7 +2560,7 @@ public static partial class Net40
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net40)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net40)");
                 }
                 return _SystemXml;
             }
@@ -2577,7 +2577,7 @@ public static partial class Net40
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net40)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net40)");
                 }
                 return _SystemXmlLinq;
             }
@@ -2594,7 +2594,7 @@ public static partial class Net40
             {
                 if (_UIAutomationClient is null)
                 {
-                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClient).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net40)");
+                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.UIAutomationClient")).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net40)");
                 }
                 return _UIAutomationClient;
             }
@@ -2611,7 +2611,7 @@ public static partial class Net40
             {
                 if (_UIAutomationClientsideProviders is null)
                 {
-                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClientsideProviders).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net40)");
+                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.UIAutomationClientsideProviders")).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net40)");
                 }
                 return _UIAutomationClientsideProviders;
             }
@@ -2628,7 +2628,7 @@ public static partial class Net40
             {
                 if (_UIAutomationProvider is null)
                 {
-                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(Resources.UIAutomationProvider).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net40)");
+                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.UIAutomationProvider")).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net40)");
                 }
                 return _UIAutomationProvider;
             }
@@ -2645,7 +2645,7 @@ public static partial class Net40
             {
                 if (_UIAutomationTypes is null)
                 {
-                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(Resources.UIAutomationTypes).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net40)");
+                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.UIAutomationTypes")).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net40)");
                 }
                 return _UIAutomationTypes;
             }
@@ -2662,7 +2662,7 @@ public static partial class Net40
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net40)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net40)");
                 }
                 return _WindowsBase;
             }
@@ -2679,7 +2679,7 @@ public static partial class Net40
             {
                 if (_WindowsFormsIntegration is null)
                 {
-                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(Resources.WindowsFormsIntegration).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net40)");
+                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.WindowsFormsIntegration")).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net40)");
                 }
                 return _WindowsFormsIntegration;
             }
@@ -2696,7 +2696,7 @@ public static partial class Net40
             {
                 if (_XamlBuildTask is null)
                 {
-                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(Resources.XamlBuildTask).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net40)");
+                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net40.XamlBuildTask")).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net40)");
                 }
                 return _XamlBuildTask;
             }

--- a/Src/Basic.Reference.Assemblies.Net461/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net461/Generated.cs
@@ -1149,7 +1149,7 @@ public static partial class Net461
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net461)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net461)");
                 }
                 return _Accessibility;
             }
@@ -1166,7 +1166,7 @@ public static partial class Net461
             {
                 if (_CustomMarshalers is null)
                 {
-                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(Resources.CustomMarshalers).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net461)");
+                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.CustomMarshalers")).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net461)");
                 }
                 return _CustomMarshalers;
             }
@@ -1183,7 +1183,7 @@ public static partial class Net461
             {
                 if (_ISymWrapper is null)
                 {
-                    _ISymWrapper = AssemblyMetadata.CreateFromImage(Resources.ISymWrapper).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net461)");
+                    _ISymWrapper = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.ISymWrapper")).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net461)");
                 }
                 return _ISymWrapper;
             }
@@ -1200,7 +1200,7 @@ public static partial class Net461
             {
                 if (_MicrosoftActivitiesBuild is null)
                 {
-                    _MicrosoftActivitiesBuild = AssemblyMetadata.CreateFromImage(Resources.MicrosoftActivitiesBuild).GetReference(filePath: "Microsoft.Activities.Build.dll", display: "Microsoft.Activities.Build (net461)");
+                    _MicrosoftActivitiesBuild = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.Activities.Build")).GetReference(filePath: "Microsoft.Activities.Build.dll", display: "Microsoft.Activities.Build (net461)");
                 }
                 return _MicrosoftActivitiesBuild;
             }
@@ -1217,7 +1217,7 @@ public static partial class Net461
             {
                 if (_MicrosoftBuildConversionv40 is null)
                 {
-                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildConversionv40).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net461)");
+                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.Build.Conversion.v4.0")).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net461)");
                 }
                 return _MicrosoftBuildConversionv40;
             }
@@ -1234,7 +1234,7 @@ public static partial class Net461
             {
                 if (_MicrosoftBuild is null)
                 {
-                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuild).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net461)");
+                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.Build")).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net461)");
                 }
                 return _MicrosoftBuild;
             }
@@ -1251,7 +1251,7 @@ public static partial class Net461
             {
                 if (_MicrosoftBuildEngine is null)
                 {
-                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildEngine).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net461)");
+                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.Build.Engine")).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net461)");
                 }
                 return _MicrosoftBuildEngine;
             }
@@ -1268,7 +1268,7 @@ public static partial class Net461
             {
                 if (_MicrosoftBuildFramework is null)
                 {
-                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildFramework).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net461)");
+                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.Build.Framework")).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net461)");
                 }
                 return _MicrosoftBuildFramework;
             }
@@ -1285,7 +1285,7 @@ public static partial class Net461
             {
                 if (_MicrosoftBuildTasksv40 is null)
                 {
-                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildTasksv40).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net461)");
+                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.Build.Tasks.v4.0")).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net461)");
                 }
                 return _MicrosoftBuildTasksv40;
             }
@@ -1302,7 +1302,7 @@ public static partial class Net461
             {
                 if (_MicrosoftBuildUtilitiesv40 is null)
                 {
-                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildUtilitiesv40).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net461)");
+                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.Build.Utilities.v4.0")).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net461)");
                 }
                 return _MicrosoftBuildUtilitiesv40;
             }
@@ -1319,7 +1319,7 @@ public static partial class Net461
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net461)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net461)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1336,7 +1336,7 @@ public static partial class Net461
             {
                 if (_MicrosoftJScript is null)
                 {
-                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJScript).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net461)");
+                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.JScript")).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net461)");
                 }
                 return _MicrosoftJScript;
             }
@@ -1353,7 +1353,7 @@ public static partial class Net461
             {
                 if (_MicrosoftVisualBasicCompatibilityData is null)
                 {
-                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibilityData).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net461)");
+                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.VisualBasic.Compatibility.Data")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net461)");
                 }
                 return _MicrosoftVisualBasicCompatibilityData;
             }
@@ -1370,7 +1370,7 @@ public static partial class Net461
             {
                 if (_MicrosoftVisualBasicCompatibility is null)
                 {
-                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibility).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net461)");
+                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.VisualBasic.Compatibility")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net461)");
                 }
                 return _MicrosoftVisualBasicCompatibility;
             }
@@ -1387,7 +1387,7 @@ public static partial class Net461
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net461)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net461)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1404,7 +1404,7 @@ public static partial class Net461
             {
                 if (_MicrosoftVisualC is null)
                 {
-                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualC).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net461)");
+                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.VisualC")).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net461)");
                 }
                 return _MicrosoftVisualC;
             }
@@ -1421,7 +1421,7 @@ public static partial class Net461
             {
                 if (_MicrosoftVisualCSTLCLR is null)
                 {
-                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualCSTLCLR).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net461)");
+                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.Microsoft.VisualC.STLCLR")).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net461)");
                 }
                 return _MicrosoftVisualCSTLCLR;
             }
@@ -1438,7 +1438,7 @@ public static partial class Net461
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net461)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net461)");
                 }
                 return _mscorlib;
             }
@@ -1455,7 +1455,7 @@ public static partial class Net461
             {
                 if (_PresentationBuildTasks is null)
                 {
-                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(Resources.PresentationBuildTasks).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net461)");
+                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationBuildTasks")).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net461)");
                 }
                 return _PresentationBuildTasks;
             }
@@ -1472,7 +1472,7 @@ public static partial class Net461
             {
                 if (_PresentationCore is null)
                 {
-                    _PresentationCore = AssemblyMetadata.CreateFromImage(Resources.PresentationCore).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net461)");
+                    _PresentationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationCore")).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net461)");
                 }
                 return _PresentationCore;
             }
@@ -1489,7 +1489,7 @@ public static partial class Net461
             {
                 if (_PresentationFrameworkAero is null)
                 {
-                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net461)");
+                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationFramework.Aero")).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net461)");
                 }
                 return _PresentationFrameworkAero;
             }
@@ -1506,7 +1506,7 @@ public static partial class Net461
             {
                 if (_PresentationFrameworkAero2 is null)
                 {
-                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero2).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net461)");
+                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationFramework.Aero2")).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net461)");
                 }
                 return _PresentationFrameworkAero2;
             }
@@ -1523,7 +1523,7 @@ public static partial class Net461
             {
                 if (_PresentationFrameworkAeroLite is null)
                 {
-                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAeroLite).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net461)");
+                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationFramework.AeroLite")).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net461)");
                 }
                 return _PresentationFrameworkAeroLite;
             }
@@ -1540,7 +1540,7 @@ public static partial class Net461
             {
                 if (_PresentationFrameworkClassic is null)
                 {
-                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkClassic).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net461)");
+                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationFramework.Classic")).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net461)");
                 }
                 return _PresentationFrameworkClassic;
             }
@@ -1557,7 +1557,7 @@ public static partial class Net461
             {
                 if (_PresentationFramework is null)
                 {
-                    _PresentationFramework = AssemblyMetadata.CreateFromImage(Resources.PresentationFramework).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net461)");
+                    _PresentationFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationFramework")).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net461)");
                 }
                 return _PresentationFramework;
             }
@@ -1574,7 +1574,7 @@ public static partial class Net461
             {
                 if (_PresentationFrameworkLuna is null)
                 {
-                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkLuna).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net461)");
+                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationFramework.Luna")).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net461)");
                 }
                 return _PresentationFrameworkLuna;
             }
@@ -1591,7 +1591,7 @@ public static partial class Net461
             {
                 if (_PresentationFrameworkRoyale is null)
                 {
-                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkRoyale).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net461)");
+                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.PresentationFramework.Royale")).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net461)");
                 }
                 return _PresentationFrameworkRoyale;
             }
@@ -1608,7 +1608,7 @@ public static partial class Net461
             {
                 if (_ReachFramework is null)
                 {
-                    _ReachFramework = AssemblyMetadata.CreateFromImage(Resources.ReachFramework).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net461)");
+                    _ReachFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.ReachFramework")).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net461)");
                 }
                 return _ReachFramework;
             }
@@ -1625,7 +1625,7 @@ public static partial class Net461
             {
                 if (_sysglobl is null)
                 {
-                    _sysglobl = AssemblyMetadata.CreateFromImage(Resources.sysglobl).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net461)");
+                    _sysglobl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.sysglobl")).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net461)");
                 }
                 return _sysglobl;
             }
@@ -1642,7 +1642,7 @@ public static partial class Net461
             {
                 if (_SystemActivitiesCorePresentation is null)
                 {
-                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesCorePresentation).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net461)");
+                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Activities.Core.Presentation")).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net461)");
                 }
                 return _SystemActivitiesCorePresentation;
             }
@@ -1659,7 +1659,7 @@ public static partial class Net461
             {
                 if (_SystemActivities is null)
                 {
-                    _SystemActivities = AssemblyMetadata.CreateFromImage(Resources.SystemActivities).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net461)");
+                    _SystemActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Activities")).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net461)");
                 }
                 return _SystemActivities;
             }
@@ -1676,7 +1676,7 @@ public static partial class Net461
             {
                 if (_SystemActivitiesDurableInstancing is null)
                 {
-                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesDurableInstancing).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net461)");
+                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Activities.DurableInstancing")).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net461)");
                 }
                 return _SystemActivitiesDurableInstancing;
             }
@@ -1693,7 +1693,7 @@ public static partial class Net461
             {
                 if (_SystemActivitiesPresentation is null)
                 {
-                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesPresentation).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net461)");
+                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Activities.Presentation")).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net461)");
                 }
                 return _SystemActivitiesPresentation;
             }
@@ -1710,7 +1710,7 @@ public static partial class Net461
             {
                 if (_SystemAddInContract is null)
                 {
-                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(Resources.SystemAddInContract).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net461)");
+                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.AddIn.Contract")).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net461)");
                 }
                 return _SystemAddInContract;
             }
@@ -1727,7 +1727,7 @@ public static partial class Net461
             {
                 if (_SystemAddIn is null)
                 {
-                    _SystemAddIn = AssemblyMetadata.CreateFromImage(Resources.SystemAddIn).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net461)");
+                    _SystemAddIn = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.AddIn")).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net461)");
                 }
                 return _SystemAddIn;
             }
@@ -1744,7 +1744,7 @@ public static partial class Net461
             {
                 if (_SystemComponentModelComposition is null)
                 {
-                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelComposition).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net461)");
+                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ComponentModel.Composition")).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net461)");
                 }
                 return _SystemComponentModelComposition;
             }
@@ -1761,7 +1761,7 @@ public static partial class Net461
             {
                 if (_SystemComponentModelCompositionRegistration is null)
                 {
-                    _SystemComponentModelCompositionRegistration = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelCompositionRegistration).GetReference(filePath: "System.ComponentModel.Composition.Registration.dll", display: "System.ComponentModel.Composition.Registration (net461)");
+                    _SystemComponentModelCompositionRegistration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ComponentModel.Composition.Registration")).GetReference(filePath: "System.ComponentModel.Composition.Registration.dll", display: "System.ComponentModel.Composition.Registration (net461)");
                 }
                 return _SystemComponentModelCompositionRegistration;
             }
@@ -1778,7 +1778,7 @@ public static partial class Net461
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net461)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net461)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1795,7 +1795,7 @@ public static partial class Net461
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net461)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net461)");
                 }
                 return _SystemConfiguration;
             }
@@ -1812,7 +1812,7 @@ public static partial class Net461
             {
                 if (_SystemConfigurationInstall is null)
                 {
-                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationInstall).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net461)");
+                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Configuration.Install")).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net461)");
                 }
                 return _SystemConfigurationInstall;
             }
@@ -1829,7 +1829,7 @@ public static partial class Net461
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net461)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net461)");
                 }
                 return _SystemCore;
             }
@@ -1846,7 +1846,7 @@ public static partial class Net461
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net461)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net461)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1863,7 +1863,7 @@ public static partial class Net461
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net461)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net461)");
                 }
                 return _SystemData;
             }
@@ -1880,7 +1880,7 @@ public static partial class Net461
             {
                 if (_SystemDataEntityDesign is null)
                 {
-                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntityDesign).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net461)");
+                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.Entity.Design")).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net461)");
                 }
                 return _SystemDataEntityDesign;
             }
@@ -1897,7 +1897,7 @@ public static partial class Net461
             {
                 if (_SystemDataEntity is null)
                 {
-                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntity).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net461)");
+                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.Entity")).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net461)");
                 }
                 return _SystemDataEntity;
             }
@@ -1914,7 +1914,7 @@ public static partial class Net461
             {
                 if (_SystemDataLinq is null)
                 {
-                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(Resources.SystemDataLinq).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net461)");
+                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.Linq")).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net461)");
                 }
                 return _SystemDataLinq;
             }
@@ -1931,7 +1931,7 @@ public static partial class Net461
             {
                 if (_SystemDataOracleClient is null)
                 {
-                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataOracleClient).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net461)");
+                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.OracleClient")).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net461)");
                 }
                 return _SystemDataOracleClient;
             }
@@ -1948,7 +1948,7 @@ public static partial class Net461
             {
                 if (_SystemDataServicesClient is null)
                 {
-                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesClient).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net461)");
+                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.Services.Client")).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net461)");
                 }
                 return _SystemDataServicesClient;
             }
@@ -1965,7 +1965,7 @@ public static partial class Net461
             {
                 if (_SystemDataServicesDesign is null)
                 {
-                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesDesign).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net461)");
+                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.Services.Design")).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net461)");
                 }
                 return _SystemDataServicesDesign;
             }
@@ -1982,7 +1982,7 @@ public static partial class Net461
             {
                 if (_SystemDataServices is null)
                 {
-                    _SystemDataServices = AssemblyMetadata.CreateFromImage(Resources.SystemDataServices).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net461)");
+                    _SystemDataServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.Services")).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net461)");
                 }
                 return _SystemDataServices;
             }
@@ -1999,7 +1999,7 @@ public static partial class Net461
             {
                 if (_SystemDataSqlXml is null)
                 {
-                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(Resources.SystemDataSqlXml).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net461)");
+                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Data.SqlXml")).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net461)");
                 }
                 return _SystemDataSqlXml;
             }
@@ -2016,7 +2016,7 @@ public static partial class Net461
             {
                 if (_SystemDeployment is null)
                 {
-                    _SystemDeployment = AssemblyMetadata.CreateFromImage(Resources.SystemDeployment).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net461)");
+                    _SystemDeployment = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Deployment")).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net461)");
                 }
                 return _SystemDeployment;
             }
@@ -2033,7 +2033,7 @@ public static partial class Net461
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net461)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net461)");
                 }
                 return _SystemDesign;
             }
@@ -2050,7 +2050,7 @@ public static partial class Net461
             {
                 if (_SystemDevice is null)
                 {
-                    _SystemDevice = AssemblyMetadata.CreateFromImage(Resources.SystemDevice).GetReference(filePath: "System.Device.dll", display: "System.Device (net461)");
+                    _SystemDevice = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Device")).GetReference(filePath: "System.Device.dll", display: "System.Device (net461)");
                 }
                 return _SystemDevice;
             }
@@ -2067,7 +2067,7 @@ public static partial class Net461
             {
                 if (_SystemDirectoryServicesAccountManagement is null)
                 {
-                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesAccountManagement).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net461)");
+                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.DirectoryServices.AccountManagement")).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net461)");
                 }
                 return _SystemDirectoryServicesAccountManagement;
             }
@@ -2084,7 +2084,7 @@ public static partial class Net461
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net461)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net461)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -2101,7 +2101,7 @@ public static partial class Net461
             {
                 if (_SystemDirectoryServicesProtocols is null)
                 {
-                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesProtocols).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net461)");
+                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.DirectoryServices.Protocols")).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net461)");
                 }
                 return _SystemDirectoryServicesProtocols;
             }
@@ -2118,7 +2118,7 @@ public static partial class Net461
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net461)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System")).GetReference(filePath: "System.dll", display: "System (net461)");
                 }
                 return _System;
             }
@@ -2135,7 +2135,7 @@ public static partial class Net461
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net461)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net461)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -2152,7 +2152,7 @@ public static partial class Net461
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net461)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net461)");
                 }
                 return _SystemDrawing;
             }
@@ -2169,7 +2169,7 @@ public static partial class Net461
             {
                 if (_SystemDynamic is null)
                 {
-                    _SystemDynamic = AssemblyMetadata.CreateFromImage(Resources.SystemDynamic).GetReference(filePath: "System.Dynamic.dll", display: "System.Dynamic (net461)");
+                    _SystemDynamic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Dynamic")).GetReference(filePath: "System.Dynamic.dll", display: "System.Dynamic (net461)");
                 }
                 return _SystemDynamic;
             }
@@ -2186,7 +2186,7 @@ public static partial class Net461
             {
                 if (_SystemEnterpriseServices is null)
                 {
-                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(Resources.SystemEnterpriseServices).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net461)");
+                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.EnterpriseServices")).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net461)");
                 }
                 return _SystemEnterpriseServices;
             }
@@ -2203,7 +2203,7 @@ public static partial class Net461
             {
                 if (_SystemIdentityModel is null)
                 {
-                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModel).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net461)");
+                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.IdentityModel")).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net461)");
                 }
                 return _SystemIdentityModel;
             }
@@ -2220,7 +2220,7 @@ public static partial class Net461
             {
                 if (_SystemIdentityModelSelectors is null)
                 {
-                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelSelectors).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net461)");
+                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.IdentityModel.Selectors")).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net461)");
                 }
                 return _SystemIdentityModelSelectors;
             }
@@ -2237,7 +2237,7 @@ public static partial class Net461
             {
                 if (_SystemIdentityModelServices is null)
                 {
-                    _SystemIdentityModelServices = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelServices).GetReference(filePath: "System.IdentityModel.Services.dll", display: "System.IdentityModel.Services (net461)");
+                    _SystemIdentityModelServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.IdentityModel.Services")).GetReference(filePath: "System.IdentityModel.Services.dll", display: "System.IdentityModel.Services (net461)");
                 }
                 return _SystemIdentityModelServices;
             }
@@ -2254,7 +2254,7 @@ public static partial class Net461
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net461)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net461)");
                 }
                 return _SystemIOCompression;
             }
@@ -2271,7 +2271,7 @@ public static partial class Net461
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net461)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net461)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -2288,7 +2288,7 @@ public static partial class Net461
             {
                 if (_SystemIOLog is null)
                 {
-                    _SystemIOLog = AssemblyMetadata.CreateFromImage(Resources.SystemIOLog).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net461)");
+                    _SystemIOLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.IO.Log")).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net461)");
                 }
                 return _SystemIOLog;
             }
@@ -2305,7 +2305,7 @@ public static partial class Net461
             {
                 if (_SystemManagement is null)
                 {
-                    _SystemManagement = AssemblyMetadata.CreateFromImage(Resources.SystemManagement).GetReference(filePath: "System.Management.dll", display: "System.Management (net461)");
+                    _SystemManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Management")).GetReference(filePath: "System.Management.dll", display: "System.Management (net461)");
                 }
                 return _SystemManagement;
             }
@@ -2322,7 +2322,7 @@ public static partial class Net461
             {
                 if (_SystemManagementInstrumentation is null)
                 {
-                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(Resources.SystemManagementInstrumentation).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net461)");
+                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Management.Instrumentation")).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net461)");
                 }
                 return _SystemManagementInstrumentation;
             }
@@ -2339,7 +2339,7 @@ public static partial class Net461
             {
                 if (_SystemMessaging is null)
                 {
-                    _SystemMessaging = AssemblyMetadata.CreateFromImage(Resources.SystemMessaging).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net461)");
+                    _SystemMessaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Messaging")).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net461)");
                 }
                 return _SystemMessaging;
             }
@@ -2356,7 +2356,7 @@ public static partial class Net461
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net461)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net461)");
                 }
                 return _SystemNet;
             }
@@ -2373,7 +2373,7 @@ public static partial class Net461
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net461)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net461)");
                 }
                 return _SystemNetHttp;
             }
@@ -2390,7 +2390,7 @@ public static partial class Net461
             {
                 if (_SystemNetHttpWebRequest is null)
                 {
-                    _SystemNetHttpWebRequest = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpWebRequest).GetReference(filePath: "System.Net.Http.WebRequest.dll", display: "System.Net.Http.WebRequest (net461)");
+                    _SystemNetHttpWebRequest = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Net.Http.WebRequest")).GetReference(filePath: "System.Net.Http.WebRequest.dll", display: "System.Net.Http.WebRequest (net461)");
                 }
                 return _SystemNetHttpWebRequest;
             }
@@ -2407,7 +2407,7 @@ public static partial class Net461
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net461)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net461)");
                 }
                 return _SystemNumerics;
             }
@@ -2424,7 +2424,7 @@ public static partial class Net461
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net461)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net461)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2441,7 +2441,7 @@ public static partial class Net461
             {
                 if (_SystemPrinting is null)
                 {
-                    _SystemPrinting = AssemblyMetadata.CreateFromImage(Resources.SystemPrinting).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net461)");
+                    _SystemPrinting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Printing")).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net461)");
                 }
                 return _SystemPrinting;
             }
@@ -2458,7 +2458,7 @@ public static partial class Net461
             {
                 if (_SystemReflectionContext is null)
                 {
-                    _SystemReflectionContext = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionContext).GetReference(filePath: "System.Reflection.Context.dll", display: "System.Reflection.Context (net461)");
+                    _SystemReflectionContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Reflection.Context")).GetReference(filePath: "System.Reflection.Context.dll", display: "System.Reflection.Context (net461)");
                 }
                 return _SystemReflectionContext;
             }
@@ -2475,7 +2475,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeCaching is null)
                 {
-                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCaching).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net461)");
+                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Caching")).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net461)");
                 }
                 return _SystemRuntimeCaching;
             }
@@ -2492,7 +2492,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeDurableInstancing is null)
                 {
-                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeDurableInstancing).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net461)");
+                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.DurableInstancing")).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net461)");
                 }
                 return _SystemRuntimeDurableInstancing;
             }
@@ -2509,7 +2509,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeRemoting is null)
                 {
-                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeRemoting).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net461)");
+                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Remoting")).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net461)");
                 }
                 return _SystemRuntimeRemoting;
             }
@@ -2526,7 +2526,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net461)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net461)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2543,7 +2543,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeSerializationFormattersSoap is null)
                 {
-                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormattersSoap).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net461)");
+                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Serialization.Formatters.Soap")).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net461)");
                 }
                 return _SystemRuntimeSerializationFormattersSoap;
             }
@@ -2560,7 +2560,7 @@ public static partial class Net461
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net461)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net461)");
                 }
                 return _SystemSecurity;
             }
@@ -2577,7 +2577,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelActivation is null)
                 {
-                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivation).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net461)");
+                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Activation")).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net461)");
                 }
                 return _SystemServiceModelActivation;
             }
@@ -2594,7 +2594,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelActivities is null)
                 {
-                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivities).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net461)");
+                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Activities")).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net461)");
                 }
                 return _SystemServiceModelActivities;
             }
@@ -2611,7 +2611,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelChannels is null)
                 {
-                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelChannels).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net461)");
+                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Channels")).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net461)");
                 }
                 return _SystemServiceModelChannels;
             }
@@ -2628,7 +2628,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelDiscovery is null)
                 {
-                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelDiscovery).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net461)");
+                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Discovery")).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net461)");
                 }
                 return _SystemServiceModelDiscovery;
             }
@@ -2645,7 +2645,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModel is null)
                 {
-                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModel).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net461)");
+                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel")).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net461)");
                 }
                 return _SystemServiceModel;
             }
@@ -2662,7 +2662,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelRouting is null)
                 {
-                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelRouting).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net461)");
+                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Routing")).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net461)");
                 }
                 return _SystemServiceModelRouting;
             }
@@ -2679,7 +2679,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net461)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net461)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -2696,7 +2696,7 @@ public static partial class Net461
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net461)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net461)");
                 }
                 return _SystemServiceProcess;
             }
@@ -2713,7 +2713,7 @@ public static partial class Net461
             {
                 if (_SystemSpeech is null)
                 {
-                    _SystemSpeech = AssemblyMetadata.CreateFromImage(Resources.SystemSpeech).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net461)");
+                    _SystemSpeech = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Speech")).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net461)");
                 }
                 return _SystemSpeech;
             }
@@ -2730,7 +2730,7 @@ public static partial class Net461
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net461)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net461)");
                 }
                 return _SystemTransactions;
             }
@@ -2747,7 +2747,7 @@ public static partial class Net461
             {
                 if (_SystemWebAbstractions is null)
                 {
-                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(Resources.SystemWebAbstractions).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net461)");
+                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Abstractions")).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net461)");
                 }
                 return _SystemWebAbstractions;
             }
@@ -2764,7 +2764,7 @@ public static partial class Net461
             {
                 if (_SystemWebApplicationServices is null)
                 {
-                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebApplicationServices).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net461)");
+                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.ApplicationServices")).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net461)");
                 }
                 return _SystemWebApplicationServices;
             }
@@ -2781,7 +2781,7 @@ public static partial class Net461
             {
                 if (_SystemWebDataVisualizationDesign is null)
                 {
-                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualizationDesign).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net461)");
+                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.DataVisualization.Design")).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net461)");
                 }
                 return _SystemWebDataVisualizationDesign;
             }
@@ -2798,7 +2798,7 @@ public static partial class Net461
             {
                 if (_SystemWebDataVisualization is null)
                 {
-                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualization).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net461)");
+                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.DataVisualization")).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net461)");
                 }
                 return _SystemWebDataVisualization;
             }
@@ -2815,7 +2815,7 @@ public static partial class Net461
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net461)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net461)");
                 }
                 return _SystemWeb;
             }
@@ -2832,7 +2832,7 @@ public static partial class Net461
             {
                 if (_SystemWebDynamicDataDesign is null)
                 {
-                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicDataDesign).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net461)");
+                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.DynamicData.Design")).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net461)");
                 }
                 return _SystemWebDynamicDataDesign;
             }
@@ -2849,7 +2849,7 @@ public static partial class Net461
             {
                 if (_SystemWebDynamicData is null)
                 {
-                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicData).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net461)");
+                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.DynamicData")).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net461)");
                 }
                 return _SystemWebDynamicData;
             }
@@ -2866,7 +2866,7 @@ public static partial class Net461
             {
                 if (_SystemWebEntityDesign is null)
                 {
-                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntityDesign).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net461)");
+                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Entity.Design")).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net461)");
                 }
                 return _SystemWebEntityDesign;
             }
@@ -2883,7 +2883,7 @@ public static partial class Net461
             {
                 if (_SystemWebEntity is null)
                 {
-                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntity).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net461)");
+                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Entity")).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net461)");
                 }
                 return _SystemWebEntity;
             }
@@ -2900,7 +2900,7 @@ public static partial class Net461
             {
                 if (_SystemWebExtensionsDesign is null)
                 {
-                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensionsDesign).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net461)");
+                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Extensions.Design")).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net461)");
                 }
                 return _SystemWebExtensionsDesign;
             }
@@ -2917,7 +2917,7 @@ public static partial class Net461
             {
                 if (_SystemWebExtensions is null)
                 {
-                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensions).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net461)");
+                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Extensions")).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net461)");
                 }
                 return _SystemWebExtensions;
             }
@@ -2934,7 +2934,7 @@ public static partial class Net461
             {
                 if (_SystemWebMobile is null)
                 {
-                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(Resources.SystemWebMobile).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net461)");
+                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Mobile")).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net461)");
                 }
                 return _SystemWebMobile;
             }
@@ -2951,7 +2951,7 @@ public static partial class Net461
             {
                 if (_SystemWebRegularExpressions is null)
                 {
-                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemWebRegularExpressions).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net461)");
+                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.RegularExpressions")).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net461)");
                 }
                 return _SystemWebRegularExpressions;
             }
@@ -2968,7 +2968,7 @@ public static partial class Net461
             {
                 if (_SystemWebRouting is null)
                 {
-                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(Resources.SystemWebRouting).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net461)");
+                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Routing")).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net461)");
                 }
                 return _SystemWebRouting;
             }
@@ -2985,7 +2985,7 @@ public static partial class Net461
             {
                 if (_SystemWebServices is null)
                 {
-                    _SystemWebServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebServices).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net461)");
+                    _SystemWebServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Web.Services")).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net461)");
                 }
                 return _SystemWebServices;
             }
@@ -3002,7 +3002,7 @@ public static partial class Net461
             {
                 if (_SystemWindowsControlsRibbon is null)
                 {
-                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsControlsRibbon).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net461)");
+                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Windows.Controls.Ribbon")).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net461)");
                 }
                 return _SystemWindowsControlsRibbon;
             }
@@ -3019,7 +3019,7 @@ public static partial class Net461
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net461)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net461)");
                 }
                 return _SystemWindows;
             }
@@ -3036,7 +3036,7 @@ public static partial class Net461
             {
                 if (_SystemWindowsFormsDataVisualizationDesign is null)
                 {
-                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualizationDesign).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net461)");
+                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Windows.Forms.DataVisualization.Design")).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net461)");
                 }
                 return _SystemWindowsFormsDataVisualizationDesign;
             }
@@ -3053,7 +3053,7 @@ public static partial class Net461
             {
                 if (_SystemWindowsFormsDataVisualization is null)
                 {
-                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualization).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net461)");
+                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Windows.Forms.DataVisualization")).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net461)");
                 }
                 return _SystemWindowsFormsDataVisualization;
             }
@@ -3070,7 +3070,7 @@ public static partial class Net461
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net461)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net461)");
                 }
                 return _SystemWindowsForms;
             }
@@ -3087,7 +3087,7 @@ public static partial class Net461
             {
                 if (_SystemWindowsInputManipulations is null)
                 {
-                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsInputManipulations).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net461)");
+                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Windows.Input.Manipulations")).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net461)");
                 }
                 return _SystemWindowsInputManipulations;
             }
@@ -3104,7 +3104,7 @@ public static partial class Net461
             {
                 if (_SystemWindowsPresentation is null)
                 {
-                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsPresentation).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net461)");
+                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Windows.Presentation")).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net461)");
                 }
                 return _SystemWindowsPresentation;
             }
@@ -3121,7 +3121,7 @@ public static partial class Net461
             {
                 if (_SystemWorkflowActivities is null)
                 {
-                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowActivities).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net461)");
+                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Workflow.Activities")).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net461)");
                 }
                 return _SystemWorkflowActivities;
             }
@@ -3138,7 +3138,7 @@ public static partial class Net461
             {
                 if (_SystemWorkflowComponentModel is null)
                 {
-                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowComponentModel).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net461)");
+                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Workflow.ComponentModel")).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net461)");
                 }
                 return _SystemWorkflowComponentModel;
             }
@@ -3155,7 +3155,7 @@ public static partial class Net461
             {
                 if (_SystemWorkflowRuntime is null)
                 {
-                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowRuntime).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net461)");
+                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Workflow.Runtime")).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net461)");
                 }
                 return _SystemWorkflowRuntime;
             }
@@ -3172,7 +3172,7 @@ public static partial class Net461
             {
                 if (_SystemWorkflowServices is null)
                 {
-                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowServices).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net461)");
+                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.WorkflowServices")).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net461)");
                 }
                 return _SystemWorkflowServices;
             }
@@ -3189,7 +3189,7 @@ public static partial class Net461
             {
                 if (_SystemXaml is null)
                 {
-                    _SystemXaml = AssemblyMetadata.CreateFromImage(Resources.SystemXaml).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net461)");
+                    _SystemXaml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Xaml")).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net461)");
                 }
                 return _SystemXaml;
             }
@@ -3206,7 +3206,7 @@ public static partial class Net461
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net461)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net461)");
                 }
                 return _SystemXml;
             }
@@ -3223,7 +3223,7 @@ public static partial class Net461
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net461)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net461)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3240,7 +3240,7 @@ public static partial class Net461
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net461)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net461)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3257,7 +3257,7 @@ public static partial class Net461
             {
                 if (_UIAutomationClient is null)
                 {
-                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClient).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net461)");
+                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.UIAutomationClient")).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net461)");
                 }
                 return _UIAutomationClient;
             }
@@ -3274,7 +3274,7 @@ public static partial class Net461
             {
                 if (_UIAutomationClientsideProviders is null)
                 {
-                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClientsideProviders).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net461)");
+                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.UIAutomationClientsideProviders")).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net461)");
                 }
                 return _UIAutomationClientsideProviders;
             }
@@ -3291,7 +3291,7 @@ public static partial class Net461
             {
                 if (_UIAutomationProvider is null)
                 {
-                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(Resources.UIAutomationProvider).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net461)");
+                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.UIAutomationProvider")).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net461)");
                 }
                 return _UIAutomationProvider;
             }
@@ -3308,7 +3308,7 @@ public static partial class Net461
             {
                 if (_UIAutomationTypes is null)
                 {
-                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(Resources.UIAutomationTypes).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net461)");
+                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.UIAutomationTypes")).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net461)");
                 }
                 return _UIAutomationTypes;
             }
@@ -3325,7 +3325,7 @@ public static partial class Net461
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net461)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net461)");
                 }
                 return _WindowsBase;
             }
@@ -3342,7 +3342,7 @@ public static partial class Net461
             {
                 if (_WindowsFormsIntegration is null)
                 {
-                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(Resources.WindowsFormsIntegration).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net461)");
+                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.WindowsFormsIntegration")).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net461)");
                 }
                 return _WindowsFormsIntegration;
             }
@@ -3359,7 +3359,7 @@ public static partial class Net461
             {
                 if (_XamlBuildTask is null)
                 {
-                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(Resources.XamlBuildTask).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net461)");
+                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.XamlBuildTask")).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net461)");
                 }
                 return _XamlBuildTask;
             }
@@ -3376,7 +3376,7 @@ public static partial class Net461
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net461)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net461)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -3393,7 +3393,7 @@ public static partial class Net461
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net461)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net461)");
                 }
                 return _SystemCollections;
             }
@@ -3410,7 +3410,7 @@ public static partial class Net461
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net461)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net461)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -3427,7 +3427,7 @@ public static partial class Net461
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net461)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net461)");
                 }
                 return _SystemComponentModel;
             }
@@ -3444,7 +3444,7 @@ public static partial class Net461
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net461)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net461)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -3461,7 +3461,7 @@ public static partial class Net461
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net461)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net461)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -3478,7 +3478,7 @@ public static partial class Net461
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net461)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net461)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -3495,7 +3495,7 @@ public static partial class Net461
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net461)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net461)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -3512,7 +3512,7 @@ public static partial class Net461
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net461)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net461)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -3529,7 +3529,7 @@ public static partial class Net461
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net461)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net461)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -3546,7 +3546,7 @@ public static partial class Net461
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net461)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net461)");
                 }
                 return _SystemGlobalization;
             }
@@ -3563,7 +3563,7 @@ public static partial class Net461
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net461)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net461)");
                 }
                 return _SystemIO;
             }
@@ -3580,7 +3580,7 @@ public static partial class Net461
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net461)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net461)");
                 }
                 return _SystemLinq;
             }
@@ -3597,7 +3597,7 @@ public static partial class Net461
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net461)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net461)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -3614,7 +3614,7 @@ public static partial class Net461
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net461)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net461)");
                 }
                 return _SystemLinqParallel;
             }
@@ -3631,7 +3631,7 @@ public static partial class Net461
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net461)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net461)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -3648,7 +3648,7 @@ public static partial class Net461
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net461)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net461)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -3665,7 +3665,7 @@ public static partial class Net461
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net461)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net461)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -3682,7 +3682,7 @@ public static partial class Net461
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net461)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net461)");
                 }
                 return _SystemNetRequests;
             }
@@ -3699,7 +3699,7 @@ public static partial class Net461
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net461)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net461)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -3716,7 +3716,7 @@ public static partial class Net461
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net461)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net461)");
                 }
                 return _SystemObjectModel;
             }
@@ -3733,7 +3733,7 @@ public static partial class Net461
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net461)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net461)");
                 }
                 return _SystemReflection;
             }
@@ -3750,7 +3750,7 @@ public static partial class Net461
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net461)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net461)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -3767,7 +3767,7 @@ public static partial class Net461
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net461)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net461)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -3784,7 +3784,7 @@ public static partial class Net461
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net461)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net461)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -3801,7 +3801,7 @@ public static partial class Net461
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net461)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net461)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -3818,7 +3818,7 @@ public static partial class Net461
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net461)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net461)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -3835,7 +3835,7 @@ public static partial class Net461
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net461)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net461)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -3852,7 +3852,7 @@ public static partial class Net461
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net461)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net461)");
                 }
                 return _SystemRuntime;
             }
@@ -3869,7 +3869,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net461)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net461)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -3886,7 +3886,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net461)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net461)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -3903,7 +3903,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net461)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net461)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -3920,7 +3920,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeInteropServicesWindowsRuntime is null)
                 {
-                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesWindowsRuntime).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (net461)");
+                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.InteropServices.WindowsRuntime")).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (net461)");
                 }
                 return _SystemRuntimeInteropServicesWindowsRuntime;
             }
@@ -3937,7 +3937,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net461)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net461)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -3954,7 +3954,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net461)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net461)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -3971,7 +3971,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net461)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net461)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -3988,7 +3988,7 @@ public static partial class Net461
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net461)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net461)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -4005,7 +4005,7 @@ public static partial class Net461
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net461)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net461)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -4022,7 +4022,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelDuplex is null)
                 {
-                    _SystemServiceModelDuplex = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelDuplex).GetReference(filePath: "System.ServiceModel.Duplex.dll", display: "System.ServiceModel.Duplex (net461)");
+                    _SystemServiceModelDuplex = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Duplex")).GetReference(filePath: "System.ServiceModel.Duplex.dll", display: "System.ServiceModel.Duplex (net461)");
                 }
                 return _SystemServiceModelDuplex;
             }
@@ -4039,7 +4039,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelHttp is null)
                 {
-                    _SystemServiceModelHttp = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelHttp).GetReference(filePath: "System.ServiceModel.Http.dll", display: "System.ServiceModel.Http (net461)");
+                    _SystemServiceModelHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Http")).GetReference(filePath: "System.ServiceModel.Http.dll", display: "System.ServiceModel.Http (net461)");
                 }
                 return _SystemServiceModelHttp;
             }
@@ -4056,7 +4056,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelNetTcp is null)
                 {
-                    _SystemServiceModelNetTcp = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelNetTcp).GetReference(filePath: "System.ServiceModel.NetTcp.dll", display: "System.ServiceModel.NetTcp (net461)");
+                    _SystemServiceModelNetTcp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.NetTcp")).GetReference(filePath: "System.ServiceModel.NetTcp.dll", display: "System.ServiceModel.NetTcp (net461)");
                 }
                 return _SystemServiceModelNetTcp;
             }
@@ -4073,7 +4073,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelPrimitives is null)
                 {
-                    _SystemServiceModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelPrimitives).GetReference(filePath: "System.ServiceModel.Primitives.dll", display: "System.ServiceModel.Primitives (net461)");
+                    _SystemServiceModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Primitives")).GetReference(filePath: "System.ServiceModel.Primitives.dll", display: "System.ServiceModel.Primitives (net461)");
                 }
                 return _SystemServiceModelPrimitives;
             }
@@ -4090,7 +4090,7 @@ public static partial class Net461
             {
                 if (_SystemServiceModelSecurity is null)
                 {
-                    _SystemServiceModelSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelSecurity).GetReference(filePath: "System.ServiceModel.Security.dll", display: "System.ServiceModel.Security (net461)");
+                    _SystemServiceModelSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ServiceModel.Security")).GetReference(filePath: "System.ServiceModel.Security.dll", display: "System.ServiceModel.Security (net461)");
                 }
                 return _SystemServiceModelSecurity;
             }
@@ -4107,7 +4107,7 @@ public static partial class Net461
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net461)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net461)");
                 }
                 return _SystemTextEncoding;
             }
@@ -4124,7 +4124,7 @@ public static partial class Net461
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net461)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net461)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -4141,7 +4141,7 @@ public static partial class Net461
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net461)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net461)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -4158,7 +4158,7 @@ public static partial class Net461
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net461)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net461)");
                 }
                 return _SystemThreading;
             }
@@ -4175,7 +4175,7 @@ public static partial class Net461
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net461)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net461)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -4192,7 +4192,7 @@ public static partial class Net461
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net461)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net461)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -4209,7 +4209,7 @@ public static partial class Net461
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net461)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net461)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -4226,7 +4226,7 @@ public static partial class Net461
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net461)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net461)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -4243,7 +4243,7 @@ public static partial class Net461
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net461)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net461)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -4260,7 +4260,7 @@ public static partial class Net461
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net461)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net461)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -4517,7 +4517,7 @@ public static partial class Net461
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net461)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net461)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -4534,7 +4534,7 @@ public static partial class Net461
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net461)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net461.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net461)");
                 }
                 return _SystemValueTuple;
             }

--- a/Src/Basic.Reference.Assemblies.Net472/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net472/Generated.cs
@@ -1455,7 +1455,7 @@ public static partial class Net472
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net472)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net472)");
                 }
                 return _Accessibility;
             }
@@ -1472,7 +1472,7 @@ public static partial class Net472
             {
                 if (_CustomMarshalers is null)
                 {
-                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(Resources.CustomMarshalers).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net472)");
+                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.CustomMarshalers")).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net472)");
                 }
                 return _CustomMarshalers;
             }
@@ -1489,7 +1489,7 @@ public static partial class Net472
             {
                 if (_ISymWrapper is null)
                 {
-                    _ISymWrapper = AssemblyMetadata.CreateFromImage(Resources.ISymWrapper).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net472)");
+                    _ISymWrapper = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.ISymWrapper")).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net472)");
                 }
                 return _ISymWrapper;
             }
@@ -1506,7 +1506,7 @@ public static partial class Net472
             {
                 if (_MicrosoftActivitiesBuild is null)
                 {
-                    _MicrosoftActivitiesBuild = AssemblyMetadata.CreateFromImage(Resources.MicrosoftActivitiesBuild).GetReference(filePath: "Microsoft.Activities.Build.dll", display: "Microsoft.Activities.Build (net472)");
+                    _MicrosoftActivitiesBuild = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Activities.Build")).GetReference(filePath: "Microsoft.Activities.Build.dll", display: "Microsoft.Activities.Build (net472)");
                 }
                 return _MicrosoftActivitiesBuild;
             }
@@ -1523,7 +1523,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildConversionv40 is null)
                 {
-                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildConversionv40).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net472)");
+                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Conversion.v4.0")).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net472)");
                 }
                 return _MicrosoftBuildConversionv40;
             }
@@ -1540,7 +1540,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuild is null)
                 {
-                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuild).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net472)");
+                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build")).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net472)");
                 }
                 return _MicrosoftBuild;
             }
@@ -1557,7 +1557,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildEngine is null)
                 {
-                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildEngine).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net472)");
+                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Engine")).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net472)");
                 }
                 return _MicrosoftBuildEngine;
             }
@@ -1574,7 +1574,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildFramework is null)
                 {
-                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildFramework).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net472)");
+                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Framework")).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net472)");
                 }
                 return _MicrosoftBuildFramework;
             }
@@ -1591,7 +1591,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildTasksv40 is null)
                 {
-                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildTasksv40).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net472)");
+                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Tasks.v4.0")).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net472)");
                 }
                 return _MicrosoftBuildTasksv40;
             }
@@ -1608,7 +1608,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildUtilitiesv40 is null)
                 {
-                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildUtilitiesv40).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net472)");
+                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Utilities.v4.0")).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net472)");
                 }
                 return _MicrosoftBuildUtilitiesv40;
             }
@@ -1625,7 +1625,7 @@ public static partial class Net472
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net472)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net472)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1642,7 +1642,7 @@ public static partial class Net472
             {
                 if (_MicrosoftJScript is null)
                 {
-                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJScript).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net472)");
+                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.JScript")).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net472)");
                 }
                 return _MicrosoftJScript;
             }
@@ -1659,7 +1659,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualBasicCompatibilityData is null)
                 {
-                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibilityData).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net472)");
+                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualBasic.Compatibility.Data")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net472)");
                 }
                 return _MicrosoftVisualBasicCompatibilityData;
             }
@@ -1676,7 +1676,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualBasicCompatibility is null)
                 {
-                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibility).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net472)");
+                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualBasic.Compatibility")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net472)");
                 }
                 return _MicrosoftVisualBasicCompatibility;
             }
@@ -1693,7 +1693,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net472)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net472)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1710,7 +1710,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualC is null)
                 {
-                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualC).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net472)");
+                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualC")).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net472)");
                 }
                 return _MicrosoftVisualC;
             }
@@ -1727,7 +1727,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualCSTLCLR is null)
                 {
-                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualCSTLCLR).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net472)");
+                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualC.STLCLR")).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net472)");
                 }
                 return _MicrosoftVisualCSTLCLR;
             }
@@ -1744,7 +1744,7 @@ public static partial class Net472
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net472)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net472)");
                 }
                 return _mscorlib;
             }
@@ -1761,7 +1761,7 @@ public static partial class Net472
             {
                 if (_PresentationBuildTasks is null)
                 {
-                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(Resources.PresentationBuildTasks).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net472)");
+                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationBuildTasks")).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net472)");
                 }
                 return _PresentationBuildTasks;
             }
@@ -1778,7 +1778,7 @@ public static partial class Net472
             {
                 if (_PresentationCore is null)
                 {
-                    _PresentationCore = AssemblyMetadata.CreateFromImage(Resources.PresentationCore).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net472)");
+                    _PresentationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationCore")).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net472)");
                 }
                 return _PresentationCore;
             }
@@ -1795,7 +1795,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkAero is null)
                 {
-                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net472)");
+                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Aero")).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net472)");
                 }
                 return _PresentationFrameworkAero;
             }
@@ -1812,7 +1812,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkAero2 is null)
                 {
-                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero2).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net472)");
+                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Aero2")).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net472)");
                 }
                 return _PresentationFrameworkAero2;
             }
@@ -1829,7 +1829,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkAeroLite is null)
                 {
-                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAeroLite).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net472)");
+                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.AeroLite")).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net472)");
                 }
                 return _PresentationFrameworkAeroLite;
             }
@@ -1846,7 +1846,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkClassic is null)
                 {
-                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkClassic).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net472)");
+                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Classic")).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net472)");
                 }
                 return _PresentationFrameworkClassic;
             }
@@ -1863,7 +1863,7 @@ public static partial class Net472
             {
                 if (_PresentationFramework is null)
                 {
-                    _PresentationFramework = AssemblyMetadata.CreateFromImage(Resources.PresentationFramework).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net472)");
+                    _PresentationFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework")).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net472)");
                 }
                 return _PresentationFramework;
             }
@@ -1880,7 +1880,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkLuna is null)
                 {
-                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkLuna).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net472)");
+                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Luna")).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net472)");
                 }
                 return _PresentationFrameworkLuna;
             }
@@ -1897,7 +1897,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkRoyale is null)
                 {
-                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkRoyale).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net472)");
+                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Royale")).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net472)");
                 }
                 return _PresentationFrameworkRoyale;
             }
@@ -1914,7 +1914,7 @@ public static partial class Net472
             {
                 if (_ReachFramework is null)
                 {
-                    _ReachFramework = AssemblyMetadata.CreateFromImage(Resources.ReachFramework).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net472)");
+                    _ReachFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.ReachFramework")).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net472)");
                 }
                 return _ReachFramework;
             }
@@ -1931,7 +1931,7 @@ public static partial class Net472
             {
                 if (_sysglobl is null)
                 {
-                    _sysglobl = AssemblyMetadata.CreateFromImage(Resources.sysglobl).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net472)");
+                    _sysglobl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.sysglobl")).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net472)");
                 }
                 return _sysglobl;
             }
@@ -1948,7 +1948,7 @@ public static partial class Net472
             {
                 if (_SystemActivitiesCorePresentation is null)
                 {
-                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesCorePresentation).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net472)");
+                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities.Core.Presentation")).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net472)");
                 }
                 return _SystemActivitiesCorePresentation;
             }
@@ -1965,7 +1965,7 @@ public static partial class Net472
             {
                 if (_SystemActivities is null)
                 {
-                    _SystemActivities = AssemblyMetadata.CreateFromImage(Resources.SystemActivities).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net472)");
+                    _SystemActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities")).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net472)");
                 }
                 return _SystemActivities;
             }
@@ -1982,7 +1982,7 @@ public static partial class Net472
             {
                 if (_SystemActivitiesDurableInstancing is null)
                 {
-                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesDurableInstancing).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net472)");
+                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities.DurableInstancing")).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net472)");
                 }
                 return _SystemActivitiesDurableInstancing;
             }
@@ -1999,7 +1999,7 @@ public static partial class Net472
             {
                 if (_SystemActivitiesPresentation is null)
                 {
-                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesPresentation).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net472)");
+                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities.Presentation")).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net472)");
                 }
                 return _SystemActivitiesPresentation;
             }
@@ -2016,7 +2016,7 @@ public static partial class Net472
             {
                 if (_SystemAddInContract is null)
                 {
-                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(Resources.SystemAddInContract).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net472)");
+                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.AddIn.Contract")).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net472)");
                 }
                 return _SystemAddInContract;
             }
@@ -2033,7 +2033,7 @@ public static partial class Net472
             {
                 if (_SystemAddIn is null)
                 {
-                    _SystemAddIn = AssemblyMetadata.CreateFromImage(Resources.SystemAddIn).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net472)");
+                    _SystemAddIn = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.AddIn")).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net472)");
                 }
                 return _SystemAddIn;
             }
@@ -2050,7 +2050,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelComposition is null)
                 {
-                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelComposition).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net472)");
+                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Composition")).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net472)");
                 }
                 return _SystemComponentModelComposition;
             }
@@ -2067,7 +2067,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelCompositionRegistration is null)
                 {
-                    _SystemComponentModelCompositionRegistration = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelCompositionRegistration).GetReference(filePath: "System.ComponentModel.Composition.Registration.dll", display: "System.ComponentModel.Composition.Registration (net472)");
+                    _SystemComponentModelCompositionRegistration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Composition.Registration")).GetReference(filePath: "System.ComponentModel.Composition.Registration.dll", display: "System.ComponentModel.Composition.Registration (net472)");
                 }
                 return _SystemComponentModelCompositionRegistration;
             }
@@ -2084,7 +2084,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net472)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net472)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -2101,7 +2101,7 @@ public static partial class Net472
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net472)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net472)");
                 }
                 return _SystemConfiguration;
             }
@@ -2118,7 +2118,7 @@ public static partial class Net472
             {
                 if (_SystemConfigurationInstall is null)
                 {
-                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationInstall).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net472)");
+                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Configuration.Install")).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net472)");
                 }
                 return _SystemConfigurationInstall;
             }
@@ -2135,7 +2135,7 @@ public static partial class Net472
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net472)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net472)");
                 }
                 return _SystemCore;
             }
@@ -2152,7 +2152,7 @@ public static partial class Net472
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net472)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net472)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -2169,7 +2169,7 @@ public static partial class Net472
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net472)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net472)");
                 }
                 return _SystemData;
             }
@@ -2186,7 +2186,7 @@ public static partial class Net472
             {
                 if (_SystemDataEntityDesign is null)
                 {
-                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntityDesign).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net472)");
+                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Entity.Design")).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net472)");
                 }
                 return _SystemDataEntityDesign;
             }
@@ -2203,7 +2203,7 @@ public static partial class Net472
             {
                 if (_SystemDataEntity is null)
                 {
-                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntity).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net472)");
+                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Entity")).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net472)");
                 }
                 return _SystemDataEntity;
             }
@@ -2220,7 +2220,7 @@ public static partial class Net472
             {
                 if (_SystemDataLinq is null)
                 {
-                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(Resources.SystemDataLinq).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net472)");
+                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Linq")).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net472)");
                 }
                 return _SystemDataLinq;
             }
@@ -2237,7 +2237,7 @@ public static partial class Net472
             {
                 if (_SystemDataOracleClient is null)
                 {
-                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataOracleClient).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net472)");
+                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.OracleClient")).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net472)");
                 }
                 return _SystemDataOracleClient;
             }
@@ -2254,7 +2254,7 @@ public static partial class Net472
             {
                 if (_SystemDataServicesClient is null)
                 {
-                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesClient).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net472)");
+                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Services.Client")).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net472)");
                 }
                 return _SystemDataServicesClient;
             }
@@ -2271,7 +2271,7 @@ public static partial class Net472
             {
                 if (_SystemDataServicesDesign is null)
                 {
-                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesDesign).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net472)");
+                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Services.Design")).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net472)");
                 }
                 return _SystemDataServicesDesign;
             }
@@ -2288,7 +2288,7 @@ public static partial class Net472
             {
                 if (_SystemDataServices is null)
                 {
-                    _SystemDataServices = AssemblyMetadata.CreateFromImage(Resources.SystemDataServices).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net472)");
+                    _SystemDataServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Services")).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net472)");
                 }
                 return _SystemDataServices;
             }
@@ -2305,7 +2305,7 @@ public static partial class Net472
             {
                 if (_SystemDataSqlXml is null)
                 {
-                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(Resources.SystemDataSqlXml).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net472)");
+                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.SqlXml")).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net472)");
                 }
                 return _SystemDataSqlXml;
             }
@@ -2322,7 +2322,7 @@ public static partial class Net472
             {
                 if (_SystemDeployment is null)
                 {
-                    _SystemDeployment = AssemblyMetadata.CreateFromImage(Resources.SystemDeployment).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net472)");
+                    _SystemDeployment = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Deployment")).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net472)");
                 }
                 return _SystemDeployment;
             }
@@ -2339,7 +2339,7 @@ public static partial class Net472
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net472)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net472)");
                 }
                 return _SystemDesign;
             }
@@ -2356,7 +2356,7 @@ public static partial class Net472
             {
                 if (_SystemDevice is null)
                 {
-                    _SystemDevice = AssemblyMetadata.CreateFromImage(Resources.SystemDevice).GetReference(filePath: "System.Device.dll", display: "System.Device (net472)");
+                    _SystemDevice = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Device")).GetReference(filePath: "System.Device.dll", display: "System.Device (net472)");
                 }
                 return _SystemDevice;
             }
@@ -2373,7 +2373,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net472)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net472)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -2390,7 +2390,7 @@ public static partial class Net472
             {
                 if (_SystemDirectoryServicesAccountManagement is null)
                 {
-                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesAccountManagement).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net472)");
+                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.DirectoryServices.AccountManagement")).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net472)");
                 }
                 return _SystemDirectoryServicesAccountManagement;
             }
@@ -2407,7 +2407,7 @@ public static partial class Net472
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net472)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net472)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -2424,7 +2424,7 @@ public static partial class Net472
             {
                 if (_SystemDirectoryServicesProtocols is null)
                 {
-                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesProtocols).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net472)");
+                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.DirectoryServices.Protocols")).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net472)");
                 }
                 return _SystemDirectoryServicesProtocols;
             }
@@ -2441,7 +2441,7 @@ public static partial class Net472
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net472)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System")).GetReference(filePath: "System.dll", display: "System (net472)");
                 }
                 return _System;
             }
@@ -2458,7 +2458,7 @@ public static partial class Net472
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net472)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net472)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -2475,7 +2475,7 @@ public static partial class Net472
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net472)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net472)");
                 }
                 return _SystemDrawing;
             }
@@ -2492,7 +2492,7 @@ public static partial class Net472
             {
                 if (_SystemDynamic is null)
                 {
-                    _SystemDynamic = AssemblyMetadata.CreateFromImage(Resources.SystemDynamic).GetReference(filePath: "System.Dynamic.dll", display: "System.Dynamic (net472)");
+                    _SystemDynamic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Dynamic")).GetReference(filePath: "System.Dynamic.dll", display: "System.Dynamic (net472)");
                 }
                 return _SystemDynamic;
             }
@@ -2509,7 +2509,7 @@ public static partial class Net472
             {
                 if (_SystemEnterpriseServices is null)
                 {
-                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(Resources.SystemEnterpriseServices).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net472)");
+                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.EnterpriseServices")).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net472)");
                 }
                 return _SystemEnterpriseServices;
             }
@@ -2526,7 +2526,7 @@ public static partial class Net472
             {
                 if (_SystemIdentityModel is null)
                 {
-                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModel).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net472)");
+                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IdentityModel")).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net472)");
                 }
                 return _SystemIdentityModel;
             }
@@ -2543,7 +2543,7 @@ public static partial class Net472
             {
                 if (_SystemIdentityModelSelectors is null)
                 {
-                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelSelectors).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net472)");
+                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IdentityModel.Selectors")).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net472)");
                 }
                 return _SystemIdentityModelSelectors;
             }
@@ -2560,7 +2560,7 @@ public static partial class Net472
             {
                 if (_SystemIdentityModelServices is null)
                 {
-                    _SystemIdentityModelServices = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelServices).GetReference(filePath: "System.IdentityModel.Services.dll", display: "System.IdentityModel.Services (net472)");
+                    _SystemIdentityModelServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IdentityModel.Services")).GetReference(filePath: "System.IdentityModel.Services.dll", display: "System.IdentityModel.Services (net472)");
                 }
                 return _SystemIdentityModelServices;
             }
@@ -2577,7 +2577,7 @@ public static partial class Net472
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net472)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net472)");
                 }
                 return _SystemIOCompression;
             }
@@ -2594,7 +2594,7 @@ public static partial class Net472
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net472)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net472)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -2611,7 +2611,7 @@ public static partial class Net472
             {
                 if (_SystemIOLog is null)
                 {
-                    _SystemIOLog = AssemblyMetadata.CreateFromImage(Resources.SystemIOLog).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net472)");
+                    _SystemIOLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Log")).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net472)");
                 }
                 return _SystemIOLog;
             }
@@ -2628,7 +2628,7 @@ public static partial class Net472
             {
                 if (_SystemManagement is null)
                 {
-                    _SystemManagement = AssemblyMetadata.CreateFromImage(Resources.SystemManagement).GetReference(filePath: "System.Management.dll", display: "System.Management (net472)");
+                    _SystemManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Management")).GetReference(filePath: "System.Management.dll", display: "System.Management (net472)");
                 }
                 return _SystemManagement;
             }
@@ -2645,7 +2645,7 @@ public static partial class Net472
             {
                 if (_SystemManagementInstrumentation is null)
                 {
-                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(Resources.SystemManagementInstrumentation).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net472)");
+                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Management.Instrumentation")).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net472)");
                 }
                 return _SystemManagementInstrumentation;
             }
@@ -2662,7 +2662,7 @@ public static partial class Net472
             {
                 if (_SystemMessaging is null)
                 {
-                    _SystemMessaging = AssemblyMetadata.CreateFromImage(Resources.SystemMessaging).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net472)");
+                    _SystemMessaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Messaging")).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net472)");
                 }
                 return _SystemMessaging;
             }
@@ -2679,7 +2679,7 @@ public static partial class Net472
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net472)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net472)");
                 }
                 return _SystemNet;
             }
@@ -2696,7 +2696,7 @@ public static partial class Net472
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net472)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net472)");
                 }
                 return _SystemNetHttp;
             }
@@ -2713,7 +2713,7 @@ public static partial class Net472
             {
                 if (_SystemNetHttpWebRequest is null)
                 {
-                    _SystemNetHttpWebRequest = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpWebRequest).GetReference(filePath: "System.Net.Http.WebRequest.dll", display: "System.Net.Http.WebRequest (net472)");
+                    _SystemNetHttpWebRequest = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Http.WebRequest")).GetReference(filePath: "System.Net.Http.WebRequest.dll", display: "System.Net.Http.WebRequest (net472)");
                 }
                 return _SystemNetHttpWebRequest;
             }
@@ -2730,7 +2730,7 @@ public static partial class Net472
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net472)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net472)");
                 }
                 return _SystemNumerics;
             }
@@ -2747,7 +2747,7 @@ public static partial class Net472
             {
                 if (_SystemPrinting is null)
                 {
-                    _SystemPrinting = AssemblyMetadata.CreateFromImage(Resources.SystemPrinting).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net472)");
+                    _SystemPrinting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Printing")).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net472)");
                 }
                 return _SystemPrinting;
             }
@@ -2764,7 +2764,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionContext is null)
                 {
-                    _SystemReflectionContext = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionContext).GetReference(filePath: "System.Reflection.Context.dll", display: "System.Reflection.Context (net472)");
+                    _SystemReflectionContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Context")).GetReference(filePath: "System.Reflection.Context.dll", display: "System.Reflection.Context (net472)");
                 }
                 return _SystemReflectionContext;
             }
@@ -2781,7 +2781,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeCaching is null)
                 {
-                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCaching).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net472)");
+                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Caching")).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net472)");
                 }
                 return _SystemRuntimeCaching;
             }
@@ -2798,7 +2798,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeDurableInstancing is null)
                 {
-                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeDurableInstancing).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net472)");
+                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.DurableInstancing")).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net472)");
                 }
                 return _SystemRuntimeDurableInstancing;
             }
@@ -2815,7 +2815,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeRemoting is null)
                 {
-                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeRemoting).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net472)");
+                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Remoting")).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net472)");
                 }
                 return _SystemRuntimeRemoting;
             }
@@ -2832,7 +2832,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net472)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net472)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2849,7 +2849,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationFormattersSoap is null)
                 {
-                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormattersSoap).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net472)");
+                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Formatters.Soap")).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net472)");
                 }
                 return _SystemRuntimeSerializationFormattersSoap;
             }
@@ -2866,7 +2866,7 @@ public static partial class Net472
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net472)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net472)");
                 }
                 return _SystemSecurity;
             }
@@ -2883,7 +2883,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelActivation is null)
                 {
-                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivation).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net472)");
+                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Activation")).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net472)");
                 }
                 return _SystemServiceModelActivation;
             }
@@ -2900,7 +2900,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelActivities is null)
                 {
-                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivities).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net472)");
+                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Activities")).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net472)");
                 }
                 return _SystemServiceModelActivities;
             }
@@ -2917,7 +2917,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelChannels is null)
                 {
-                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelChannels).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net472)");
+                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Channels")).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net472)");
                 }
                 return _SystemServiceModelChannels;
             }
@@ -2934,7 +2934,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelDiscovery is null)
                 {
-                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelDiscovery).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net472)");
+                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Discovery")).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net472)");
                 }
                 return _SystemServiceModelDiscovery;
             }
@@ -2951,7 +2951,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModel is null)
                 {
-                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModel).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net472)");
+                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel")).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net472)");
                 }
                 return _SystemServiceModel;
             }
@@ -2968,7 +2968,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelRouting is null)
                 {
-                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelRouting).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net472)");
+                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Routing")).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net472)");
                 }
                 return _SystemServiceModelRouting;
             }
@@ -2985,7 +2985,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net472)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net472)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -3002,7 +3002,7 @@ public static partial class Net472
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net472)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net472)");
                 }
                 return _SystemServiceProcess;
             }
@@ -3019,7 +3019,7 @@ public static partial class Net472
             {
                 if (_SystemSpeech is null)
                 {
-                    _SystemSpeech = AssemblyMetadata.CreateFromImage(Resources.SystemSpeech).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net472)");
+                    _SystemSpeech = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Speech")).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net472)");
                 }
                 return _SystemSpeech;
             }
@@ -3036,7 +3036,7 @@ public static partial class Net472
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net472)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net472)");
                 }
                 return _SystemTransactions;
             }
@@ -3053,7 +3053,7 @@ public static partial class Net472
             {
                 if (_SystemWebAbstractions is null)
                 {
-                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(Resources.SystemWebAbstractions).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net472)");
+                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Abstractions")).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net472)");
                 }
                 return _SystemWebAbstractions;
             }
@@ -3070,7 +3070,7 @@ public static partial class Net472
             {
                 if (_SystemWebApplicationServices is null)
                 {
-                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebApplicationServices).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net472)");
+                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.ApplicationServices")).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net472)");
                 }
                 return _SystemWebApplicationServices;
             }
@@ -3087,7 +3087,7 @@ public static partial class Net472
             {
                 if (_SystemWebDataVisualizationDesign is null)
                 {
-                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualizationDesign).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net472)");
+                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DataVisualization.Design")).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net472)");
                 }
                 return _SystemWebDataVisualizationDesign;
             }
@@ -3104,7 +3104,7 @@ public static partial class Net472
             {
                 if (_SystemWebDataVisualization is null)
                 {
-                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualization).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net472)");
+                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DataVisualization")).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net472)");
                 }
                 return _SystemWebDataVisualization;
             }
@@ -3121,7 +3121,7 @@ public static partial class Net472
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net472)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net472)");
                 }
                 return _SystemWeb;
             }
@@ -3138,7 +3138,7 @@ public static partial class Net472
             {
                 if (_SystemWebDynamicDataDesign is null)
                 {
-                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicDataDesign).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net472)");
+                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DynamicData.Design")).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net472)");
                 }
                 return _SystemWebDynamicDataDesign;
             }
@@ -3155,7 +3155,7 @@ public static partial class Net472
             {
                 if (_SystemWebDynamicData is null)
                 {
-                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicData).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net472)");
+                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DynamicData")).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net472)");
                 }
                 return _SystemWebDynamicData;
             }
@@ -3172,7 +3172,7 @@ public static partial class Net472
             {
                 if (_SystemWebEntityDesign is null)
                 {
-                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntityDesign).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net472)");
+                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Entity.Design")).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net472)");
                 }
                 return _SystemWebEntityDesign;
             }
@@ -3189,7 +3189,7 @@ public static partial class Net472
             {
                 if (_SystemWebEntity is null)
                 {
-                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntity).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net472)");
+                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Entity")).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net472)");
                 }
                 return _SystemWebEntity;
             }
@@ -3206,7 +3206,7 @@ public static partial class Net472
             {
                 if (_SystemWebExtensionsDesign is null)
                 {
-                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensionsDesign).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net472)");
+                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Extensions.Design")).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net472)");
                 }
                 return _SystemWebExtensionsDesign;
             }
@@ -3223,7 +3223,7 @@ public static partial class Net472
             {
                 if (_SystemWebExtensions is null)
                 {
-                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensions).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net472)");
+                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Extensions")).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net472)");
                 }
                 return _SystemWebExtensions;
             }
@@ -3240,7 +3240,7 @@ public static partial class Net472
             {
                 if (_SystemWebMobile is null)
                 {
-                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(Resources.SystemWebMobile).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net472)");
+                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Mobile")).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net472)");
                 }
                 return _SystemWebMobile;
             }
@@ -3257,7 +3257,7 @@ public static partial class Net472
             {
                 if (_SystemWebRegularExpressions is null)
                 {
-                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemWebRegularExpressions).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net472)");
+                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.RegularExpressions")).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net472)");
                 }
                 return _SystemWebRegularExpressions;
             }
@@ -3274,7 +3274,7 @@ public static partial class Net472
             {
                 if (_SystemWebRouting is null)
                 {
-                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(Resources.SystemWebRouting).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net472)");
+                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Routing")).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net472)");
                 }
                 return _SystemWebRouting;
             }
@@ -3291,7 +3291,7 @@ public static partial class Net472
             {
                 if (_SystemWebServices is null)
                 {
-                    _SystemWebServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebServices).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net472)");
+                    _SystemWebServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Services")).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net472)");
                 }
                 return _SystemWebServices;
             }
@@ -3308,7 +3308,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsControlsRibbon is null)
                 {
-                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsControlsRibbon).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net472)");
+                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Controls.Ribbon")).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net472)");
                 }
                 return _SystemWindowsControlsRibbon;
             }
@@ -3325,7 +3325,7 @@ public static partial class Net472
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net472)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net472)");
                 }
                 return _SystemWindows;
             }
@@ -3342,7 +3342,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsFormsDataVisualizationDesign is null)
                 {
-                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualizationDesign).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net472)");
+                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Forms.DataVisualization.Design")).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net472)");
                 }
                 return _SystemWindowsFormsDataVisualizationDesign;
             }
@@ -3359,7 +3359,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsFormsDataVisualization is null)
                 {
-                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualization).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net472)");
+                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Forms.DataVisualization")).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net472)");
                 }
                 return _SystemWindowsFormsDataVisualization;
             }
@@ -3376,7 +3376,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net472)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net472)");
                 }
                 return _SystemWindowsForms;
             }
@@ -3393,7 +3393,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsInputManipulations is null)
                 {
-                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsInputManipulations).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net472)");
+                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Input.Manipulations")).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net472)");
                 }
                 return _SystemWindowsInputManipulations;
             }
@@ -3410,7 +3410,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsPresentation is null)
                 {
-                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsPresentation).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net472)");
+                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Presentation")).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net472)");
                 }
                 return _SystemWindowsPresentation;
             }
@@ -3427,7 +3427,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowActivities is null)
                 {
-                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowActivities).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net472)");
+                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Workflow.Activities")).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net472)");
                 }
                 return _SystemWorkflowActivities;
             }
@@ -3444,7 +3444,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowComponentModel is null)
                 {
-                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowComponentModel).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net472)");
+                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Workflow.ComponentModel")).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net472)");
                 }
                 return _SystemWorkflowComponentModel;
             }
@@ -3461,7 +3461,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowRuntime is null)
                 {
-                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowRuntime).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net472)");
+                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Workflow.Runtime")).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net472)");
                 }
                 return _SystemWorkflowRuntime;
             }
@@ -3478,7 +3478,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowServices is null)
                 {
-                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowServices).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net472)");
+                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.WorkflowServices")).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net472)");
                 }
                 return _SystemWorkflowServices;
             }
@@ -3495,7 +3495,7 @@ public static partial class Net472
             {
                 if (_SystemXaml is null)
                 {
-                    _SystemXaml = AssemblyMetadata.CreateFromImage(Resources.SystemXaml).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net472)");
+                    _SystemXaml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xaml")).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net472)");
                 }
                 return _SystemXaml;
             }
@@ -3512,7 +3512,7 @@ public static partial class Net472
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net472)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net472)");
                 }
                 return _SystemXml;
             }
@@ -3529,7 +3529,7 @@ public static partial class Net472
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net472)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net472)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3546,7 +3546,7 @@ public static partial class Net472
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net472)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net472)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3563,7 +3563,7 @@ public static partial class Net472
             {
                 if (_UIAutomationClient is null)
                 {
-                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClient).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net472)");
+                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationClient")).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net472)");
                 }
                 return _UIAutomationClient;
             }
@@ -3580,7 +3580,7 @@ public static partial class Net472
             {
                 if (_UIAutomationClientsideProviders is null)
                 {
-                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClientsideProviders).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net472)");
+                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationClientsideProviders")).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net472)");
                 }
                 return _UIAutomationClientsideProviders;
             }
@@ -3597,7 +3597,7 @@ public static partial class Net472
             {
                 if (_UIAutomationProvider is null)
                 {
-                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(Resources.UIAutomationProvider).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net472)");
+                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationProvider")).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net472)");
                 }
                 return _UIAutomationProvider;
             }
@@ -3614,7 +3614,7 @@ public static partial class Net472
             {
                 if (_UIAutomationTypes is null)
                 {
-                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(Resources.UIAutomationTypes).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net472)");
+                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationTypes")).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net472)");
                 }
                 return _UIAutomationTypes;
             }
@@ -3631,7 +3631,7 @@ public static partial class Net472
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net472)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net472)");
                 }
                 return _WindowsBase;
             }
@@ -3648,7 +3648,7 @@ public static partial class Net472
             {
                 if (_WindowsFormsIntegration is null)
                 {
-                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(Resources.WindowsFormsIntegration).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net472)");
+                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.WindowsFormsIntegration")).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net472)");
                 }
                 return _WindowsFormsIntegration;
             }
@@ -3665,7 +3665,7 @@ public static partial class Net472
             {
                 if (_XamlBuildTask is null)
                 {
-                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(Resources.XamlBuildTask).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net472)");
+                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.XamlBuildTask")).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net472)");
                 }
                 return _XamlBuildTask;
             }
@@ -3682,7 +3682,7 @@ public static partial class Net472
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net472)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net472)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -3699,7 +3699,7 @@ public static partial class Net472
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net472)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net472)");
                 }
                 return _netstandard;
             }
@@ -3716,7 +3716,7 @@ public static partial class Net472
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net472)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net472)");
                 }
                 return _SystemAppContext;
             }
@@ -3733,7 +3733,7 @@ public static partial class Net472
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net472)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net472)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -3750,7 +3750,7 @@ public static partial class Net472
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net472)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net472)");
                 }
                 return _SystemCollections;
             }
@@ -3767,7 +3767,7 @@ public static partial class Net472
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net472)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net472)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -3784,7 +3784,7 @@ public static partial class Net472
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net472)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net472)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -3801,7 +3801,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net472)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net472)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -3818,7 +3818,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net472)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net472)");
                 }
                 return _SystemComponentModel;
             }
@@ -3835,7 +3835,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net472)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net472)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -3852,7 +3852,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net472)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net472)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -3869,7 +3869,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net472)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net472)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -3886,7 +3886,7 @@ public static partial class Net472
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net472)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net472)");
                 }
                 return _SystemConsole;
             }
@@ -3903,7 +3903,7 @@ public static partial class Net472
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net472)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net472)");
                 }
                 return _SystemDataCommon;
             }
@@ -3920,7 +3920,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net472)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net472)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -3937,7 +3937,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net472)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net472)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -3954,7 +3954,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net472)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net472)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -3971,7 +3971,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net472)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net472)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -3988,7 +3988,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net472)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net472)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -4005,7 +4005,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net472)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net472)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -4022,7 +4022,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net472)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net472)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -4039,7 +4039,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net472)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net472)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -4056,7 +4056,7 @@ public static partial class Net472
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net472)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net472)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -4073,7 +4073,7 @@ public static partial class Net472
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net472)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net472)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -4090,7 +4090,7 @@ public static partial class Net472
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net472)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net472)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -4107,7 +4107,7 @@ public static partial class Net472
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net472)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net472)");
                 }
                 return _SystemGlobalization;
             }
@@ -4124,7 +4124,7 @@ public static partial class Net472
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net472)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net472)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -4141,7 +4141,7 @@ public static partial class Net472
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net472)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net472)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -4158,7 +4158,7 @@ public static partial class Net472
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net472)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net472)");
                 }
                 return _SystemIO;
             }
@@ -4175,7 +4175,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net472)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net472)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -4192,7 +4192,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net472)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net472)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -4209,7 +4209,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net472)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net472)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -4226,7 +4226,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net472)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net472)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -4243,7 +4243,7 @@ public static partial class Net472
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net472)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net472)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -4260,7 +4260,7 @@ public static partial class Net472
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net472)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net472)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -4277,7 +4277,7 @@ public static partial class Net472
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net472)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net472)");
                 }
                 return _SystemIOPipes;
             }
@@ -4294,7 +4294,7 @@ public static partial class Net472
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net472)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net472)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -4311,7 +4311,7 @@ public static partial class Net472
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net472)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net472)");
                 }
                 return _SystemLinq;
             }
@@ -4328,7 +4328,7 @@ public static partial class Net472
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net472)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net472)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -4345,7 +4345,7 @@ public static partial class Net472
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net472)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net472)");
                 }
                 return _SystemLinqParallel;
             }
@@ -4362,7 +4362,7 @@ public static partial class Net472
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net472)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net472)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -4379,7 +4379,7 @@ public static partial class Net472
             {
                 if (_SystemNetHttpRtc is null)
                 {
-                    _SystemNetHttpRtc = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpRtc).GetReference(filePath: "System.Net.Http.Rtc.dll", display: "System.Net.Http.Rtc (net472)");
+                    _SystemNetHttpRtc = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Http.Rtc")).GetReference(filePath: "System.Net.Http.Rtc.dll", display: "System.Net.Http.Rtc (net472)");
                 }
                 return _SystemNetHttpRtc;
             }
@@ -4396,7 +4396,7 @@ public static partial class Net472
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net472)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net472)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -4413,7 +4413,7 @@ public static partial class Net472
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net472)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net472)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -4430,7 +4430,7 @@ public static partial class Net472
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net472)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net472)");
                 }
                 return _SystemNetPing;
             }
@@ -4447,7 +4447,7 @@ public static partial class Net472
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net472)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net472)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -4464,7 +4464,7 @@ public static partial class Net472
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net472)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net472)");
                 }
                 return _SystemNetRequests;
             }
@@ -4481,7 +4481,7 @@ public static partial class Net472
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net472)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net472)");
                 }
                 return _SystemNetSecurity;
             }
@@ -4498,7 +4498,7 @@ public static partial class Net472
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net472)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net472)");
                 }
                 return _SystemNetSockets;
             }
@@ -4515,7 +4515,7 @@ public static partial class Net472
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net472)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net472)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -4532,7 +4532,7 @@ public static partial class Net472
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net472)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net472)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -4549,7 +4549,7 @@ public static partial class Net472
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net472)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net472)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -4566,7 +4566,7 @@ public static partial class Net472
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net472)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net472)");
                 }
                 return _SystemObjectModel;
             }
@@ -4583,7 +4583,7 @@ public static partial class Net472
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net472)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net472)");
                 }
                 return _SystemReflection;
             }
@@ -4600,7 +4600,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net472)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net472)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -4617,7 +4617,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net472)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net472)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -4634,7 +4634,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net472)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net472)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -4651,7 +4651,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net472)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net472)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -4668,7 +4668,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net472)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net472)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -4685,7 +4685,7 @@ public static partial class Net472
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net472)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net472)");
                 }
                 return _SystemResourcesReader;
             }
@@ -4702,7 +4702,7 @@ public static partial class Net472
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net472)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net472)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -4719,7 +4719,7 @@ public static partial class Net472
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net472)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net472)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -4736,7 +4736,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net472)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net472)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -4753,7 +4753,7 @@ public static partial class Net472
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net472)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net472)");
                 }
                 return _SystemRuntime;
             }
@@ -4770,7 +4770,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net472)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net472)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -4787,7 +4787,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net472)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net472)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -4804,7 +4804,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net472)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net472)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -4821,7 +4821,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net472)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net472)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -4838,7 +4838,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeInteropServicesWindowsRuntime is null)
                 {
-                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesWindowsRuntime).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (net472)");
+                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.InteropServices.WindowsRuntime")).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (net472)");
                 }
                 return _SystemRuntimeInteropServicesWindowsRuntime;
             }
@@ -4855,7 +4855,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net472)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net472)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -4872,7 +4872,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net472)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net472)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -4889,7 +4889,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net472)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net472)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -4906,7 +4906,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net472)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net472)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -4923,7 +4923,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net472)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net472)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -4940,7 +4940,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net472)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net472)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -4957,7 +4957,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net472)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net472)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -4974,7 +4974,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net472)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net472)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -4991,7 +4991,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net472)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net472)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -5008,7 +5008,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net472)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net472)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -5025,7 +5025,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net472)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net472)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -5042,7 +5042,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net472)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net472)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -5059,7 +5059,7 @@ public static partial class Net472
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net472)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net472)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -5076,7 +5076,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelDuplex is null)
                 {
-                    _SystemServiceModelDuplex = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelDuplex).GetReference(filePath: "System.ServiceModel.Duplex.dll", display: "System.ServiceModel.Duplex (net472)");
+                    _SystemServiceModelDuplex = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Duplex")).GetReference(filePath: "System.ServiceModel.Duplex.dll", display: "System.ServiceModel.Duplex (net472)");
                 }
                 return _SystemServiceModelDuplex;
             }
@@ -5093,7 +5093,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelHttp is null)
                 {
-                    _SystemServiceModelHttp = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelHttp).GetReference(filePath: "System.ServiceModel.Http.dll", display: "System.ServiceModel.Http (net472)");
+                    _SystemServiceModelHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Http")).GetReference(filePath: "System.ServiceModel.Http.dll", display: "System.ServiceModel.Http (net472)");
                 }
                 return _SystemServiceModelHttp;
             }
@@ -5110,7 +5110,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelNetTcp is null)
                 {
-                    _SystemServiceModelNetTcp = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelNetTcp).GetReference(filePath: "System.ServiceModel.NetTcp.dll", display: "System.ServiceModel.NetTcp (net472)");
+                    _SystemServiceModelNetTcp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.NetTcp")).GetReference(filePath: "System.ServiceModel.NetTcp.dll", display: "System.ServiceModel.NetTcp (net472)");
                 }
                 return _SystemServiceModelNetTcp;
             }
@@ -5127,7 +5127,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelPrimitives is null)
                 {
-                    _SystemServiceModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelPrimitives).GetReference(filePath: "System.ServiceModel.Primitives.dll", display: "System.ServiceModel.Primitives (net472)");
+                    _SystemServiceModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Primitives")).GetReference(filePath: "System.ServiceModel.Primitives.dll", display: "System.ServiceModel.Primitives (net472)");
                 }
                 return _SystemServiceModelPrimitives;
             }
@@ -5144,7 +5144,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelSecurity is null)
                 {
-                    _SystemServiceModelSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelSecurity).GetReference(filePath: "System.ServiceModel.Security.dll", display: "System.ServiceModel.Security (net472)");
+                    _SystemServiceModelSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Security")).GetReference(filePath: "System.ServiceModel.Security.dll", display: "System.ServiceModel.Security (net472)");
                 }
                 return _SystemServiceModelSecurity;
             }
@@ -5161,7 +5161,7 @@ public static partial class Net472
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net472)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net472)");
                 }
                 return _SystemTextEncoding;
             }
@@ -5178,7 +5178,7 @@ public static partial class Net472
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net472)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net472)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -5195,7 +5195,7 @@ public static partial class Net472
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net472)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net472)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -5212,7 +5212,7 @@ public static partial class Net472
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net472)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net472)");
                 }
                 return _SystemThreading;
             }
@@ -5229,7 +5229,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net472)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net472)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -5246,7 +5246,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net472)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net472)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -5263,7 +5263,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net472)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net472)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -5280,7 +5280,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net472)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net472)");
                 }
                 return _SystemThreadingThread;
             }
@@ -5297,7 +5297,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net472)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net472)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -5314,7 +5314,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net472)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net472)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -5331,7 +5331,7 @@ public static partial class Net472
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net472)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net472)");
                 }
                 return _SystemValueTuple;
             }
@@ -5348,7 +5348,7 @@ public static partial class Net472
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net472)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net472)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -5365,7 +5365,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net472)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net472)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -5382,7 +5382,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net472)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net472)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -5399,7 +5399,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net472)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net472)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -5416,7 +5416,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net472)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net472)");
                 }
                 return _SystemXmlXPath;
             }
@@ -5433,7 +5433,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net472)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net472)");
                 }
                 return _SystemXmlXPathXDocument;
             }

--- a/Src/Basic.Reference.Assemblies.Net50/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net50/Generated.cs
@@ -957,7 +957,7 @@ public static partial class Net50
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net50)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net50)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -974,7 +974,7 @@ public static partial class Net50
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net50)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net50)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -991,7 +991,7 @@ public static partial class Net50
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net50)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net50)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1008,7 +1008,7 @@ public static partial class Net50
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net50)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net50)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1025,7 +1025,7 @@ public static partial class Net50
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net50)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net50)");
                 }
                 return _mscorlib;
             }
@@ -1042,7 +1042,7 @@ public static partial class Net50
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net50)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net50)");
                 }
                 return _netstandard;
             }
@@ -1059,7 +1059,7 @@ public static partial class Net50
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net50)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net50)");
                 }
                 return _SystemAppContext;
             }
@@ -1076,7 +1076,7 @@ public static partial class Net50
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net50)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net50)");
                 }
                 return _SystemBuffers;
             }
@@ -1093,7 +1093,7 @@ public static partial class Net50
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net50)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net50)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -1110,7 +1110,7 @@ public static partial class Net50
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net50)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net50)");
                 }
                 return _SystemCollections;
             }
@@ -1127,7 +1127,7 @@ public static partial class Net50
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net50)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net50)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -1144,7 +1144,7 @@ public static partial class Net50
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net50)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net50)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -1161,7 +1161,7 @@ public static partial class Net50
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net50)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net50)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -1178,7 +1178,7 @@ public static partial class Net50
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net50)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net50)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -1195,7 +1195,7 @@ public static partial class Net50
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net50)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net50)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1212,7 +1212,7 @@ public static partial class Net50
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net50)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net50)");
                 }
                 return _SystemComponentModel;
             }
@@ -1229,7 +1229,7 @@ public static partial class Net50
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net50)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net50)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -1246,7 +1246,7 @@ public static partial class Net50
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net50)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net50)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -1263,7 +1263,7 @@ public static partial class Net50
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net50)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net50)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -1280,7 +1280,7 @@ public static partial class Net50
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net50)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net50)");
                 }
                 return _SystemConfiguration;
             }
@@ -1297,7 +1297,7 @@ public static partial class Net50
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net50)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net50)");
                 }
                 return _SystemConsole;
             }
@@ -1314,7 +1314,7 @@ public static partial class Net50
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net50)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net50)");
                 }
                 return _SystemCore;
             }
@@ -1331,7 +1331,7 @@ public static partial class Net50
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net50)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net50)");
                 }
                 return _SystemDataCommon;
             }
@@ -1348,7 +1348,7 @@ public static partial class Net50
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net50)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net50)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1365,7 +1365,7 @@ public static partial class Net50
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net50)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net50)");
                 }
                 return _SystemData;
             }
@@ -1382,7 +1382,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net50)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net50)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1399,7 +1399,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net50)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net50)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1416,7 +1416,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net50)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net50)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -1433,7 +1433,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net50)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net50)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1450,7 +1450,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net50)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net50)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1467,7 +1467,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net50)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net50)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1484,7 +1484,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net50)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net50)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1501,7 +1501,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net50)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net50)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1518,7 +1518,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net50)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net50)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1535,7 +1535,7 @@ public static partial class Net50
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net50)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net50)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1552,7 +1552,7 @@ public static partial class Net50
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net50)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System")).GetReference(filePath: "System.dll", display: "System (net50)");
                 }
                 return _System;
             }
@@ -1569,7 +1569,7 @@ public static partial class Net50
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net50)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net50)");
                 }
                 return _SystemDrawing;
             }
@@ -1586,7 +1586,7 @@ public static partial class Net50
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net50)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net50)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1603,7 +1603,7 @@ public static partial class Net50
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net50)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net50)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1620,7 +1620,7 @@ public static partial class Net50
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net50)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net50)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -1637,7 +1637,7 @@ public static partial class Net50
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net50)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net50)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1654,7 +1654,7 @@ public static partial class Net50
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net50)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net50)");
                 }
                 return _SystemGlobalization;
             }
@@ -1671,7 +1671,7 @@ public static partial class Net50
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net50)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net50)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1688,7 +1688,7 @@ public static partial class Net50
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net50)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net50)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -1705,7 +1705,7 @@ public static partial class Net50
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net50)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net50)");
                 }
                 return _SystemIOCompression;
             }
@@ -1722,7 +1722,7 @@ public static partial class Net50
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net50)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net50)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1739,7 +1739,7 @@ public static partial class Net50
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net50)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net50)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1756,7 +1756,7 @@ public static partial class Net50
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net50)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net50)");
                 }
                 return _SystemIO;
             }
@@ -1773,7 +1773,7 @@ public static partial class Net50
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net50)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net50)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1790,7 +1790,7 @@ public static partial class Net50
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net50)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net50)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1807,7 +1807,7 @@ public static partial class Net50
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net50)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net50)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1824,7 +1824,7 @@ public static partial class Net50
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net50)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net50)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1841,7 +1841,7 @@ public static partial class Net50
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net50)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net50)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1858,7 +1858,7 @@ public static partial class Net50
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net50)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net50)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1875,7 +1875,7 @@ public static partial class Net50
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net50)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net50)");
                 }
                 return _SystemIOPipes;
             }
@@ -1892,7 +1892,7 @@ public static partial class Net50
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net50)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net50)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -1909,7 +1909,7 @@ public static partial class Net50
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net50)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net50)");
                 }
                 return _SystemLinq;
             }
@@ -1926,7 +1926,7 @@ public static partial class Net50
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net50)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net50)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -1943,7 +1943,7 @@ public static partial class Net50
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net50)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net50)");
                 }
                 return _SystemLinqParallel;
             }
@@ -1960,7 +1960,7 @@ public static partial class Net50
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net50)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net50)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -1977,7 +1977,7 @@ public static partial class Net50
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net50)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net50)");
                 }
                 return _SystemMemory;
             }
@@ -1994,7 +1994,7 @@ public static partial class Net50
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net50)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net50)");
                 }
                 return _SystemNet;
             }
@@ -2011,7 +2011,7 @@ public static partial class Net50
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net50)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net50)");
                 }
                 return _SystemNetHttp;
             }
@@ -2028,7 +2028,7 @@ public static partial class Net50
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net50)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net50)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -2045,7 +2045,7 @@ public static partial class Net50
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net50)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net50)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -2062,7 +2062,7 @@ public static partial class Net50
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net50)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net50)");
                 }
                 return _SystemNetMail;
             }
@@ -2079,7 +2079,7 @@ public static partial class Net50
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net50)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net50)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -2096,7 +2096,7 @@ public static partial class Net50
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net50)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net50)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -2113,7 +2113,7 @@ public static partial class Net50
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net50)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net50)");
                 }
                 return _SystemNetPing;
             }
@@ -2130,7 +2130,7 @@ public static partial class Net50
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net50)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net50)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -2147,7 +2147,7 @@ public static partial class Net50
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net50)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net50)");
                 }
                 return _SystemNetRequests;
             }
@@ -2164,7 +2164,7 @@ public static partial class Net50
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net50)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net50)");
                 }
                 return _SystemNetSecurity;
             }
@@ -2181,7 +2181,7 @@ public static partial class Net50
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net50)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net50)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -2198,7 +2198,7 @@ public static partial class Net50
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net50)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net50)");
                 }
                 return _SystemNetSockets;
             }
@@ -2215,7 +2215,7 @@ public static partial class Net50
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net50)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net50)");
                 }
                 return _SystemNetWebClient;
             }
@@ -2232,7 +2232,7 @@ public static partial class Net50
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net50)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net50)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -2249,7 +2249,7 @@ public static partial class Net50
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net50)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net50)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -2266,7 +2266,7 @@ public static partial class Net50
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net50)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net50)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -2283,7 +2283,7 @@ public static partial class Net50
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net50)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net50)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -2300,7 +2300,7 @@ public static partial class Net50
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net50)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net50)");
                 }
                 return _SystemNumerics;
             }
@@ -2317,7 +2317,7 @@ public static partial class Net50
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net50)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net50)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2334,7 +2334,7 @@ public static partial class Net50
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net50)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net50)");
                 }
                 return _SystemObjectModel;
             }
@@ -2351,7 +2351,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net50)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net50)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -2368,7 +2368,7 @@ public static partial class Net50
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net50)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net50)");
                 }
                 return _SystemReflection;
             }
@@ -2385,7 +2385,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net50)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net50)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -2402,7 +2402,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net50)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net50)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -2419,7 +2419,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net50)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net50)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -2436,7 +2436,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net50)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net50)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -2453,7 +2453,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net50)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net50)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -2470,7 +2470,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net50)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net50)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -2487,7 +2487,7 @@ public static partial class Net50
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net50)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net50)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -2504,7 +2504,7 @@ public static partial class Net50
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net50)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net50)");
                 }
                 return _SystemResourcesReader;
             }
@@ -2521,7 +2521,7 @@ public static partial class Net50
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net50)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net50)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -2538,7 +2538,7 @@ public static partial class Net50
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net50)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net50)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -2555,7 +2555,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net50)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net50)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -2572,7 +2572,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net50)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net50)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -2589,7 +2589,7 @@ public static partial class Net50
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net50)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net50)");
                 }
                 return _SystemRuntime;
             }
@@ -2606,7 +2606,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net50)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net50)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -2623,7 +2623,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net50)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net50)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -2640,7 +2640,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net50)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net50)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -2657,7 +2657,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net50)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net50)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -2674,7 +2674,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net50)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net50)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -2691,7 +2691,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net50)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net50)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -2708,7 +2708,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net50)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net50)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2725,7 +2725,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net50)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net50)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2742,7 +2742,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net50)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net50)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2759,7 +2759,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net50)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net50)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2776,7 +2776,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net50)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net50)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2793,7 +2793,7 @@ public static partial class Net50
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net50)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net50)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2810,7 +2810,7 @@ public static partial class Net50
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net50)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net50)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -2827,7 +2827,7 @@ public static partial class Net50
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net50)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net50)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -2844,7 +2844,7 @@ public static partial class Net50
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net50)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net50)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -2861,7 +2861,7 @@ public static partial class Net50
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net50)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net50)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -2878,7 +2878,7 @@ public static partial class Net50
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net50)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net50)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -2895,7 +2895,7 @@ public static partial class Net50
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net50)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net50)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -2912,7 +2912,7 @@ public static partial class Net50
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net50)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net50)");
                 }
                 return _SystemSecurity;
             }
@@ -2929,7 +2929,7 @@ public static partial class Net50
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net50)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net50)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -2946,7 +2946,7 @@ public static partial class Net50
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net50)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net50)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -2963,7 +2963,7 @@ public static partial class Net50
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net50)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net50)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -2980,7 +2980,7 @@ public static partial class Net50
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net50)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net50)");
                 }
                 return _SystemServiceProcess;
             }
@@ -2997,7 +2997,7 @@ public static partial class Net50
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net50)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net50)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -3014,7 +3014,7 @@ public static partial class Net50
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net50)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net50)");
                 }
                 return _SystemTextEncoding;
             }
@@ -3031,7 +3031,7 @@ public static partial class Net50
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net50)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net50)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -3048,7 +3048,7 @@ public static partial class Net50
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net50)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net50)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -3065,7 +3065,7 @@ public static partial class Net50
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net50)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net50)");
                 }
                 return _SystemTextJson;
             }
@@ -3082,7 +3082,7 @@ public static partial class Net50
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net50)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net50)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -3099,7 +3099,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net50)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net50)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -3116,7 +3116,7 @@ public static partial class Net50
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net50)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net50)");
                 }
                 return _SystemThreading;
             }
@@ -3133,7 +3133,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net50)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net50)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -3150,7 +3150,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net50)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net50)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -3167,7 +3167,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net50)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net50)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -3184,7 +3184,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net50)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net50)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -3201,7 +3201,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net50)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net50)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -3218,7 +3218,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net50)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net50)");
                 }
                 return _SystemThreadingThread;
             }
@@ -3235,7 +3235,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net50)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net50)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -3252,7 +3252,7 @@ public static partial class Net50
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net50)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net50)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -3269,7 +3269,7 @@ public static partial class Net50
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net50)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net50)");
                 }
                 return _SystemTransactions;
             }
@@ -3286,7 +3286,7 @@ public static partial class Net50
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net50)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net50)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -3303,7 +3303,7 @@ public static partial class Net50
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net50)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net50)");
                 }
                 return _SystemValueTuple;
             }
@@ -3320,7 +3320,7 @@ public static partial class Net50
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net50)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net50)");
                 }
                 return _SystemWeb;
             }
@@ -3337,7 +3337,7 @@ public static partial class Net50
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net50)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net50)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -3354,7 +3354,7 @@ public static partial class Net50
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net50)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net50)");
                 }
                 return _SystemWindows;
             }
@@ -3371,7 +3371,7 @@ public static partial class Net50
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net50)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net50)");
                 }
                 return _SystemXml;
             }
@@ -3388,7 +3388,7 @@ public static partial class Net50
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net50)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net50)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3405,7 +3405,7 @@ public static partial class Net50
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net50)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net50)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -3422,7 +3422,7 @@ public static partial class Net50
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net50)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net50)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3439,7 +3439,7 @@ public static partial class Net50
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net50)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net50)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -3456,7 +3456,7 @@ public static partial class Net50
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net50)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net50)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -3473,7 +3473,7 @@ public static partial class Net50
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net50)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net50)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -3490,7 +3490,7 @@ public static partial class Net50
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net50)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net50)");
                 }
                 return _SystemXmlXPath;
             }
@@ -3507,7 +3507,7 @@ public static partial class Net50
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net50)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net50)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -3524,7 +3524,7 @@ public static partial class Net50
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net50)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net50.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net50)");
                 }
                 return _WindowsBase;
             }

--- a/Src/Basic.Reference.Assemblies.Net60/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net60/Generated.cs
@@ -999,7 +999,7 @@ public static partial class Net60
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net60)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net60)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1016,7 +1016,7 @@ public static partial class Net60
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net60)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net60)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -1033,7 +1033,7 @@ public static partial class Net60
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net60)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net60)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1050,7 +1050,7 @@ public static partial class Net60
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net60)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net60)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1067,7 +1067,7 @@ public static partial class Net60
             {
                 if (_MicrosoftWin32Registry is null)
                 {
-                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Registry).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net60)");
+                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.Microsoft.Win32.Registry")).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net60)");
                 }
                 return _MicrosoftWin32Registry;
             }
@@ -1084,7 +1084,7 @@ public static partial class Net60
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net60)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net60)");
                 }
                 return _mscorlib;
             }
@@ -1101,7 +1101,7 @@ public static partial class Net60
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net60)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net60)");
                 }
                 return _netstandard;
             }
@@ -1118,7 +1118,7 @@ public static partial class Net60
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net60)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net60)");
                 }
                 return _SystemAppContext;
             }
@@ -1135,7 +1135,7 @@ public static partial class Net60
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net60)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net60)");
                 }
                 return _SystemBuffers;
             }
@@ -1152,7 +1152,7 @@ public static partial class Net60
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net60)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net60)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -1169,7 +1169,7 @@ public static partial class Net60
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net60)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net60)");
                 }
                 return _SystemCollections;
             }
@@ -1186,7 +1186,7 @@ public static partial class Net60
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net60)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net60)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -1203,7 +1203,7 @@ public static partial class Net60
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net60)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net60)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -1220,7 +1220,7 @@ public static partial class Net60
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net60)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net60)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -1237,7 +1237,7 @@ public static partial class Net60
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net60)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net60)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -1254,7 +1254,7 @@ public static partial class Net60
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net60)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net60)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1271,7 +1271,7 @@ public static partial class Net60
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net60)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net60)");
                 }
                 return _SystemComponentModel;
             }
@@ -1288,7 +1288,7 @@ public static partial class Net60
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net60)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net60)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -1305,7 +1305,7 @@ public static partial class Net60
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net60)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net60)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -1322,7 +1322,7 @@ public static partial class Net60
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net60)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net60)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -1339,7 +1339,7 @@ public static partial class Net60
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net60)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net60)");
                 }
                 return _SystemConfiguration;
             }
@@ -1356,7 +1356,7 @@ public static partial class Net60
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net60)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net60)");
                 }
                 return _SystemConsole;
             }
@@ -1373,7 +1373,7 @@ public static partial class Net60
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net60)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net60)");
                 }
                 return _SystemCore;
             }
@@ -1390,7 +1390,7 @@ public static partial class Net60
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net60)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net60)");
                 }
                 return _SystemDataCommon;
             }
@@ -1407,7 +1407,7 @@ public static partial class Net60
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net60)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net60)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1424,7 +1424,7 @@ public static partial class Net60
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net60)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net60)");
                 }
                 return _SystemData;
             }
@@ -1441,7 +1441,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net60)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net60)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1458,7 +1458,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net60)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net60)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1475,7 +1475,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net60)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net60)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -1492,7 +1492,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net60)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net60)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1509,7 +1509,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net60)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net60)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1526,7 +1526,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net60)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net60)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1543,7 +1543,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net60)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net60)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1560,7 +1560,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net60)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net60)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1577,7 +1577,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net60)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net60)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1594,7 +1594,7 @@ public static partial class Net60
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net60)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net60)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1611,7 +1611,7 @@ public static partial class Net60
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net60)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System")).GetReference(filePath: "System.dll", display: "System (net60)");
                 }
                 return _System;
             }
@@ -1628,7 +1628,7 @@ public static partial class Net60
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net60)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net60)");
                 }
                 return _SystemDrawing;
             }
@@ -1645,7 +1645,7 @@ public static partial class Net60
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net60)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net60)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1662,7 +1662,7 @@ public static partial class Net60
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net60)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net60)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1679,7 +1679,7 @@ public static partial class Net60
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net60)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net60)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -1696,7 +1696,7 @@ public static partial class Net60
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net60)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net60)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1713,7 +1713,7 @@ public static partial class Net60
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net60)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net60)");
                 }
                 return _SystemGlobalization;
             }
@@ -1730,7 +1730,7 @@ public static partial class Net60
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net60)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net60)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1747,7 +1747,7 @@ public static partial class Net60
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net60)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net60)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -1764,7 +1764,7 @@ public static partial class Net60
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net60)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net60)");
                 }
                 return _SystemIOCompression;
             }
@@ -1781,7 +1781,7 @@ public static partial class Net60
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net60)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net60)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1798,7 +1798,7 @@ public static partial class Net60
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net60)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net60)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1815,7 +1815,7 @@ public static partial class Net60
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net60)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net60)");
                 }
                 return _SystemIO;
             }
@@ -1832,7 +1832,7 @@ public static partial class Net60
             {
                 if (_SystemIOFileSystemAccessControl is null)
                 {
-                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemAccessControl).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net60)");
+                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.FileSystem.AccessControl")).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net60)");
                 }
                 return _SystemIOFileSystemAccessControl;
             }
@@ -1849,7 +1849,7 @@ public static partial class Net60
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net60)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net60)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1866,7 +1866,7 @@ public static partial class Net60
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net60)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net60)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1883,7 +1883,7 @@ public static partial class Net60
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net60)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net60)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1900,7 +1900,7 @@ public static partial class Net60
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net60)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net60)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1917,7 +1917,7 @@ public static partial class Net60
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net60)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net60)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1934,7 +1934,7 @@ public static partial class Net60
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net60)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net60)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1951,7 +1951,7 @@ public static partial class Net60
             {
                 if (_SystemIOPipesAccessControl is null)
                 {
-                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipesAccessControl).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net60)");
+                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.Pipes.AccessControl")).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net60)");
                 }
                 return _SystemIOPipesAccessControl;
             }
@@ -1968,7 +1968,7 @@ public static partial class Net60
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net60)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net60)");
                 }
                 return _SystemIOPipes;
             }
@@ -1985,7 +1985,7 @@ public static partial class Net60
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net60)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net60)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -2002,7 +2002,7 @@ public static partial class Net60
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net60)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net60)");
                 }
                 return _SystemLinq;
             }
@@ -2019,7 +2019,7 @@ public static partial class Net60
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net60)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net60)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -2036,7 +2036,7 @@ public static partial class Net60
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net60)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net60)");
                 }
                 return _SystemLinqParallel;
             }
@@ -2053,7 +2053,7 @@ public static partial class Net60
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net60)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net60)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -2070,7 +2070,7 @@ public static partial class Net60
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net60)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net60)");
                 }
                 return _SystemMemory;
             }
@@ -2087,7 +2087,7 @@ public static partial class Net60
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net60)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net60)");
                 }
                 return _SystemNet;
             }
@@ -2104,7 +2104,7 @@ public static partial class Net60
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net60)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net60)");
                 }
                 return _SystemNetHttp;
             }
@@ -2121,7 +2121,7 @@ public static partial class Net60
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net60)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net60)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -2138,7 +2138,7 @@ public static partial class Net60
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net60)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net60)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -2155,7 +2155,7 @@ public static partial class Net60
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net60)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net60)");
                 }
                 return _SystemNetMail;
             }
@@ -2172,7 +2172,7 @@ public static partial class Net60
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net60)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net60)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -2189,7 +2189,7 @@ public static partial class Net60
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net60)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net60)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -2206,7 +2206,7 @@ public static partial class Net60
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net60)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net60)");
                 }
                 return _SystemNetPing;
             }
@@ -2223,7 +2223,7 @@ public static partial class Net60
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net60)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net60)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -2240,7 +2240,7 @@ public static partial class Net60
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net60)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net60)");
                 }
                 return _SystemNetRequests;
             }
@@ -2257,7 +2257,7 @@ public static partial class Net60
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net60)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net60)");
                 }
                 return _SystemNetSecurity;
             }
@@ -2274,7 +2274,7 @@ public static partial class Net60
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net60)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net60)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -2291,7 +2291,7 @@ public static partial class Net60
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net60)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net60)");
                 }
                 return _SystemNetSockets;
             }
@@ -2308,7 +2308,7 @@ public static partial class Net60
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net60)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net60)");
                 }
                 return _SystemNetWebClient;
             }
@@ -2325,7 +2325,7 @@ public static partial class Net60
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net60)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net60)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -2342,7 +2342,7 @@ public static partial class Net60
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net60)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net60)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -2359,7 +2359,7 @@ public static partial class Net60
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net60)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net60)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -2376,7 +2376,7 @@ public static partial class Net60
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net60)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net60)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -2393,7 +2393,7 @@ public static partial class Net60
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net60)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net60)");
                 }
                 return _SystemNumerics;
             }
@@ -2410,7 +2410,7 @@ public static partial class Net60
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net60)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net60)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2427,7 +2427,7 @@ public static partial class Net60
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net60)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net60)");
                 }
                 return _SystemObjectModel;
             }
@@ -2444,7 +2444,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net60)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net60)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -2461,7 +2461,7 @@ public static partial class Net60
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net60)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net60)");
                 }
                 return _SystemReflection;
             }
@@ -2478,7 +2478,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net60)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net60)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -2495,7 +2495,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net60)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net60)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -2512,7 +2512,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net60)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net60)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -2529,7 +2529,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net60)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net60)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -2546,7 +2546,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net60)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net60)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -2563,7 +2563,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net60)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net60)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -2580,7 +2580,7 @@ public static partial class Net60
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net60)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net60)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -2597,7 +2597,7 @@ public static partial class Net60
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net60)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net60)");
                 }
                 return _SystemResourcesReader;
             }
@@ -2614,7 +2614,7 @@ public static partial class Net60
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net60)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net60)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -2631,7 +2631,7 @@ public static partial class Net60
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net60)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net60)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -2648,7 +2648,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net60)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net60)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -2665,7 +2665,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net60)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net60)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -2682,7 +2682,7 @@ public static partial class Net60
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net60)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net60)");
                 }
                 return _SystemRuntime;
             }
@@ -2699,7 +2699,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net60)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net60)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -2716,7 +2716,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net60)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net60)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -2733,7 +2733,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net60)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net60)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -2750,7 +2750,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net60)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net60)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -2767,7 +2767,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net60)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net60)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -2784,7 +2784,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net60)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net60)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -2801,7 +2801,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net60)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net60)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2818,7 +2818,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net60)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net60)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2835,7 +2835,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net60)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net60)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2852,7 +2852,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net60)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net60)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2869,7 +2869,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net60)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net60)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2886,7 +2886,7 @@ public static partial class Net60
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net60)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net60)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2903,7 +2903,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net60)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net60)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -2920,7 +2920,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net60)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net60)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -2937,7 +2937,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net60)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net60)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -2954,7 +2954,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityCryptographyCng is null)
                 {
-                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCng).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net60)");
+                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Cryptography.Cng")).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net60)");
                 }
                 return _SystemSecurityCryptographyCng;
             }
@@ -2971,7 +2971,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net60)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net60)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -2988,7 +2988,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net60)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net60)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -3005,7 +3005,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityCryptographyOpenSsl is null)
                 {
-                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyOpenSsl).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net60)");
+                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Cryptography.OpenSsl")).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net60)");
                 }
                 return _SystemSecurityCryptographyOpenSsl;
             }
@@ -3022,7 +3022,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net60)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net60)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -3039,7 +3039,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net60)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net60)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -3056,7 +3056,7 @@ public static partial class Net60
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net60)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net60)");
                 }
                 return _SystemSecurity;
             }
@@ -3073,7 +3073,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net60)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net60)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -3090,7 +3090,7 @@ public static partial class Net60
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net60)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net60)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -3107,7 +3107,7 @@ public static partial class Net60
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net60)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net60)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -3124,7 +3124,7 @@ public static partial class Net60
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net60)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net60)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -3141,7 +3141,7 @@ public static partial class Net60
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net60)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net60)");
                 }
                 return _SystemServiceProcess;
             }
@@ -3158,7 +3158,7 @@ public static partial class Net60
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net60)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net60)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -3175,7 +3175,7 @@ public static partial class Net60
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net60)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net60)");
                 }
                 return _SystemTextEncoding;
             }
@@ -3192,7 +3192,7 @@ public static partial class Net60
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net60)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net60)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -3209,7 +3209,7 @@ public static partial class Net60
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net60)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net60)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -3226,7 +3226,7 @@ public static partial class Net60
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net60)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net60)");
                 }
                 return _SystemTextJson;
             }
@@ -3243,7 +3243,7 @@ public static partial class Net60
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net60)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net60)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -3260,7 +3260,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net60)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net60)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -3277,7 +3277,7 @@ public static partial class Net60
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net60)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net60)");
                 }
                 return _SystemThreading;
             }
@@ -3294,7 +3294,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net60)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net60)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -3311,7 +3311,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net60)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net60)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -3328,7 +3328,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net60)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net60)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -3345,7 +3345,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net60)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net60)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -3362,7 +3362,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net60)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net60)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -3379,7 +3379,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net60)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net60)");
                 }
                 return _SystemThreadingThread;
             }
@@ -3396,7 +3396,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net60)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net60)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -3413,7 +3413,7 @@ public static partial class Net60
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net60)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net60)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -3430,7 +3430,7 @@ public static partial class Net60
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net60)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net60)");
                 }
                 return _SystemTransactions;
             }
@@ -3447,7 +3447,7 @@ public static partial class Net60
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net60)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net60)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -3464,7 +3464,7 @@ public static partial class Net60
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net60)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net60)");
                 }
                 return _SystemValueTuple;
             }
@@ -3481,7 +3481,7 @@ public static partial class Net60
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net60)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net60)");
                 }
                 return _SystemWeb;
             }
@@ -3498,7 +3498,7 @@ public static partial class Net60
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net60)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net60)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -3515,7 +3515,7 @@ public static partial class Net60
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net60)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net60)");
                 }
                 return _SystemWindows;
             }
@@ -3532,7 +3532,7 @@ public static partial class Net60
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net60)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net60)");
                 }
                 return _SystemXml;
             }
@@ -3549,7 +3549,7 @@ public static partial class Net60
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net60)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net60)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3566,7 +3566,7 @@ public static partial class Net60
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net60)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net60)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -3583,7 +3583,7 @@ public static partial class Net60
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net60)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net60)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3600,7 +3600,7 @@ public static partial class Net60
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net60)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net60)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -3617,7 +3617,7 @@ public static partial class Net60
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net60)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net60)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -3634,7 +3634,7 @@ public static partial class Net60
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net60)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net60)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -3651,7 +3651,7 @@ public static partial class Net60
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net60)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net60)");
                 }
                 return _SystemXmlXPath;
             }
@@ -3668,7 +3668,7 @@ public static partial class Net60
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net60)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net60)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -3685,7 +3685,7 @@ public static partial class Net60
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net60)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net60)");
                 }
                 return _WindowsBase;
             }

--- a/Src/Basic.Reference.Assemblies.Net60Windows/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net60Windows/Generated.cs
@@ -327,7 +327,7 @@ public static partial class Net60Windows
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net60windows)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net60windows)");
                 }
                 return _Accessibility;
             }
@@ -344,7 +344,7 @@ public static partial class Net60Windows
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net60windows)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net60windows)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -361,7 +361,7 @@ public static partial class Net60Windows
             {
                 if (_MicrosoftVisualBasicForms is null)
                 {
-                    _MicrosoftVisualBasicForms = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicForms).GetReference(filePath: "Microsoft.VisualBasic.Forms.dll", display: "Microsoft.VisualBasic.Forms (net60windows)");
+                    _MicrosoftVisualBasicForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.Microsoft.VisualBasic.Forms")).GetReference(filePath: "Microsoft.VisualBasic.Forms.dll", display: "Microsoft.VisualBasic.Forms (net60windows)");
                 }
                 return _MicrosoftVisualBasicForms;
             }
@@ -378,7 +378,7 @@ public static partial class Net60Windows
             {
                 if (_MicrosoftWin32RegistryAccessControl is null)
                 {
-                    _MicrosoftWin32RegistryAccessControl = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32RegistryAccessControl).GetReference(filePath: "Microsoft.Win32.Registry.AccessControl.dll", display: "Microsoft.Win32.Registry.AccessControl (net60windows)");
+                    _MicrosoftWin32RegistryAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.Microsoft.Win32.Registry.AccessControl")).GetReference(filePath: "Microsoft.Win32.Registry.AccessControl.dll", display: "Microsoft.Win32.Registry.AccessControl (net60windows)");
                 }
                 return _MicrosoftWin32RegistryAccessControl;
             }
@@ -395,7 +395,7 @@ public static partial class Net60Windows
             {
                 if (_MicrosoftWin32SystemEvents is null)
                 {
-                    _MicrosoftWin32SystemEvents = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32SystemEvents).GetReference(filePath: "Microsoft.Win32.SystemEvents.dll", display: "Microsoft.Win32.SystemEvents (net60windows)");
+                    _MicrosoftWin32SystemEvents = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.Microsoft.Win32.SystemEvents")).GetReference(filePath: "Microsoft.Win32.SystemEvents.dll", display: "Microsoft.Win32.SystemEvents (net60windows)");
                 }
                 return _MicrosoftWin32SystemEvents;
             }
@@ -412,7 +412,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationCore is null)
                 {
-                    _PresentationCore = AssemblyMetadata.CreateFromImage(Resources.PresentationCore).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net60windows)");
+                    _PresentationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationCore")).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net60windows)");
                 }
                 return _PresentationCore;
             }
@@ -429,7 +429,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationFrameworkAero is null)
                 {
-                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net60windows)");
+                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationFramework.Aero")).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net60windows)");
                 }
                 return _PresentationFrameworkAero;
             }
@@ -446,7 +446,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationFrameworkAero2 is null)
                 {
-                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero2).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net60windows)");
+                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationFramework.Aero2")).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net60windows)");
                 }
                 return _PresentationFrameworkAero2;
             }
@@ -463,7 +463,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationFrameworkAeroLite is null)
                 {
-                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAeroLite).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net60windows)");
+                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationFramework.AeroLite")).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net60windows)");
                 }
                 return _PresentationFrameworkAeroLite;
             }
@@ -480,7 +480,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationFrameworkClassic is null)
                 {
-                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkClassic).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net60windows)");
+                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationFramework.Classic")).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net60windows)");
                 }
                 return _PresentationFrameworkClassic;
             }
@@ -497,7 +497,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationFramework is null)
                 {
-                    _PresentationFramework = AssemblyMetadata.CreateFromImage(Resources.PresentationFramework).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net60windows)");
+                    _PresentationFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationFramework")).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net60windows)");
                 }
                 return _PresentationFramework;
             }
@@ -514,7 +514,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationFrameworkLuna is null)
                 {
-                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkLuna).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net60windows)");
+                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationFramework.Luna")).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net60windows)");
                 }
                 return _PresentationFrameworkLuna;
             }
@@ -531,7 +531,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationFrameworkRoyale is null)
                 {
-                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkRoyale).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net60windows)");
+                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationFramework.Royale")).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net60windows)");
                 }
                 return _PresentationFrameworkRoyale;
             }
@@ -548,7 +548,7 @@ public static partial class Net60Windows
             {
                 if (_PresentationUI is null)
                 {
-                    _PresentationUI = AssemblyMetadata.CreateFromImage(Resources.PresentationUI).GetReference(filePath: "PresentationUI.dll", display: "PresentationUI (net60windows)");
+                    _PresentationUI = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.PresentationUI")).GetReference(filePath: "PresentationUI.dll", display: "PresentationUI (net60windows)");
                 }
                 return _PresentationUI;
             }
@@ -565,7 +565,7 @@ public static partial class Net60Windows
             {
                 if (_ReachFramework is null)
                 {
-                    _ReachFramework = AssemblyMetadata.CreateFromImage(Resources.ReachFramework).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net60windows)");
+                    _ReachFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.ReachFramework")).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net60windows)");
                 }
                 return _ReachFramework;
             }
@@ -582,7 +582,7 @@ public static partial class Net60Windows
             {
                 if (_SystemCodeDom is null)
                 {
-                    _SystemCodeDom = AssemblyMetadata.CreateFromImage(Resources.SystemCodeDom).GetReference(filePath: "System.CodeDom.dll", display: "System.CodeDom (net60windows)");
+                    _SystemCodeDom = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.CodeDom")).GetReference(filePath: "System.CodeDom.dll", display: "System.CodeDom (net60windows)");
                 }
                 return _SystemCodeDom;
             }
@@ -599,7 +599,7 @@ public static partial class Net60Windows
             {
                 if (_SystemConfigurationConfigurationManager is null)
                 {
-                    _SystemConfigurationConfigurationManager = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationConfigurationManager).GetReference(filePath: "System.Configuration.ConfigurationManager.dll", display: "System.Configuration.ConfigurationManager (net60windows)");
+                    _SystemConfigurationConfigurationManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Configuration.ConfigurationManager")).GetReference(filePath: "System.Configuration.ConfigurationManager.dll", display: "System.Configuration.ConfigurationManager (net60windows)");
                 }
                 return _SystemConfigurationConfigurationManager;
             }
@@ -616,7 +616,7 @@ public static partial class Net60Windows
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net60windows)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net60windows)");
                 }
                 return _SystemDesign;
             }
@@ -633,7 +633,7 @@ public static partial class Net60Windows
             {
                 if (_SystemDiagnosticsEventLog is null)
                 {
-                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsEventLog).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (net60windows)");
+                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Diagnostics.EventLog")).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (net60windows)");
                 }
                 return _SystemDiagnosticsEventLog;
             }
@@ -650,7 +650,7 @@ public static partial class Net60Windows
             {
                 if (_SystemDiagnosticsPerformanceCounter is null)
                 {
-                    _SystemDiagnosticsPerformanceCounter = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsPerformanceCounter).GetReference(filePath: "System.Diagnostics.PerformanceCounter.dll", display: "System.Diagnostics.PerformanceCounter (net60windows)");
+                    _SystemDiagnosticsPerformanceCounter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Diagnostics.PerformanceCounter")).GetReference(filePath: "System.Diagnostics.PerformanceCounter.dll", display: "System.Diagnostics.PerformanceCounter (net60windows)");
                 }
                 return _SystemDiagnosticsPerformanceCounter;
             }
@@ -667,7 +667,7 @@ public static partial class Net60Windows
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net60windows)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net60windows)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -684,7 +684,7 @@ public static partial class Net60Windows
             {
                 if (_SystemDrawingCommon is null)
                 {
-                    _SystemDrawingCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingCommon).GetReference(filePath: "System.Drawing.Common.dll", display: "System.Drawing.Common (net60windows)");
+                    _SystemDrawingCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Drawing.Common")).GetReference(filePath: "System.Drawing.Common.dll", display: "System.Drawing.Common (net60windows)");
                 }
                 return _SystemDrawingCommon;
             }
@@ -701,7 +701,7 @@ public static partial class Net60Windows
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net60windows)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net60windows)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -718,7 +718,7 @@ public static partial class Net60Windows
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net60windows)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net60windows)");
                 }
                 return _SystemDrawing;
             }
@@ -735,7 +735,7 @@ public static partial class Net60Windows
             {
                 if (_SystemIOPackaging is null)
                 {
-                    _SystemIOPackaging = AssemblyMetadata.CreateFromImage(Resources.SystemIOPackaging).GetReference(filePath: "System.IO.Packaging.dll", display: "System.IO.Packaging (net60windows)");
+                    _SystemIOPackaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.IO.Packaging")).GetReference(filePath: "System.IO.Packaging.dll", display: "System.IO.Packaging (net60windows)");
                 }
                 return _SystemIOPackaging;
             }
@@ -752,7 +752,7 @@ public static partial class Net60Windows
             {
                 if (_SystemPrinting is null)
                 {
-                    _SystemPrinting = AssemblyMetadata.CreateFromImage(Resources.SystemPrinting).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net60windows)");
+                    _SystemPrinting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Printing")).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net60windows)");
                 }
                 return _SystemPrinting;
             }
@@ -769,7 +769,7 @@ public static partial class Net60Windows
             {
                 if (_SystemResourcesExtensions is null)
                 {
-                    _SystemResourcesExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesExtensions).GetReference(filePath: "System.Resources.Extensions.dll", display: "System.Resources.Extensions (net60windows)");
+                    _SystemResourcesExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Resources.Extensions")).GetReference(filePath: "System.Resources.Extensions.dll", display: "System.Resources.Extensions (net60windows)");
                 }
                 return _SystemResourcesExtensions;
             }
@@ -786,7 +786,7 @@ public static partial class Net60Windows
             {
                 if (_SystemSecurityCryptographyPkcs is null)
                 {
-                    _SystemSecurityCryptographyPkcs = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPkcs).GetReference(filePath: "System.Security.Cryptography.Pkcs.dll", display: "System.Security.Cryptography.Pkcs (net60windows)");
+                    _SystemSecurityCryptographyPkcs = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Security.Cryptography.Pkcs")).GetReference(filePath: "System.Security.Cryptography.Pkcs.dll", display: "System.Security.Cryptography.Pkcs (net60windows)");
                 }
                 return _SystemSecurityCryptographyPkcs;
             }
@@ -803,7 +803,7 @@ public static partial class Net60Windows
             {
                 if (_SystemSecurityCryptographyProtectedData is null)
                 {
-                    _SystemSecurityCryptographyProtectedData = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyProtectedData).GetReference(filePath: "System.Security.Cryptography.ProtectedData.dll", display: "System.Security.Cryptography.ProtectedData (net60windows)");
+                    _SystemSecurityCryptographyProtectedData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Security.Cryptography.ProtectedData")).GetReference(filePath: "System.Security.Cryptography.ProtectedData.dll", display: "System.Security.Cryptography.ProtectedData (net60windows)");
                 }
                 return _SystemSecurityCryptographyProtectedData;
             }
@@ -820,7 +820,7 @@ public static partial class Net60Windows
             {
                 if (_SystemSecurityCryptographyXml is null)
                 {
-                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyXml).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (net60windows)");
+                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Security.Cryptography.Xml")).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (net60windows)");
                 }
                 return _SystemSecurityCryptographyXml;
             }
@@ -837,7 +837,7 @@ public static partial class Net60Windows
             {
                 if (_SystemSecurityPermissions is null)
                 {
-                    _SystemSecurityPermissions = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPermissions).GetReference(filePath: "System.Security.Permissions.dll", display: "System.Security.Permissions (net60windows)");
+                    _SystemSecurityPermissions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Security.Permissions")).GetReference(filePath: "System.Security.Permissions.dll", display: "System.Security.Permissions (net60windows)");
                 }
                 return _SystemSecurityPermissions;
             }
@@ -854,7 +854,7 @@ public static partial class Net60Windows
             {
                 if (_SystemThreadingAccessControl is null)
                 {
-                    _SystemThreadingAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingAccessControl).GetReference(filePath: "System.Threading.AccessControl.dll", display: "System.Threading.AccessControl (net60windows)");
+                    _SystemThreadingAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Threading.AccessControl")).GetReference(filePath: "System.Threading.AccessControl.dll", display: "System.Threading.AccessControl (net60windows)");
                 }
                 return _SystemThreadingAccessControl;
             }
@@ -871,7 +871,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsControlsRibbon is null)
                 {
-                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsControlsRibbon).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net60windows)");
+                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Controls.Ribbon")).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net60windows)");
                 }
                 return _SystemWindowsControlsRibbon;
             }
@@ -888,7 +888,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsExtensions is null)
                 {
-                    _SystemWindowsExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsExtensions).GetReference(filePath: "System.Windows.Extensions.dll", display: "System.Windows.Extensions (net60windows)");
+                    _SystemWindowsExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Extensions")).GetReference(filePath: "System.Windows.Extensions.dll", display: "System.Windows.Extensions (net60windows)");
                 }
                 return _SystemWindowsExtensions;
             }
@@ -905,7 +905,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsFormsDesign is null)
                 {
-                    _SystemWindowsFormsDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDesign).GetReference(filePath: "System.Windows.Forms.Design.dll", display: "System.Windows.Forms.Design (net60windows)");
+                    _SystemWindowsFormsDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Forms.Design")).GetReference(filePath: "System.Windows.Forms.Design.dll", display: "System.Windows.Forms.Design (net60windows)");
                 }
                 return _SystemWindowsFormsDesign;
             }
@@ -922,7 +922,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsFormsDesignEditors is null)
                 {
-                    _SystemWindowsFormsDesignEditors = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDesignEditors).GetReference(filePath: "System.Windows.Forms.Design.Editors.dll", display: "System.Windows.Forms.Design.Editors (net60windows)");
+                    _SystemWindowsFormsDesignEditors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Forms.Design.Editors")).GetReference(filePath: "System.Windows.Forms.Design.Editors.dll", display: "System.Windows.Forms.Design.Editors (net60windows)");
                 }
                 return _SystemWindowsFormsDesignEditors;
             }
@@ -939,7 +939,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net60windows)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net60windows)");
                 }
                 return _SystemWindowsForms;
             }
@@ -956,7 +956,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsFormsPrimitives is null)
                 {
-                    _SystemWindowsFormsPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsPrimitives).GetReference(filePath: "System.Windows.Forms.Primitives.dll", display: "System.Windows.Forms.Primitives (net60windows)");
+                    _SystemWindowsFormsPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Forms.Primitives")).GetReference(filePath: "System.Windows.Forms.Primitives.dll", display: "System.Windows.Forms.Primitives (net60windows)");
                 }
                 return _SystemWindowsFormsPrimitives;
             }
@@ -973,7 +973,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsInputManipulations is null)
                 {
-                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsInputManipulations).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net60windows)");
+                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Input.Manipulations")).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net60windows)");
                 }
                 return _SystemWindowsInputManipulations;
             }
@@ -990,7 +990,7 @@ public static partial class Net60Windows
             {
                 if (_SystemWindowsPresentation is null)
                 {
-                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsPresentation).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net60windows)");
+                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Windows.Presentation")).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net60windows)");
                 }
                 return _SystemWindowsPresentation;
             }
@@ -1007,7 +1007,7 @@ public static partial class Net60Windows
             {
                 if (_SystemXaml is null)
                 {
-                    _SystemXaml = AssemblyMetadata.CreateFromImage(Resources.SystemXaml).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net60windows)");
+                    _SystemXaml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.System.Xaml")).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net60windows)");
                 }
                 return _SystemXaml;
             }
@@ -1024,7 +1024,7 @@ public static partial class Net60Windows
             {
                 if (_UIAutomationClient is null)
                 {
-                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClient).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net60windows)");
+                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.UIAutomationClient")).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net60windows)");
                 }
                 return _UIAutomationClient;
             }
@@ -1041,7 +1041,7 @@ public static partial class Net60Windows
             {
                 if (_UIAutomationClientSideProviders is null)
                 {
-                    _UIAutomationClientSideProviders = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClientSideProviders).GetReference(filePath: "UIAutomationClientSideProviders.dll", display: "UIAutomationClientSideProviders (net60windows)");
+                    _UIAutomationClientSideProviders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.UIAutomationClientSideProviders")).GetReference(filePath: "UIAutomationClientSideProviders.dll", display: "UIAutomationClientSideProviders (net60windows)");
                 }
                 return _UIAutomationClientSideProviders;
             }
@@ -1058,7 +1058,7 @@ public static partial class Net60Windows
             {
                 if (_UIAutomationProvider is null)
                 {
-                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(Resources.UIAutomationProvider).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net60windows)");
+                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.UIAutomationProvider")).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net60windows)");
                 }
                 return _UIAutomationProvider;
             }
@@ -1075,7 +1075,7 @@ public static partial class Net60Windows
             {
                 if (_UIAutomationTypes is null)
                 {
-                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(Resources.UIAutomationTypes).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net60windows)");
+                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.UIAutomationTypes")).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net60windows)");
                 }
                 return _UIAutomationTypes;
             }
@@ -1092,7 +1092,7 @@ public static partial class Net60Windows
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net60windows)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net60windows)");
                 }
                 return _WindowsBase;
             }
@@ -1109,7 +1109,7 @@ public static partial class Net60Windows
             {
                 if (_WindowsFormsIntegration is null)
                 {
-                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(Resources.WindowsFormsIntegration).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net60windows)");
+                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net60windows.WindowsFormsIntegration")).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net60windows)");
                 }
                 return _WindowsFormsIntegration;
             }

--- a/Src/Basic.Reference.Assemblies.Net70/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net70/Generated.cs
@@ -1023,7 +1023,7 @@ public static partial class Net70
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net70)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net70)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1040,7 +1040,7 @@ public static partial class Net70
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net70)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net70)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -1057,7 +1057,7 @@ public static partial class Net70
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net70)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net70)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1074,7 +1074,7 @@ public static partial class Net70
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net70)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net70)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1091,7 +1091,7 @@ public static partial class Net70
             {
                 if (_MicrosoftWin32Registry is null)
                 {
-                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Registry).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net70)");
+                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.Microsoft.Win32.Registry")).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net70)");
                 }
                 return _MicrosoftWin32Registry;
             }
@@ -1108,7 +1108,7 @@ public static partial class Net70
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net70)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net70)");
                 }
                 return _mscorlib;
             }
@@ -1125,7 +1125,7 @@ public static partial class Net70
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net70)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net70)");
                 }
                 return _netstandard;
             }
@@ -1142,7 +1142,7 @@ public static partial class Net70
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net70)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net70)");
                 }
                 return _SystemAppContext;
             }
@@ -1159,7 +1159,7 @@ public static partial class Net70
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net70)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net70)");
                 }
                 return _SystemBuffers;
             }
@@ -1176,7 +1176,7 @@ public static partial class Net70
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net70)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net70)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -1193,7 +1193,7 @@ public static partial class Net70
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net70)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net70)");
                 }
                 return _SystemCollections;
             }
@@ -1210,7 +1210,7 @@ public static partial class Net70
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net70)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net70)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -1227,7 +1227,7 @@ public static partial class Net70
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net70)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net70)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -1244,7 +1244,7 @@ public static partial class Net70
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net70)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net70)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -1261,7 +1261,7 @@ public static partial class Net70
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net70)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net70)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -1278,7 +1278,7 @@ public static partial class Net70
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net70)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net70)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1295,7 +1295,7 @@ public static partial class Net70
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net70)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net70)");
                 }
                 return _SystemComponentModel;
             }
@@ -1312,7 +1312,7 @@ public static partial class Net70
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net70)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net70)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -1329,7 +1329,7 @@ public static partial class Net70
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net70)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net70)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -1346,7 +1346,7 @@ public static partial class Net70
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net70)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net70)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -1363,7 +1363,7 @@ public static partial class Net70
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net70)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net70)");
                 }
                 return _SystemConfiguration;
             }
@@ -1380,7 +1380,7 @@ public static partial class Net70
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net70)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net70)");
                 }
                 return _SystemConsole;
             }
@@ -1397,7 +1397,7 @@ public static partial class Net70
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net70)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net70)");
                 }
                 return _SystemCore;
             }
@@ -1414,7 +1414,7 @@ public static partial class Net70
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net70)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net70)");
                 }
                 return _SystemDataCommon;
             }
@@ -1431,7 +1431,7 @@ public static partial class Net70
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net70)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net70)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1448,7 +1448,7 @@ public static partial class Net70
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net70)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net70)");
                 }
                 return _SystemData;
             }
@@ -1465,7 +1465,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net70)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net70)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1482,7 +1482,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net70)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net70)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1499,7 +1499,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net70)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net70)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -1516,7 +1516,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net70)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net70)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1533,7 +1533,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net70)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net70)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1550,7 +1550,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net70)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net70)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1567,7 +1567,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net70)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net70)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1584,7 +1584,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net70)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net70)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1601,7 +1601,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net70)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net70)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1618,7 +1618,7 @@ public static partial class Net70
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net70)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net70)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1635,7 +1635,7 @@ public static partial class Net70
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net70)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System")).GetReference(filePath: "System.dll", display: "System (net70)");
                 }
                 return _System;
             }
@@ -1652,7 +1652,7 @@ public static partial class Net70
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net70)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net70)");
                 }
                 return _SystemDrawing;
             }
@@ -1669,7 +1669,7 @@ public static partial class Net70
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net70)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net70)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1686,7 +1686,7 @@ public static partial class Net70
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net70)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net70)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1703,7 +1703,7 @@ public static partial class Net70
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net70)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net70)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -1720,7 +1720,7 @@ public static partial class Net70
             {
                 if (_SystemFormatsTar is null)
                 {
-                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsTar).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net70)");
+                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Formats.Tar")).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net70)");
                 }
                 return _SystemFormatsTar;
             }
@@ -1737,7 +1737,7 @@ public static partial class Net70
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net70)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net70)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1754,7 +1754,7 @@ public static partial class Net70
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net70)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net70)");
                 }
                 return _SystemGlobalization;
             }
@@ -1771,7 +1771,7 @@ public static partial class Net70
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net70)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net70)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1788,7 +1788,7 @@ public static partial class Net70
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net70)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net70)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -1805,7 +1805,7 @@ public static partial class Net70
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net70)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net70)");
                 }
                 return _SystemIOCompression;
             }
@@ -1822,7 +1822,7 @@ public static partial class Net70
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net70)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net70)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1839,7 +1839,7 @@ public static partial class Net70
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net70)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net70)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1856,7 +1856,7 @@ public static partial class Net70
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net70)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net70)");
                 }
                 return _SystemIO;
             }
@@ -1873,7 +1873,7 @@ public static partial class Net70
             {
                 if (_SystemIOFileSystemAccessControl is null)
                 {
-                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemAccessControl).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net70)");
+                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.FileSystem.AccessControl")).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net70)");
                 }
                 return _SystemIOFileSystemAccessControl;
             }
@@ -1890,7 +1890,7 @@ public static partial class Net70
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net70)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net70)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1907,7 +1907,7 @@ public static partial class Net70
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net70)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net70)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1924,7 +1924,7 @@ public static partial class Net70
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net70)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net70)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1941,7 +1941,7 @@ public static partial class Net70
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net70)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net70)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1958,7 +1958,7 @@ public static partial class Net70
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net70)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net70)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1975,7 +1975,7 @@ public static partial class Net70
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net70)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net70)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1992,7 +1992,7 @@ public static partial class Net70
             {
                 if (_SystemIOPipesAccessControl is null)
                 {
-                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipesAccessControl).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net70)");
+                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.Pipes.AccessControl")).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net70)");
                 }
                 return _SystemIOPipesAccessControl;
             }
@@ -2009,7 +2009,7 @@ public static partial class Net70
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net70)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net70)");
                 }
                 return _SystemIOPipes;
             }
@@ -2026,7 +2026,7 @@ public static partial class Net70
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net70)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net70)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -2043,7 +2043,7 @@ public static partial class Net70
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net70)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net70)");
                 }
                 return _SystemLinq;
             }
@@ -2060,7 +2060,7 @@ public static partial class Net70
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net70)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net70)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -2077,7 +2077,7 @@ public static partial class Net70
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net70)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net70)");
                 }
                 return _SystemLinqParallel;
             }
@@ -2094,7 +2094,7 @@ public static partial class Net70
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net70)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net70)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -2111,7 +2111,7 @@ public static partial class Net70
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net70)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net70)");
                 }
                 return _SystemMemory;
             }
@@ -2128,7 +2128,7 @@ public static partial class Net70
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net70)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net70)");
                 }
                 return _SystemNet;
             }
@@ -2145,7 +2145,7 @@ public static partial class Net70
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net70)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net70)");
                 }
                 return _SystemNetHttp;
             }
@@ -2162,7 +2162,7 @@ public static partial class Net70
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net70)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net70)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -2179,7 +2179,7 @@ public static partial class Net70
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net70)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net70)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -2196,7 +2196,7 @@ public static partial class Net70
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net70)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net70)");
                 }
                 return _SystemNetMail;
             }
@@ -2213,7 +2213,7 @@ public static partial class Net70
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net70)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net70)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -2230,7 +2230,7 @@ public static partial class Net70
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net70)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net70)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -2247,7 +2247,7 @@ public static partial class Net70
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net70)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net70)");
                 }
                 return _SystemNetPing;
             }
@@ -2264,7 +2264,7 @@ public static partial class Net70
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net70)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net70)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -2281,7 +2281,7 @@ public static partial class Net70
             {
                 if (_SystemNetQuic is null)
                 {
-                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(Resources.SystemNetQuic).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net70)");
+                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Quic")).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net70)");
                 }
                 return _SystemNetQuic;
             }
@@ -2298,7 +2298,7 @@ public static partial class Net70
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net70)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net70)");
                 }
                 return _SystemNetRequests;
             }
@@ -2315,7 +2315,7 @@ public static partial class Net70
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net70)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net70)");
                 }
                 return _SystemNetSecurity;
             }
@@ -2332,7 +2332,7 @@ public static partial class Net70
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net70)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net70)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -2349,7 +2349,7 @@ public static partial class Net70
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net70)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net70)");
                 }
                 return _SystemNetSockets;
             }
@@ -2366,7 +2366,7 @@ public static partial class Net70
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net70)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net70)");
                 }
                 return _SystemNetWebClient;
             }
@@ -2383,7 +2383,7 @@ public static partial class Net70
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net70)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net70)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -2400,7 +2400,7 @@ public static partial class Net70
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net70)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net70)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -2417,7 +2417,7 @@ public static partial class Net70
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net70)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net70)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -2434,7 +2434,7 @@ public static partial class Net70
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net70)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net70)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -2451,7 +2451,7 @@ public static partial class Net70
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net70)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net70)");
                 }
                 return _SystemNumerics;
             }
@@ -2468,7 +2468,7 @@ public static partial class Net70
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net70)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net70)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2485,7 +2485,7 @@ public static partial class Net70
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net70)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net70)");
                 }
                 return _SystemObjectModel;
             }
@@ -2502,7 +2502,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net70)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net70)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -2519,7 +2519,7 @@ public static partial class Net70
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net70)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net70)");
                 }
                 return _SystemReflection;
             }
@@ -2536,7 +2536,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net70)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net70)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -2553,7 +2553,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net70)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net70)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -2570,7 +2570,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net70)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net70)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -2587,7 +2587,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net70)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net70)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -2604,7 +2604,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net70)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net70)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -2621,7 +2621,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net70)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net70)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -2638,7 +2638,7 @@ public static partial class Net70
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net70)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net70)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -2655,7 +2655,7 @@ public static partial class Net70
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net70)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net70)");
                 }
                 return _SystemResourcesReader;
             }
@@ -2672,7 +2672,7 @@ public static partial class Net70
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net70)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net70)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -2689,7 +2689,7 @@ public static partial class Net70
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net70)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net70)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -2706,7 +2706,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net70)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net70)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -2723,7 +2723,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net70)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net70)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -2740,7 +2740,7 @@ public static partial class Net70
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net70)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net70)");
                 }
                 return _SystemRuntime;
             }
@@ -2757,7 +2757,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net70)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net70)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -2774,7 +2774,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net70)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net70)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -2791,7 +2791,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net70)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net70)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -2808,7 +2808,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeInteropServicesJavaScript is null)
                 {
-                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesJavaScript).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net70)");
+                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.InteropServices.JavaScript")).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net70)");
                 }
                 return _SystemRuntimeInteropServicesJavaScript;
             }
@@ -2825,7 +2825,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net70)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net70)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -2842,7 +2842,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net70)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net70)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -2859,7 +2859,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net70)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net70)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -2876,7 +2876,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net70)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net70)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2893,7 +2893,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net70)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net70)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2910,7 +2910,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net70)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net70)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2927,7 +2927,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net70)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net70)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2944,7 +2944,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net70)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net70)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2961,7 +2961,7 @@ public static partial class Net70
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net70)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net70)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2978,7 +2978,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net70)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net70)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -2995,7 +2995,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net70)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net70)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -3012,7 +3012,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net70)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net70)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -3029,7 +3029,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptographyCng is null)
                 {
-                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCng).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net70)");
+                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography.Cng")).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net70)");
                 }
                 return _SystemSecurityCryptographyCng;
             }
@@ -3046,7 +3046,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net70)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net70)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -3063,7 +3063,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptography is null)
                 {
-                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptography).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net70)");
+                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography")).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net70)");
                 }
                 return _SystemSecurityCryptography;
             }
@@ -3080,7 +3080,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net70)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net70)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -3097,7 +3097,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptographyOpenSsl is null)
                 {
-                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyOpenSsl).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net70)");
+                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography.OpenSsl")).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net70)");
                 }
                 return _SystemSecurityCryptographyOpenSsl;
             }
@@ -3114,7 +3114,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net70)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net70)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -3131,7 +3131,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net70)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net70)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -3148,7 +3148,7 @@ public static partial class Net70
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net70)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net70)");
                 }
                 return _SystemSecurity;
             }
@@ -3165,7 +3165,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net70)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net70)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -3182,7 +3182,7 @@ public static partial class Net70
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net70)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net70)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -3199,7 +3199,7 @@ public static partial class Net70
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net70)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net70)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -3216,7 +3216,7 @@ public static partial class Net70
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net70)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net70)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -3233,7 +3233,7 @@ public static partial class Net70
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net70)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net70)");
                 }
                 return _SystemServiceProcess;
             }
@@ -3250,7 +3250,7 @@ public static partial class Net70
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net70)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net70)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -3267,7 +3267,7 @@ public static partial class Net70
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net70)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net70)");
                 }
                 return _SystemTextEncoding;
             }
@@ -3284,7 +3284,7 @@ public static partial class Net70
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net70)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net70)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -3301,7 +3301,7 @@ public static partial class Net70
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net70)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net70)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -3318,7 +3318,7 @@ public static partial class Net70
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net70)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net70)");
                 }
                 return _SystemTextJson;
             }
@@ -3335,7 +3335,7 @@ public static partial class Net70
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net70)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net70)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -3352,7 +3352,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net70)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net70)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -3369,7 +3369,7 @@ public static partial class Net70
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net70)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net70)");
                 }
                 return _SystemThreading;
             }
@@ -3386,7 +3386,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net70)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net70)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -3403,7 +3403,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net70)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net70)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -3420,7 +3420,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net70)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net70)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -3437,7 +3437,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net70)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net70)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -3454,7 +3454,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net70)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net70)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -3471,7 +3471,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net70)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net70)");
                 }
                 return _SystemThreadingThread;
             }
@@ -3488,7 +3488,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net70)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net70)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -3505,7 +3505,7 @@ public static partial class Net70
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net70)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net70)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -3522,7 +3522,7 @@ public static partial class Net70
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net70)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net70)");
                 }
                 return _SystemTransactions;
             }
@@ -3539,7 +3539,7 @@ public static partial class Net70
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net70)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net70)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -3556,7 +3556,7 @@ public static partial class Net70
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net70)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net70)");
                 }
                 return _SystemValueTuple;
             }
@@ -3573,7 +3573,7 @@ public static partial class Net70
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net70)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net70)");
                 }
                 return _SystemWeb;
             }
@@ -3590,7 +3590,7 @@ public static partial class Net70
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net70)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net70)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -3607,7 +3607,7 @@ public static partial class Net70
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net70)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net70)");
                 }
                 return _SystemWindows;
             }
@@ -3624,7 +3624,7 @@ public static partial class Net70
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net70)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net70)");
                 }
                 return _SystemXml;
             }
@@ -3641,7 +3641,7 @@ public static partial class Net70
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net70)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net70)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3658,7 +3658,7 @@ public static partial class Net70
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net70)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net70)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -3675,7 +3675,7 @@ public static partial class Net70
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net70)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net70)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3692,7 +3692,7 @@ public static partial class Net70
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net70)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net70)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -3709,7 +3709,7 @@ public static partial class Net70
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net70)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net70)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -3726,7 +3726,7 @@ public static partial class Net70
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net70)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net70)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -3743,7 +3743,7 @@ public static partial class Net70
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net70)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net70)");
                 }
                 return _SystemXmlXPath;
             }
@@ -3760,7 +3760,7 @@ public static partial class Net70
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net70)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net70)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -3777,7 +3777,7 @@ public static partial class Net70
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net70)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net70.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net70)");
                 }
                 return _WindowsBase;
             }

--- a/Src/Basic.Reference.Assemblies.Net80/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net80/Generated.cs
@@ -1023,7 +1023,7 @@ public static partial class Net80
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net80)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net80)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1040,7 +1040,7 @@ public static partial class Net80
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net80)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net80)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -1057,7 +1057,7 @@ public static partial class Net80
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net80)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net80)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1074,7 +1074,7 @@ public static partial class Net80
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net80)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net80)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1091,7 +1091,7 @@ public static partial class Net80
             {
                 if (_MicrosoftWin32Registry is null)
                 {
-                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Registry).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net80)");
+                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.Win32.Registry")).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net80)");
                 }
                 return _MicrosoftWin32Registry;
             }
@@ -1108,7 +1108,7 @@ public static partial class Net80
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net80)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net80)");
                 }
                 return _mscorlib;
             }
@@ -1125,7 +1125,7 @@ public static partial class Net80
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net80)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net80)");
                 }
                 return _netstandard;
             }
@@ -1142,7 +1142,7 @@ public static partial class Net80
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net80)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net80)");
                 }
                 return _SystemAppContext;
             }
@@ -1159,7 +1159,7 @@ public static partial class Net80
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net80)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net80)");
                 }
                 return _SystemBuffers;
             }
@@ -1176,7 +1176,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net80)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net80)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -1193,7 +1193,7 @@ public static partial class Net80
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net80)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net80)");
                 }
                 return _SystemCollections;
             }
@@ -1210,7 +1210,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net80)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net80)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -1227,7 +1227,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net80)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net80)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -1244,7 +1244,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net80)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net80)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -1261,7 +1261,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net80)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net80)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -1278,7 +1278,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net80)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net80)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1295,7 +1295,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net80)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net80)");
                 }
                 return _SystemComponentModel;
             }
@@ -1312,7 +1312,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net80)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net80)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -1329,7 +1329,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net80)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net80)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -1346,7 +1346,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net80)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net80)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -1363,7 +1363,7 @@ public static partial class Net80
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net80)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net80)");
                 }
                 return _SystemConfiguration;
             }
@@ -1380,7 +1380,7 @@ public static partial class Net80
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net80)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net80)");
                 }
                 return _SystemConsole;
             }
@@ -1397,7 +1397,7 @@ public static partial class Net80
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net80)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net80)");
                 }
                 return _SystemCore;
             }
@@ -1414,7 +1414,7 @@ public static partial class Net80
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net80)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net80)");
                 }
                 return _SystemDataCommon;
             }
@@ -1431,7 +1431,7 @@ public static partial class Net80
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net80)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net80)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1448,7 +1448,7 @@ public static partial class Net80
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net80)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net80)");
                 }
                 return _SystemData;
             }
@@ -1465,7 +1465,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net80)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net80)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1482,7 +1482,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net80)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net80)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1499,7 +1499,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net80)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net80)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -1516,7 +1516,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net80)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net80)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1533,7 +1533,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net80)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net80)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1550,7 +1550,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net80)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net80)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1567,7 +1567,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net80)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net80)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1584,7 +1584,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net80)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net80)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1601,7 +1601,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net80)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net80)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1618,7 +1618,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net80)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net80)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1635,7 +1635,7 @@ public static partial class Net80
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net80)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System")).GetReference(filePath: "System.dll", display: "System (net80)");
                 }
                 return _System;
             }
@@ -1652,7 +1652,7 @@ public static partial class Net80
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net80)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net80)");
                 }
                 return _SystemDrawing;
             }
@@ -1669,7 +1669,7 @@ public static partial class Net80
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net80)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net80)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1686,7 +1686,7 @@ public static partial class Net80
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net80)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net80)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1703,7 +1703,7 @@ public static partial class Net80
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net80)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net80)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -1720,7 +1720,7 @@ public static partial class Net80
             {
                 if (_SystemFormatsTar is null)
                 {
-                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsTar).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net80)");
+                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Formats.Tar")).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net80)");
                 }
                 return _SystemFormatsTar;
             }
@@ -1737,7 +1737,7 @@ public static partial class Net80
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net80)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net80)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1754,7 +1754,7 @@ public static partial class Net80
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net80)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net80)");
                 }
                 return _SystemGlobalization;
             }
@@ -1771,7 +1771,7 @@ public static partial class Net80
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net80)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net80)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1788,7 +1788,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net80)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net80)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -1805,7 +1805,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net80)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net80)");
                 }
                 return _SystemIOCompression;
             }
@@ -1822,7 +1822,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net80)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net80)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1839,7 +1839,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net80)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net80)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1856,7 +1856,7 @@ public static partial class Net80
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net80)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net80)");
                 }
                 return _SystemIO;
             }
@@ -1873,7 +1873,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemAccessControl is null)
                 {
-                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemAccessControl).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net80)");
+                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.AccessControl")).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net80)");
                 }
                 return _SystemIOFileSystemAccessControl;
             }
@@ -1890,7 +1890,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net80)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net80)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1907,7 +1907,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net80)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net80)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1924,7 +1924,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net80)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net80)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1941,7 +1941,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net80)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net80)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1958,7 +1958,7 @@ public static partial class Net80
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net80)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net80)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1975,7 +1975,7 @@ public static partial class Net80
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net80)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net80)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1992,7 +1992,7 @@ public static partial class Net80
             {
                 if (_SystemIOPipesAccessControl is null)
                 {
-                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipesAccessControl).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net80)");
+                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Pipes.AccessControl")).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net80)");
                 }
                 return _SystemIOPipesAccessControl;
             }
@@ -2009,7 +2009,7 @@ public static partial class Net80
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net80)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net80)");
                 }
                 return _SystemIOPipes;
             }
@@ -2026,7 +2026,7 @@ public static partial class Net80
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net80)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net80)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -2043,7 +2043,7 @@ public static partial class Net80
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net80)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net80)");
                 }
                 return _SystemLinq;
             }
@@ -2060,7 +2060,7 @@ public static partial class Net80
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net80)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net80)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -2077,7 +2077,7 @@ public static partial class Net80
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net80)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net80)");
                 }
                 return _SystemLinqParallel;
             }
@@ -2094,7 +2094,7 @@ public static partial class Net80
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net80)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net80)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -2111,7 +2111,7 @@ public static partial class Net80
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net80)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net80)");
                 }
                 return _SystemMemory;
             }
@@ -2128,7 +2128,7 @@ public static partial class Net80
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net80)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net80)");
                 }
                 return _SystemNet;
             }
@@ -2145,7 +2145,7 @@ public static partial class Net80
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net80)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net80)");
                 }
                 return _SystemNetHttp;
             }
@@ -2162,7 +2162,7 @@ public static partial class Net80
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net80)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net80)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -2179,7 +2179,7 @@ public static partial class Net80
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net80)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net80)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -2196,7 +2196,7 @@ public static partial class Net80
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net80)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net80)");
                 }
                 return _SystemNetMail;
             }
@@ -2213,7 +2213,7 @@ public static partial class Net80
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net80)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net80)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -2230,7 +2230,7 @@ public static partial class Net80
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net80)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net80)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -2247,7 +2247,7 @@ public static partial class Net80
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net80)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net80)");
                 }
                 return _SystemNetPing;
             }
@@ -2264,7 +2264,7 @@ public static partial class Net80
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net80)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net80)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -2281,7 +2281,7 @@ public static partial class Net80
             {
                 if (_SystemNetQuic is null)
                 {
-                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(Resources.SystemNetQuic).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net80)");
+                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Quic")).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net80)");
                 }
                 return _SystemNetQuic;
             }
@@ -2298,7 +2298,7 @@ public static partial class Net80
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net80)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net80)");
                 }
                 return _SystemNetRequests;
             }
@@ -2315,7 +2315,7 @@ public static partial class Net80
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net80)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net80)");
                 }
                 return _SystemNetSecurity;
             }
@@ -2332,7 +2332,7 @@ public static partial class Net80
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net80)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net80)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -2349,7 +2349,7 @@ public static partial class Net80
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net80)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net80)");
                 }
                 return _SystemNetSockets;
             }
@@ -2366,7 +2366,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net80)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net80)");
                 }
                 return _SystemNetWebClient;
             }
@@ -2383,7 +2383,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net80)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net80)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -2400,7 +2400,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net80)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net80)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -2417,7 +2417,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net80)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net80)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -2434,7 +2434,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net80)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net80)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -2451,7 +2451,7 @@ public static partial class Net80
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net80)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net80)");
                 }
                 return _SystemNumerics;
             }
@@ -2468,7 +2468,7 @@ public static partial class Net80
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net80)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net80)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2485,7 +2485,7 @@ public static partial class Net80
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net80)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net80)");
                 }
                 return _SystemObjectModel;
             }
@@ -2502,7 +2502,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net80)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net80)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -2519,7 +2519,7 @@ public static partial class Net80
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net80)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net80)");
                 }
                 return _SystemReflection;
             }
@@ -2536,7 +2536,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net80)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net80)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -2553,7 +2553,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net80)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net80)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -2570,7 +2570,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net80)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net80)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -2587,7 +2587,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net80)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net80)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -2604,7 +2604,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net80)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net80)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -2621,7 +2621,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net80)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net80)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -2638,7 +2638,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net80)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net80)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -2655,7 +2655,7 @@ public static partial class Net80
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net80)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net80)");
                 }
                 return _SystemResourcesReader;
             }
@@ -2672,7 +2672,7 @@ public static partial class Net80
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net80)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net80)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -2689,7 +2689,7 @@ public static partial class Net80
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net80)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net80)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -2706,7 +2706,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net80)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net80)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -2723,7 +2723,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net80)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net80)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -2740,7 +2740,7 @@ public static partial class Net80
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net80)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net80)");
                 }
                 return _SystemRuntime;
             }
@@ -2757,7 +2757,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net80)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net80)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -2774,7 +2774,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net80)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net80)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -2791,7 +2791,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net80)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net80)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -2808,7 +2808,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeInteropServicesJavaScript is null)
                 {
-                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesJavaScript).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net80)");
+                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.InteropServices.JavaScript")).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net80)");
                 }
                 return _SystemRuntimeInteropServicesJavaScript;
             }
@@ -2825,7 +2825,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net80)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net80)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -2842,7 +2842,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net80)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net80)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -2859,7 +2859,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net80)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net80)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -2876,7 +2876,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net80)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net80)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2893,7 +2893,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net80)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net80)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2910,7 +2910,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net80)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net80)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2927,7 +2927,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net80)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net80)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2944,7 +2944,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net80)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net80)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2961,7 +2961,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net80)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net80)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2978,7 +2978,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net80)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net80)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -2995,7 +2995,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net80)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net80)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -3012,7 +3012,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net80)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net80)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -3029,7 +3029,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyCng is null)
                 {
-                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCng).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net80)");
+                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Cng")).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net80)");
                 }
                 return _SystemSecurityCryptographyCng;
             }
@@ -3046,7 +3046,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net80)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net80)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -3063,7 +3063,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptography is null)
                 {
-                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptography).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net80)");
+                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography")).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net80)");
                 }
                 return _SystemSecurityCryptography;
             }
@@ -3080,7 +3080,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net80)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net80)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -3097,7 +3097,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyOpenSsl is null)
                 {
-                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyOpenSsl).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net80)");
+                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.OpenSsl")).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net80)");
                 }
                 return _SystemSecurityCryptographyOpenSsl;
             }
@@ -3114,7 +3114,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net80)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net80)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -3131,7 +3131,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net80)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net80)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -3148,7 +3148,7 @@ public static partial class Net80
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net80)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net80)");
                 }
                 return _SystemSecurity;
             }
@@ -3165,7 +3165,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net80)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net80)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -3182,7 +3182,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net80)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net80)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -3199,7 +3199,7 @@ public static partial class Net80
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net80)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net80)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -3216,7 +3216,7 @@ public static partial class Net80
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net80)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net80)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -3233,7 +3233,7 @@ public static partial class Net80
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net80)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net80)");
                 }
                 return _SystemServiceProcess;
             }
@@ -3250,7 +3250,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net80)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net80)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -3267,7 +3267,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net80)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net80)");
                 }
                 return _SystemTextEncoding;
             }
@@ -3284,7 +3284,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net80)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net80)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -3301,7 +3301,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net80)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net80)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -3318,7 +3318,7 @@ public static partial class Net80
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net80)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net80)");
                 }
                 return _SystemTextJson;
             }
@@ -3335,7 +3335,7 @@ public static partial class Net80
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net80)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net80)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -3352,7 +3352,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net80)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net80)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -3369,7 +3369,7 @@ public static partial class Net80
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net80)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net80)");
                 }
                 return _SystemThreading;
             }
@@ -3386,7 +3386,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net80)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net80)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -3403,7 +3403,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net80)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net80)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -3420,7 +3420,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net80)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net80)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -3437,7 +3437,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net80)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net80)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -3454,7 +3454,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net80)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net80)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -3471,7 +3471,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net80)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net80)");
                 }
                 return _SystemThreadingThread;
             }
@@ -3488,7 +3488,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net80)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net80)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -3505,7 +3505,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net80)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net80)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -3522,7 +3522,7 @@ public static partial class Net80
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net80)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net80)");
                 }
                 return _SystemTransactions;
             }
@@ -3539,7 +3539,7 @@ public static partial class Net80
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net80)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net80)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -3556,7 +3556,7 @@ public static partial class Net80
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net80)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net80)");
                 }
                 return _SystemValueTuple;
             }
@@ -3573,7 +3573,7 @@ public static partial class Net80
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net80)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net80)");
                 }
                 return _SystemWeb;
             }
@@ -3590,7 +3590,7 @@ public static partial class Net80
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net80)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net80)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -3607,7 +3607,7 @@ public static partial class Net80
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net80)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net80)");
                 }
                 return _SystemWindows;
             }
@@ -3624,7 +3624,7 @@ public static partial class Net80
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net80)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net80)");
                 }
                 return _SystemXml;
             }
@@ -3641,7 +3641,7 @@ public static partial class Net80
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net80)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net80)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3658,7 +3658,7 @@ public static partial class Net80
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net80)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net80)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -3675,7 +3675,7 @@ public static partial class Net80
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net80)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net80)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3692,7 +3692,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net80)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net80)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -3709,7 +3709,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net80)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net80)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -3726,7 +3726,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net80)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net80)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -3743,7 +3743,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net80)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net80)");
                 }
                 return _SystemXmlXPath;
             }
@@ -3760,7 +3760,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net80)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net80)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -3777,7 +3777,7 @@ public static partial class Net80
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net80)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net80)");
                 }
                 return _WindowsBase;
             }

--- a/Src/Basic.Reference.Assemblies.Net80Windows/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net80Windows/Generated.cs
@@ -327,7 +327,7 @@ public static partial class Net80Windows
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net80windows)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net80windows)");
                 }
                 return _Accessibility;
             }
@@ -344,7 +344,7 @@ public static partial class Net80Windows
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net80windows)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net80windows)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -361,7 +361,7 @@ public static partial class Net80Windows
             {
                 if (_MicrosoftVisualBasicForms is null)
                 {
-                    _MicrosoftVisualBasicForms = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicForms).GetReference(filePath: "Microsoft.VisualBasic.Forms.dll", display: "Microsoft.VisualBasic.Forms (net80windows)");
+                    _MicrosoftVisualBasicForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.Microsoft.VisualBasic.Forms")).GetReference(filePath: "Microsoft.VisualBasic.Forms.dll", display: "Microsoft.VisualBasic.Forms (net80windows)");
                 }
                 return _MicrosoftVisualBasicForms;
             }
@@ -378,7 +378,7 @@ public static partial class Net80Windows
             {
                 if (_MicrosoftWin32RegistryAccessControl is null)
                 {
-                    _MicrosoftWin32RegistryAccessControl = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32RegistryAccessControl).GetReference(filePath: "Microsoft.Win32.Registry.AccessControl.dll", display: "Microsoft.Win32.Registry.AccessControl (net80windows)");
+                    _MicrosoftWin32RegistryAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.Microsoft.Win32.Registry.AccessControl")).GetReference(filePath: "Microsoft.Win32.Registry.AccessControl.dll", display: "Microsoft.Win32.Registry.AccessControl (net80windows)");
                 }
                 return _MicrosoftWin32RegistryAccessControl;
             }
@@ -395,7 +395,7 @@ public static partial class Net80Windows
             {
                 if (_MicrosoftWin32SystemEvents is null)
                 {
-                    _MicrosoftWin32SystemEvents = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32SystemEvents).GetReference(filePath: "Microsoft.Win32.SystemEvents.dll", display: "Microsoft.Win32.SystemEvents (net80windows)");
+                    _MicrosoftWin32SystemEvents = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.Microsoft.Win32.SystemEvents")).GetReference(filePath: "Microsoft.Win32.SystemEvents.dll", display: "Microsoft.Win32.SystemEvents (net80windows)");
                 }
                 return _MicrosoftWin32SystemEvents;
             }
@@ -412,7 +412,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationCore is null)
                 {
-                    _PresentationCore = AssemblyMetadata.CreateFromImage(Resources.PresentationCore).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net80windows)");
+                    _PresentationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationCore")).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net80windows)");
                 }
                 return _PresentationCore;
             }
@@ -429,7 +429,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationFrameworkAero is null)
                 {
-                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net80windows)");
+                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationFramework.Aero")).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net80windows)");
                 }
                 return _PresentationFrameworkAero;
             }
@@ -446,7 +446,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationFrameworkAero2 is null)
                 {
-                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero2).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net80windows)");
+                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationFramework.Aero2")).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net80windows)");
                 }
                 return _PresentationFrameworkAero2;
             }
@@ -463,7 +463,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationFrameworkAeroLite is null)
                 {
-                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAeroLite).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net80windows)");
+                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationFramework.AeroLite")).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net80windows)");
                 }
                 return _PresentationFrameworkAeroLite;
             }
@@ -480,7 +480,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationFrameworkClassic is null)
                 {
-                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkClassic).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net80windows)");
+                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationFramework.Classic")).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net80windows)");
                 }
                 return _PresentationFrameworkClassic;
             }
@@ -497,7 +497,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationFramework is null)
                 {
-                    _PresentationFramework = AssemblyMetadata.CreateFromImage(Resources.PresentationFramework).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net80windows)");
+                    _PresentationFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationFramework")).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net80windows)");
                 }
                 return _PresentationFramework;
             }
@@ -514,7 +514,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationFrameworkLuna is null)
                 {
-                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkLuna).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net80windows)");
+                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationFramework.Luna")).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net80windows)");
                 }
                 return _PresentationFrameworkLuna;
             }
@@ -531,7 +531,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationFrameworkRoyale is null)
                 {
-                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkRoyale).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net80windows)");
+                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationFramework.Royale")).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net80windows)");
                 }
                 return _PresentationFrameworkRoyale;
             }
@@ -548,7 +548,7 @@ public static partial class Net80Windows
             {
                 if (_PresentationUI is null)
                 {
-                    _PresentationUI = AssemblyMetadata.CreateFromImage(Resources.PresentationUI).GetReference(filePath: "PresentationUI.dll", display: "PresentationUI (net80windows)");
+                    _PresentationUI = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.PresentationUI")).GetReference(filePath: "PresentationUI.dll", display: "PresentationUI (net80windows)");
                 }
                 return _PresentationUI;
             }
@@ -565,7 +565,7 @@ public static partial class Net80Windows
             {
                 if (_ReachFramework is null)
                 {
-                    _ReachFramework = AssemblyMetadata.CreateFromImage(Resources.ReachFramework).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net80windows)");
+                    _ReachFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.ReachFramework")).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net80windows)");
                 }
                 return _ReachFramework;
             }
@@ -582,7 +582,7 @@ public static partial class Net80Windows
             {
                 if (_SystemCodeDom is null)
                 {
-                    _SystemCodeDom = AssemblyMetadata.CreateFromImage(Resources.SystemCodeDom).GetReference(filePath: "System.CodeDom.dll", display: "System.CodeDom (net80windows)");
+                    _SystemCodeDom = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.CodeDom")).GetReference(filePath: "System.CodeDom.dll", display: "System.CodeDom (net80windows)");
                 }
                 return _SystemCodeDom;
             }
@@ -599,7 +599,7 @@ public static partial class Net80Windows
             {
                 if (_SystemConfigurationConfigurationManager is null)
                 {
-                    _SystemConfigurationConfigurationManager = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationConfigurationManager).GetReference(filePath: "System.Configuration.ConfigurationManager.dll", display: "System.Configuration.ConfigurationManager (net80windows)");
+                    _SystemConfigurationConfigurationManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Configuration.ConfigurationManager")).GetReference(filePath: "System.Configuration.ConfigurationManager.dll", display: "System.Configuration.ConfigurationManager (net80windows)");
                 }
                 return _SystemConfigurationConfigurationManager;
             }
@@ -616,7 +616,7 @@ public static partial class Net80Windows
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net80windows)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net80windows)");
                 }
                 return _SystemDesign;
             }
@@ -633,7 +633,7 @@ public static partial class Net80Windows
             {
                 if (_SystemDiagnosticsEventLog is null)
                 {
-                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsEventLog).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (net80windows)");
+                    _SystemDiagnosticsEventLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Diagnostics.EventLog")).GetReference(filePath: "System.Diagnostics.EventLog.dll", display: "System.Diagnostics.EventLog (net80windows)");
                 }
                 return _SystemDiagnosticsEventLog;
             }
@@ -650,7 +650,7 @@ public static partial class Net80Windows
             {
                 if (_SystemDiagnosticsPerformanceCounter is null)
                 {
-                    _SystemDiagnosticsPerformanceCounter = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsPerformanceCounter).GetReference(filePath: "System.Diagnostics.PerformanceCounter.dll", display: "System.Diagnostics.PerformanceCounter (net80windows)");
+                    _SystemDiagnosticsPerformanceCounter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Diagnostics.PerformanceCounter")).GetReference(filePath: "System.Diagnostics.PerformanceCounter.dll", display: "System.Diagnostics.PerformanceCounter (net80windows)");
                 }
                 return _SystemDiagnosticsPerformanceCounter;
             }
@@ -667,7 +667,7 @@ public static partial class Net80Windows
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net80windows)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net80windows)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -684,7 +684,7 @@ public static partial class Net80Windows
             {
                 if (_SystemDrawingCommon is null)
                 {
-                    _SystemDrawingCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingCommon).GetReference(filePath: "System.Drawing.Common.dll", display: "System.Drawing.Common (net80windows)");
+                    _SystemDrawingCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Drawing.Common")).GetReference(filePath: "System.Drawing.Common.dll", display: "System.Drawing.Common (net80windows)");
                 }
                 return _SystemDrawingCommon;
             }
@@ -701,7 +701,7 @@ public static partial class Net80Windows
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net80windows)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net80windows)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -718,7 +718,7 @@ public static partial class Net80Windows
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net80windows)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net80windows)");
                 }
                 return _SystemDrawing;
             }
@@ -735,7 +735,7 @@ public static partial class Net80Windows
             {
                 if (_SystemIOPackaging is null)
                 {
-                    _SystemIOPackaging = AssemblyMetadata.CreateFromImage(Resources.SystemIOPackaging).GetReference(filePath: "System.IO.Packaging.dll", display: "System.IO.Packaging (net80windows)");
+                    _SystemIOPackaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.IO.Packaging")).GetReference(filePath: "System.IO.Packaging.dll", display: "System.IO.Packaging (net80windows)");
                 }
                 return _SystemIOPackaging;
             }
@@ -752,7 +752,7 @@ public static partial class Net80Windows
             {
                 if (_SystemPrinting is null)
                 {
-                    _SystemPrinting = AssemblyMetadata.CreateFromImage(Resources.SystemPrinting).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net80windows)");
+                    _SystemPrinting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Printing")).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net80windows)");
                 }
                 return _SystemPrinting;
             }
@@ -769,7 +769,7 @@ public static partial class Net80Windows
             {
                 if (_SystemResourcesExtensions is null)
                 {
-                    _SystemResourcesExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesExtensions).GetReference(filePath: "System.Resources.Extensions.dll", display: "System.Resources.Extensions (net80windows)");
+                    _SystemResourcesExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Resources.Extensions")).GetReference(filePath: "System.Resources.Extensions.dll", display: "System.Resources.Extensions (net80windows)");
                 }
                 return _SystemResourcesExtensions;
             }
@@ -786,7 +786,7 @@ public static partial class Net80Windows
             {
                 if (_SystemSecurityCryptographyPkcs is null)
                 {
-                    _SystemSecurityCryptographyPkcs = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPkcs).GetReference(filePath: "System.Security.Cryptography.Pkcs.dll", display: "System.Security.Cryptography.Pkcs (net80windows)");
+                    _SystemSecurityCryptographyPkcs = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Security.Cryptography.Pkcs")).GetReference(filePath: "System.Security.Cryptography.Pkcs.dll", display: "System.Security.Cryptography.Pkcs (net80windows)");
                 }
                 return _SystemSecurityCryptographyPkcs;
             }
@@ -803,7 +803,7 @@ public static partial class Net80Windows
             {
                 if (_SystemSecurityCryptographyProtectedData is null)
                 {
-                    _SystemSecurityCryptographyProtectedData = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyProtectedData).GetReference(filePath: "System.Security.Cryptography.ProtectedData.dll", display: "System.Security.Cryptography.ProtectedData (net80windows)");
+                    _SystemSecurityCryptographyProtectedData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Security.Cryptography.ProtectedData")).GetReference(filePath: "System.Security.Cryptography.ProtectedData.dll", display: "System.Security.Cryptography.ProtectedData (net80windows)");
                 }
                 return _SystemSecurityCryptographyProtectedData;
             }
@@ -820,7 +820,7 @@ public static partial class Net80Windows
             {
                 if (_SystemSecurityCryptographyXml is null)
                 {
-                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyXml).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (net80windows)");
+                    _SystemSecurityCryptographyXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Security.Cryptography.Xml")).GetReference(filePath: "System.Security.Cryptography.Xml.dll", display: "System.Security.Cryptography.Xml (net80windows)");
                 }
                 return _SystemSecurityCryptographyXml;
             }
@@ -837,7 +837,7 @@ public static partial class Net80Windows
             {
                 if (_SystemSecurityPermissions is null)
                 {
-                    _SystemSecurityPermissions = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPermissions).GetReference(filePath: "System.Security.Permissions.dll", display: "System.Security.Permissions (net80windows)");
+                    _SystemSecurityPermissions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Security.Permissions")).GetReference(filePath: "System.Security.Permissions.dll", display: "System.Security.Permissions (net80windows)");
                 }
                 return _SystemSecurityPermissions;
             }
@@ -854,7 +854,7 @@ public static partial class Net80Windows
             {
                 if (_SystemThreadingAccessControl is null)
                 {
-                    _SystemThreadingAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingAccessControl).GetReference(filePath: "System.Threading.AccessControl.dll", display: "System.Threading.AccessControl (net80windows)");
+                    _SystemThreadingAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Threading.AccessControl")).GetReference(filePath: "System.Threading.AccessControl.dll", display: "System.Threading.AccessControl (net80windows)");
                 }
                 return _SystemThreadingAccessControl;
             }
@@ -871,7 +871,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsControlsRibbon is null)
                 {
-                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsControlsRibbon).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net80windows)");
+                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Controls.Ribbon")).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net80windows)");
                 }
                 return _SystemWindowsControlsRibbon;
             }
@@ -888,7 +888,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsExtensions is null)
                 {
-                    _SystemWindowsExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsExtensions).GetReference(filePath: "System.Windows.Extensions.dll", display: "System.Windows.Extensions (net80windows)");
+                    _SystemWindowsExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Extensions")).GetReference(filePath: "System.Windows.Extensions.dll", display: "System.Windows.Extensions (net80windows)");
                 }
                 return _SystemWindowsExtensions;
             }
@@ -905,7 +905,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsFormsDesign is null)
                 {
-                    _SystemWindowsFormsDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDesign).GetReference(filePath: "System.Windows.Forms.Design.dll", display: "System.Windows.Forms.Design (net80windows)");
+                    _SystemWindowsFormsDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Forms.Design")).GetReference(filePath: "System.Windows.Forms.Design.dll", display: "System.Windows.Forms.Design (net80windows)");
                 }
                 return _SystemWindowsFormsDesign;
             }
@@ -922,7 +922,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsFormsDesignEditors is null)
                 {
-                    _SystemWindowsFormsDesignEditors = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDesignEditors).GetReference(filePath: "System.Windows.Forms.Design.Editors.dll", display: "System.Windows.Forms.Design.Editors (net80windows)");
+                    _SystemWindowsFormsDesignEditors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Forms.Design.Editors")).GetReference(filePath: "System.Windows.Forms.Design.Editors.dll", display: "System.Windows.Forms.Design.Editors (net80windows)");
                 }
                 return _SystemWindowsFormsDesignEditors;
             }
@@ -939,7 +939,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net80windows)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net80windows)");
                 }
                 return _SystemWindowsForms;
             }
@@ -956,7 +956,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsFormsPrimitives is null)
                 {
-                    _SystemWindowsFormsPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsPrimitives).GetReference(filePath: "System.Windows.Forms.Primitives.dll", display: "System.Windows.Forms.Primitives (net80windows)");
+                    _SystemWindowsFormsPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Forms.Primitives")).GetReference(filePath: "System.Windows.Forms.Primitives.dll", display: "System.Windows.Forms.Primitives (net80windows)");
                 }
                 return _SystemWindowsFormsPrimitives;
             }
@@ -973,7 +973,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsInputManipulations is null)
                 {
-                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsInputManipulations).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net80windows)");
+                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Input.Manipulations")).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net80windows)");
                 }
                 return _SystemWindowsInputManipulations;
             }
@@ -990,7 +990,7 @@ public static partial class Net80Windows
             {
                 if (_SystemWindowsPresentation is null)
                 {
-                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsPresentation).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net80windows)");
+                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Windows.Presentation")).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net80windows)");
                 }
                 return _SystemWindowsPresentation;
             }
@@ -1007,7 +1007,7 @@ public static partial class Net80Windows
             {
                 if (_SystemXaml is null)
                 {
-                    _SystemXaml = AssemblyMetadata.CreateFromImage(Resources.SystemXaml).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net80windows)");
+                    _SystemXaml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.System.Xaml")).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net80windows)");
                 }
                 return _SystemXaml;
             }
@@ -1024,7 +1024,7 @@ public static partial class Net80Windows
             {
                 if (_UIAutomationClient is null)
                 {
-                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClient).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net80windows)");
+                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.UIAutomationClient")).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net80windows)");
                 }
                 return _UIAutomationClient;
             }
@@ -1041,7 +1041,7 @@ public static partial class Net80Windows
             {
                 if (_UIAutomationClientSideProviders is null)
                 {
-                    _UIAutomationClientSideProviders = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClientSideProviders).GetReference(filePath: "UIAutomationClientSideProviders.dll", display: "UIAutomationClientSideProviders (net80windows)");
+                    _UIAutomationClientSideProviders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.UIAutomationClientSideProviders")).GetReference(filePath: "UIAutomationClientSideProviders.dll", display: "UIAutomationClientSideProviders (net80windows)");
                 }
                 return _UIAutomationClientSideProviders;
             }
@@ -1058,7 +1058,7 @@ public static partial class Net80Windows
             {
                 if (_UIAutomationProvider is null)
                 {
-                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(Resources.UIAutomationProvider).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net80windows)");
+                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.UIAutomationProvider")).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net80windows)");
                 }
                 return _UIAutomationProvider;
             }
@@ -1075,7 +1075,7 @@ public static partial class Net80Windows
             {
                 if (_UIAutomationTypes is null)
                 {
-                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(Resources.UIAutomationTypes).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net80windows)");
+                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.UIAutomationTypes")).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net80windows)");
                 }
                 return _UIAutomationTypes;
             }
@@ -1092,7 +1092,7 @@ public static partial class Net80Windows
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net80windows)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net80windows)");
                 }
                 return _WindowsBase;
             }
@@ -1109,7 +1109,7 @@ public static partial class Net80Windows
             {
                 if (_WindowsFormsIntegration is null)
                 {
-                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(Resources.WindowsFormsIntegration).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net80windows)");
+                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80windows.WindowsFormsIntegration")).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net80windows)");
                 }
                 return _WindowsFormsIntegration;
             }

--- a/Src/Basic.Reference.Assemblies.Net90/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.Net90/Generated.cs
@@ -1029,7 +1029,7 @@ public static partial class Net90
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net90)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net90)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1046,7 +1046,7 @@ public static partial class Net90
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net90)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net90)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -1063,7 +1063,7 @@ public static partial class Net90
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net90)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net90)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1080,7 +1080,7 @@ public static partial class Net90
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net90)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net90)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1097,7 +1097,7 @@ public static partial class Net90
             {
                 if (_MicrosoftWin32Registry is null)
                 {
-                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Registry).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net90)");
+                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.Microsoft.Win32.Registry")).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net90)");
                 }
                 return _MicrosoftWin32Registry;
             }
@@ -1114,7 +1114,7 @@ public static partial class Net90
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net90)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net90)");
                 }
                 return _mscorlib;
             }
@@ -1131,7 +1131,7 @@ public static partial class Net90
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net90)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net90)");
                 }
                 return _netstandard;
             }
@@ -1148,7 +1148,7 @@ public static partial class Net90
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net90)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net90)");
                 }
                 return _SystemAppContext;
             }
@@ -1165,7 +1165,7 @@ public static partial class Net90
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net90)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net90)");
                 }
                 return _SystemBuffers;
             }
@@ -1182,7 +1182,7 @@ public static partial class Net90
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net90)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net90)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -1199,7 +1199,7 @@ public static partial class Net90
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net90)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net90)");
                 }
                 return _SystemCollections;
             }
@@ -1216,7 +1216,7 @@ public static partial class Net90
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net90)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net90)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -1233,7 +1233,7 @@ public static partial class Net90
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net90)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net90)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -1250,7 +1250,7 @@ public static partial class Net90
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net90)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net90)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -1267,7 +1267,7 @@ public static partial class Net90
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net90)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net90)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -1284,7 +1284,7 @@ public static partial class Net90
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net90)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net90)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1301,7 +1301,7 @@ public static partial class Net90
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net90)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net90)");
                 }
                 return _SystemComponentModel;
             }
@@ -1318,7 +1318,7 @@ public static partial class Net90
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net90)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net90)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -1335,7 +1335,7 @@ public static partial class Net90
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net90)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net90)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -1352,7 +1352,7 @@ public static partial class Net90
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net90)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net90)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -1369,7 +1369,7 @@ public static partial class Net90
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net90)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net90)");
                 }
                 return _SystemConfiguration;
             }
@@ -1386,7 +1386,7 @@ public static partial class Net90
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net90)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net90)");
                 }
                 return _SystemConsole;
             }
@@ -1403,7 +1403,7 @@ public static partial class Net90
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net90)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net90)");
                 }
                 return _SystemCore;
             }
@@ -1420,7 +1420,7 @@ public static partial class Net90
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net90)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net90)");
                 }
                 return _SystemDataCommon;
             }
@@ -1437,7 +1437,7 @@ public static partial class Net90
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net90)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net90)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1454,7 +1454,7 @@ public static partial class Net90
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net90)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net90)");
                 }
                 return _SystemData;
             }
@@ -1471,7 +1471,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net90)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net90)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1488,7 +1488,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net90)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net90)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1505,7 +1505,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net90)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net90)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -1522,7 +1522,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net90)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net90)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1539,7 +1539,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net90)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net90)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1556,7 +1556,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net90)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net90)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1573,7 +1573,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net90)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net90)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1590,7 +1590,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net90)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net90)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1607,7 +1607,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net90)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net90)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1624,7 +1624,7 @@ public static partial class Net90
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net90)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net90)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1641,7 +1641,7 @@ public static partial class Net90
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net90)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System")).GetReference(filePath: "System.dll", display: "System (net90)");
                 }
                 return _System;
             }
@@ -1658,7 +1658,7 @@ public static partial class Net90
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net90)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net90)");
                 }
                 return _SystemDrawing;
             }
@@ -1675,7 +1675,7 @@ public static partial class Net90
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net90)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net90)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1692,7 +1692,7 @@ public static partial class Net90
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net90)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net90)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1709,7 +1709,7 @@ public static partial class Net90
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net90)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net90)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -1726,7 +1726,7 @@ public static partial class Net90
             {
                 if (_SystemFormatsTar is null)
                 {
-                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsTar).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net90)");
+                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Formats.Tar")).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net90)");
                 }
                 return _SystemFormatsTar;
             }
@@ -1743,7 +1743,7 @@ public static partial class Net90
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net90)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net90)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1760,7 +1760,7 @@ public static partial class Net90
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net90)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net90)");
                 }
                 return _SystemGlobalization;
             }
@@ -1777,7 +1777,7 @@ public static partial class Net90
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net90)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net90)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1794,7 +1794,7 @@ public static partial class Net90
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net90)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net90)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -1811,7 +1811,7 @@ public static partial class Net90
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net90)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net90)");
                 }
                 return _SystemIOCompression;
             }
@@ -1828,7 +1828,7 @@ public static partial class Net90
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net90)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net90)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1845,7 +1845,7 @@ public static partial class Net90
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net90)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net90)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1862,7 +1862,7 @@ public static partial class Net90
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net90)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net90)");
                 }
                 return _SystemIO;
             }
@@ -1879,7 +1879,7 @@ public static partial class Net90
             {
                 if (_SystemIOFileSystemAccessControl is null)
                 {
-                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemAccessControl).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net90)");
+                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.FileSystem.AccessControl")).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net90)");
                 }
                 return _SystemIOFileSystemAccessControl;
             }
@@ -1896,7 +1896,7 @@ public static partial class Net90
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net90)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net90)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1913,7 +1913,7 @@ public static partial class Net90
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net90)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net90)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1930,7 +1930,7 @@ public static partial class Net90
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net90)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net90)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1947,7 +1947,7 @@ public static partial class Net90
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net90)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net90)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1964,7 +1964,7 @@ public static partial class Net90
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net90)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net90)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1981,7 +1981,7 @@ public static partial class Net90
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net90)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net90)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1998,7 +1998,7 @@ public static partial class Net90
             {
                 if (_SystemIOPipelines is null)
                 {
-                    _SystemIOPipelines = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipelines).GetReference(filePath: "System.IO.Pipelines.dll", display: "System.IO.Pipelines (net90)");
+                    _SystemIOPipelines = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.Pipelines")).GetReference(filePath: "System.IO.Pipelines.dll", display: "System.IO.Pipelines (net90)");
                 }
                 return _SystemIOPipelines;
             }
@@ -2015,7 +2015,7 @@ public static partial class Net90
             {
                 if (_SystemIOPipesAccessControl is null)
                 {
-                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipesAccessControl).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net90)");
+                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.Pipes.AccessControl")).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net90)");
                 }
                 return _SystemIOPipesAccessControl;
             }
@@ -2032,7 +2032,7 @@ public static partial class Net90
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net90)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net90)");
                 }
                 return _SystemIOPipes;
             }
@@ -2049,7 +2049,7 @@ public static partial class Net90
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net90)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net90)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -2066,7 +2066,7 @@ public static partial class Net90
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net90)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net90)");
                 }
                 return _SystemLinq;
             }
@@ -2083,7 +2083,7 @@ public static partial class Net90
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net90)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net90)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -2100,7 +2100,7 @@ public static partial class Net90
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net90)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net90)");
                 }
                 return _SystemLinqParallel;
             }
@@ -2117,7 +2117,7 @@ public static partial class Net90
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net90)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net90)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -2134,7 +2134,7 @@ public static partial class Net90
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net90)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net90)");
                 }
                 return _SystemMemory;
             }
@@ -2151,7 +2151,7 @@ public static partial class Net90
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net90)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net90)");
                 }
                 return _SystemNet;
             }
@@ -2168,7 +2168,7 @@ public static partial class Net90
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net90)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net90)");
                 }
                 return _SystemNetHttp;
             }
@@ -2185,7 +2185,7 @@ public static partial class Net90
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net90)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net90)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -2202,7 +2202,7 @@ public static partial class Net90
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net90)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net90)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -2219,7 +2219,7 @@ public static partial class Net90
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net90)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net90)");
                 }
                 return _SystemNetMail;
             }
@@ -2236,7 +2236,7 @@ public static partial class Net90
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net90)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net90)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -2253,7 +2253,7 @@ public static partial class Net90
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net90)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net90)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -2270,7 +2270,7 @@ public static partial class Net90
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net90)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net90)");
                 }
                 return _SystemNetPing;
             }
@@ -2287,7 +2287,7 @@ public static partial class Net90
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net90)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net90)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -2304,7 +2304,7 @@ public static partial class Net90
             {
                 if (_SystemNetQuic is null)
                 {
-                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(Resources.SystemNetQuic).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net90)");
+                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Quic")).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net90)");
                 }
                 return _SystemNetQuic;
             }
@@ -2321,7 +2321,7 @@ public static partial class Net90
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net90)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net90)");
                 }
                 return _SystemNetRequests;
             }
@@ -2338,7 +2338,7 @@ public static partial class Net90
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net90)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net90)");
                 }
                 return _SystemNetSecurity;
             }
@@ -2355,7 +2355,7 @@ public static partial class Net90
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net90)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net90)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -2372,7 +2372,7 @@ public static partial class Net90
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net90)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net90)");
                 }
                 return _SystemNetSockets;
             }
@@ -2389,7 +2389,7 @@ public static partial class Net90
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net90)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net90)");
                 }
                 return _SystemNetWebClient;
             }
@@ -2406,7 +2406,7 @@ public static partial class Net90
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net90)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net90)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -2423,7 +2423,7 @@ public static partial class Net90
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net90)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net90)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -2440,7 +2440,7 @@ public static partial class Net90
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net90)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net90)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -2457,7 +2457,7 @@ public static partial class Net90
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net90)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net90)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -2474,7 +2474,7 @@ public static partial class Net90
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net90)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net90)");
                 }
                 return _SystemNumerics;
             }
@@ -2491,7 +2491,7 @@ public static partial class Net90
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net90)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net90)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2508,7 +2508,7 @@ public static partial class Net90
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net90)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net90)");
                 }
                 return _SystemObjectModel;
             }
@@ -2525,7 +2525,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net90)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net90)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -2542,7 +2542,7 @@ public static partial class Net90
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net90)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net90)");
                 }
                 return _SystemReflection;
             }
@@ -2559,7 +2559,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net90)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net90)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -2576,7 +2576,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net90)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net90)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -2593,7 +2593,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net90)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net90)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -2610,7 +2610,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net90)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net90)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -2627,7 +2627,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net90)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net90)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -2644,7 +2644,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net90)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net90)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -2661,7 +2661,7 @@ public static partial class Net90
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net90)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net90)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -2678,7 +2678,7 @@ public static partial class Net90
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net90)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net90)");
                 }
                 return _SystemResourcesReader;
             }
@@ -2695,7 +2695,7 @@ public static partial class Net90
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net90)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net90)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -2712,7 +2712,7 @@ public static partial class Net90
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net90)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net90)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -2729,7 +2729,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net90)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net90)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -2746,7 +2746,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net90)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net90)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -2763,7 +2763,7 @@ public static partial class Net90
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net90)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net90)");
                 }
                 return _SystemRuntime;
             }
@@ -2780,7 +2780,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net90)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net90)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -2797,7 +2797,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net90)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net90)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -2814,7 +2814,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net90)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net90)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -2831,7 +2831,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeInteropServicesJavaScript is null)
                 {
-                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesJavaScript).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net90)");
+                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.InteropServices.JavaScript")).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net90)");
                 }
                 return _SystemRuntimeInteropServicesJavaScript;
             }
@@ -2848,7 +2848,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net90)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net90)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -2865,7 +2865,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net90)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net90)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -2882,7 +2882,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net90)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net90)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -2899,7 +2899,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net90)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net90)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2916,7 +2916,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net90)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net90)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2933,7 +2933,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net90)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net90)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2950,7 +2950,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net90)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net90)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2967,7 +2967,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net90)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net90)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2984,7 +2984,7 @@ public static partial class Net90
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net90)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net90)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -3001,7 +3001,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net90)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net90)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -3018,7 +3018,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net90)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net90)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -3035,7 +3035,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net90)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net90)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -3052,7 +3052,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptographyCng is null)
                 {
-                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCng).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net90)");
+                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography.Cng")).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net90)");
                 }
                 return _SystemSecurityCryptographyCng;
             }
@@ -3069,7 +3069,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net90)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net90)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -3086,7 +3086,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptography is null)
                 {
-                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptography).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net90)");
+                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography")).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net90)");
                 }
                 return _SystemSecurityCryptography;
             }
@@ -3103,7 +3103,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net90)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net90)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -3120,7 +3120,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptographyOpenSsl is null)
                 {
-                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyOpenSsl).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net90)");
+                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography.OpenSsl")).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net90)");
                 }
                 return _SystemSecurityCryptographyOpenSsl;
             }
@@ -3137,7 +3137,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net90)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net90)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -3154,7 +3154,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net90)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net90)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -3171,7 +3171,7 @@ public static partial class Net90
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net90)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net90)");
                 }
                 return _SystemSecurity;
             }
@@ -3188,7 +3188,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net90)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net90)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -3205,7 +3205,7 @@ public static partial class Net90
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net90)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net90)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -3222,7 +3222,7 @@ public static partial class Net90
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net90)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net90)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -3239,7 +3239,7 @@ public static partial class Net90
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net90)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net90)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -3256,7 +3256,7 @@ public static partial class Net90
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net90)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net90)");
                 }
                 return _SystemServiceProcess;
             }
@@ -3273,7 +3273,7 @@ public static partial class Net90
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net90)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net90)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -3290,7 +3290,7 @@ public static partial class Net90
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net90)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net90)");
                 }
                 return _SystemTextEncoding;
             }
@@ -3307,7 +3307,7 @@ public static partial class Net90
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net90)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net90)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -3324,7 +3324,7 @@ public static partial class Net90
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net90)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net90)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -3341,7 +3341,7 @@ public static partial class Net90
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net90)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net90)");
                 }
                 return _SystemTextJson;
             }
@@ -3358,7 +3358,7 @@ public static partial class Net90
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net90)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net90)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -3375,7 +3375,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net90)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net90)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -3392,7 +3392,7 @@ public static partial class Net90
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net90)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net90)");
                 }
                 return _SystemThreading;
             }
@@ -3409,7 +3409,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net90)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net90)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -3426,7 +3426,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net90)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net90)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -3443,7 +3443,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net90)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net90)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -3460,7 +3460,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net90)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net90)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -3477,7 +3477,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net90)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net90)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -3494,7 +3494,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net90)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net90)");
                 }
                 return _SystemThreadingThread;
             }
@@ -3511,7 +3511,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net90)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net90)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -3528,7 +3528,7 @@ public static partial class Net90
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net90)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net90)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -3545,7 +3545,7 @@ public static partial class Net90
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net90)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net90)");
                 }
                 return _SystemTransactions;
             }
@@ -3562,7 +3562,7 @@ public static partial class Net90
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net90)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net90)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -3579,7 +3579,7 @@ public static partial class Net90
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net90)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net90)");
                 }
                 return _SystemValueTuple;
             }
@@ -3596,7 +3596,7 @@ public static partial class Net90
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net90)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net90)");
                 }
                 return _SystemWeb;
             }
@@ -3613,7 +3613,7 @@ public static partial class Net90
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net90)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net90)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -3630,7 +3630,7 @@ public static partial class Net90
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net90)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net90)");
                 }
                 return _SystemWindows;
             }
@@ -3647,7 +3647,7 @@ public static partial class Net90
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net90)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net90)");
                 }
                 return _SystemXml;
             }
@@ -3664,7 +3664,7 @@ public static partial class Net90
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net90)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net90)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3681,7 +3681,7 @@ public static partial class Net90
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net90)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net90)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -3698,7 +3698,7 @@ public static partial class Net90
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net90)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net90)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3715,7 +3715,7 @@ public static partial class Net90
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net90)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net90)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -3732,7 +3732,7 @@ public static partial class Net90
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net90)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net90)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -3749,7 +3749,7 @@ public static partial class Net90
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net90)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net90)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -3766,7 +3766,7 @@ public static partial class Net90
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net90)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net90)");
                 }
                 return _SystemXmlXPath;
             }
@@ -3783,7 +3783,7 @@ public static partial class Net90
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net90)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net90)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -3800,7 +3800,7 @@ public static partial class Net90
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net90)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net90.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net90)");
                 }
                 return _WindowsBase;
             }

--- a/Src/Basic.Reference.Assemblies.NetCoreApp31/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetCoreApp31/Generated.cs
@@ -951,7 +951,7 @@ public static partial class NetCoreApp31
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netcoreapp31)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netcoreapp31)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -968,7 +968,7 @@ public static partial class NetCoreApp31
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (netcoreapp31)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (netcoreapp31)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -985,7 +985,7 @@ public static partial class NetCoreApp31
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netcoreapp31)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netcoreapp31)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1002,7 +1002,7 @@ public static partial class NetCoreApp31
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netcoreapp31)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netcoreapp31)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1019,7 +1019,7 @@ public static partial class NetCoreApp31
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (netcoreapp31)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (netcoreapp31)");
                 }
                 return _mscorlib;
             }
@@ -1036,7 +1036,7 @@ public static partial class NetCoreApp31
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (netcoreapp31)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (netcoreapp31)");
                 }
                 return _netstandard;
             }
@@ -1053,7 +1053,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netcoreapp31)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netcoreapp31)");
                 }
                 return _SystemAppContext;
             }
@@ -1070,7 +1070,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (netcoreapp31)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (netcoreapp31)");
                 }
                 return _SystemBuffers;
             }
@@ -1087,7 +1087,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netcoreapp31)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netcoreapp31)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -1104,7 +1104,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netcoreapp31)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netcoreapp31)");
                 }
                 return _SystemCollections;
             }
@@ -1121,7 +1121,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (netcoreapp31)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (netcoreapp31)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -1138,7 +1138,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (netcoreapp31)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (netcoreapp31)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -1155,7 +1155,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (netcoreapp31)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (netcoreapp31)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -1172,7 +1172,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (netcoreapp31)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (netcoreapp31)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -1189,7 +1189,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (netcoreapp31)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (netcoreapp31)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1206,7 +1206,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (netcoreapp31)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (netcoreapp31)");
                 }
                 return _SystemComponentModel;
             }
@@ -1223,7 +1223,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (netcoreapp31)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (netcoreapp31)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -1240,7 +1240,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (netcoreapp31)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (netcoreapp31)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -1257,7 +1257,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (netcoreapp31)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (netcoreapp31)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -1274,7 +1274,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (netcoreapp31)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (netcoreapp31)");
                 }
                 return _SystemConfiguration;
             }
@@ -1291,7 +1291,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (netcoreapp31)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (netcoreapp31)");
                 }
                 return _SystemConsole;
             }
@@ -1308,7 +1308,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (netcoreapp31)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (netcoreapp31)");
                 }
                 return _SystemCore;
             }
@@ -1325,7 +1325,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (netcoreapp31)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (netcoreapp31)");
                 }
                 return _SystemDataCommon;
             }
@@ -1342,7 +1342,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (netcoreapp31)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (netcoreapp31)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1359,7 +1359,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (netcoreapp31)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (netcoreapp31)");
                 }
                 return _SystemData;
             }
@@ -1376,7 +1376,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (netcoreapp31)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (netcoreapp31)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1393,7 +1393,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netcoreapp31)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netcoreapp31)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1410,7 +1410,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (netcoreapp31)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (netcoreapp31)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -1427,7 +1427,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netcoreapp31)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netcoreapp31)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1444,7 +1444,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netcoreapp31)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netcoreapp31)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1461,7 +1461,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (netcoreapp31)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (netcoreapp31)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1478,7 +1478,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (netcoreapp31)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (netcoreapp31)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1495,7 +1495,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netcoreapp31)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netcoreapp31)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1512,7 +1512,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (netcoreapp31)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (netcoreapp31)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1529,7 +1529,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netcoreapp31)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netcoreapp31)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1546,7 +1546,7 @@ public static partial class NetCoreApp31
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (netcoreapp31)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System")).GetReference(filePath: "System.dll", display: "System (netcoreapp31)");
                 }
                 return _System;
             }
@@ -1563,7 +1563,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (netcoreapp31)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (netcoreapp31)");
                 }
                 return _SystemDrawing;
             }
@@ -1580,7 +1580,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (netcoreapp31)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (netcoreapp31)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1597,7 +1597,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (netcoreapp31)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (netcoreapp31)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1614,7 +1614,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netcoreapp31)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netcoreapp31)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1631,7 +1631,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netcoreapp31)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netcoreapp31)");
                 }
                 return _SystemGlobalization;
             }
@@ -1648,7 +1648,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (netcoreapp31)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (netcoreapp31)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1665,7 +1665,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (netcoreapp31)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (netcoreapp31)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -1682,7 +1682,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netcoreapp31)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netcoreapp31)");
                 }
                 return _SystemIOCompression;
             }
@@ -1699,7 +1699,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (netcoreapp31)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (netcoreapp31)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1716,7 +1716,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netcoreapp31)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netcoreapp31)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1733,7 +1733,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (netcoreapp31)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (netcoreapp31)");
                 }
                 return _SystemIO;
             }
@@ -1750,7 +1750,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netcoreapp31)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netcoreapp31)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1767,7 +1767,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (netcoreapp31)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (netcoreapp31)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1784,7 +1784,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netcoreapp31)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netcoreapp31)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1801,7 +1801,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (netcoreapp31)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (netcoreapp31)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1818,7 +1818,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (netcoreapp31)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (netcoreapp31)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1835,7 +1835,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (netcoreapp31)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (netcoreapp31)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1852,7 +1852,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (netcoreapp31)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (netcoreapp31)");
                 }
                 return _SystemIOPipes;
             }
@@ -1869,7 +1869,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (netcoreapp31)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (netcoreapp31)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -1886,7 +1886,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netcoreapp31)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netcoreapp31)");
                 }
                 return _SystemLinq;
             }
@@ -1903,7 +1903,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netcoreapp31)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netcoreapp31)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -1920,7 +1920,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (netcoreapp31)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (netcoreapp31)");
                 }
                 return _SystemLinqParallel;
             }
@@ -1937,7 +1937,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (netcoreapp31)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (netcoreapp31)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -1954,7 +1954,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (netcoreapp31)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (netcoreapp31)");
                 }
                 return _SystemMemory;
             }
@@ -1971,7 +1971,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (netcoreapp31)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (netcoreapp31)");
                 }
                 return _SystemNet;
             }
@@ -1988,7 +1988,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netcoreapp31)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netcoreapp31)");
                 }
                 return _SystemNetHttp;
             }
@@ -2005,7 +2005,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (netcoreapp31)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (netcoreapp31)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -2022,7 +2022,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (netcoreapp31)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (netcoreapp31)");
                 }
                 return _SystemNetMail;
             }
@@ -2039,7 +2039,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (netcoreapp31)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (netcoreapp31)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -2056,7 +2056,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (netcoreapp31)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (netcoreapp31)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -2073,7 +2073,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (netcoreapp31)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (netcoreapp31)");
                 }
                 return _SystemNetPing;
             }
@@ -2090,7 +2090,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netcoreapp31)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netcoreapp31)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -2107,7 +2107,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (netcoreapp31)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (netcoreapp31)");
                 }
                 return _SystemNetRequests;
             }
@@ -2124,7 +2124,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netcoreapp31)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netcoreapp31)");
                 }
                 return _SystemNetSecurity;
             }
@@ -2141,7 +2141,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (netcoreapp31)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (netcoreapp31)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -2158,7 +2158,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netcoreapp31)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netcoreapp31)");
                 }
                 return _SystemNetSockets;
             }
@@ -2175,7 +2175,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (netcoreapp31)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (netcoreapp31)");
                 }
                 return _SystemNetWebClient;
             }
@@ -2192,7 +2192,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (netcoreapp31)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (netcoreapp31)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -2209,7 +2209,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (netcoreapp31)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (netcoreapp31)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -2226,7 +2226,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (netcoreapp31)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (netcoreapp31)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -2243,7 +2243,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (netcoreapp31)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (netcoreapp31)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -2260,7 +2260,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (netcoreapp31)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (netcoreapp31)");
                 }
                 return _SystemNumerics;
             }
@@ -2277,7 +2277,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (netcoreapp31)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (netcoreapp31)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2294,7 +2294,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netcoreapp31)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netcoreapp31)");
                 }
                 return _SystemObjectModel;
             }
@@ -2311,7 +2311,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (netcoreapp31)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (netcoreapp31)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -2328,7 +2328,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netcoreapp31)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netcoreapp31)");
                 }
                 return _SystemReflection;
             }
@@ -2345,7 +2345,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (netcoreapp31)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (netcoreapp31)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -2362,7 +2362,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (netcoreapp31)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (netcoreapp31)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -2379,7 +2379,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (netcoreapp31)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (netcoreapp31)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -2396,7 +2396,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netcoreapp31)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netcoreapp31)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -2413,7 +2413,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (netcoreapp31)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (netcoreapp31)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -2430,7 +2430,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netcoreapp31)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netcoreapp31)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -2447,7 +2447,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (netcoreapp31)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (netcoreapp31)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -2464,7 +2464,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (netcoreapp31)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (netcoreapp31)");
                 }
                 return _SystemResourcesReader;
             }
@@ -2481,7 +2481,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netcoreapp31)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netcoreapp31)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -2498,7 +2498,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (netcoreapp31)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (netcoreapp31)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -2515,7 +2515,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (netcoreapp31)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (netcoreapp31)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -2532,7 +2532,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (netcoreapp31)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (netcoreapp31)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -2549,7 +2549,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netcoreapp31)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netcoreapp31)");
                 }
                 return _SystemRuntime;
             }
@@ -2566,7 +2566,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netcoreapp31)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netcoreapp31)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -2583,7 +2583,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netcoreapp31)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netcoreapp31)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -2600,7 +2600,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netcoreapp31)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netcoreapp31)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -2617,7 +2617,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netcoreapp31)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netcoreapp31)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -2634,7 +2634,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeInteropServicesWindowsRuntime is null)
                 {
-                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesWindowsRuntime).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (netcoreapp31)");
+                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.InteropServices.WindowsRuntime")).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (netcoreapp31)");
                 }
                 return _SystemRuntimeInteropServicesWindowsRuntime;
             }
@@ -2651,7 +2651,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (netcoreapp31)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (netcoreapp31)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -2668,7 +2668,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (netcoreapp31)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (netcoreapp31)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -2685,7 +2685,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netcoreapp31)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netcoreapp31)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2702,7 +2702,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (netcoreapp31)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (netcoreapp31)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2719,7 +2719,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (netcoreapp31)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (netcoreapp31)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2736,7 +2736,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (netcoreapp31)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (netcoreapp31)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2753,7 +2753,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netcoreapp31)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netcoreapp31)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2770,7 +2770,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (netcoreapp31)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (netcoreapp31)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2787,7 +2787,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netcoreapp31)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netcoreapp31)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -2804,7 +2804,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netcoreapp31)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netcoreapp31)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -2821,7 +2821,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netcoreapp31)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netcoreapp31)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -2838,7 +2838,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netcoreapp31)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netcoreapp31)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -2855,7 +2855,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netcoreapp31)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netcoreapp31)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -2872,7 +2872,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netcoreapp31)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netcoreapp31)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -2889,7 +2889,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (netcoreapp31)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (netcoreapp31)");
                 }
                 return _SystemSecurity;
             }
@@ -2906,7 +2906,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netcoreapp31)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netcoreapp31)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -2923,7 +2923,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (netcoreapp31)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (netcoreapp31)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -2940,7 +2940,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (netcoreapp31)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (netcoreapp31)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -2957,7 +2957,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (netcoreapp31)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (netcoreapp31)");
                 }
                 return _SystemServiceProcess;
             }
@@ -2974,7 +2974,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (netcoreapp31)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (netcoreapp31)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -2991,7 +2991,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netcoreapp31)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netcoreapp31)");
                 }
                 return _SystemTextEncoding;
             }
@@ -3008,7 +3008,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netcoreapp31)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netcoreapp31)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -3025,7 +3025,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (netcoreapp31)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (netcoreapp31)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -3042,7 +3042,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (netcoreapp31)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (netcoreapp31)");
                 }
                 return _SystemTextJson;
             }
@@ -3059,7 +3059,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netcoreapp31)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netcoreapp31)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -3076,7 +3076,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (netcoreapp31)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (netcoreapp31)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -3093,7 +3093,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netcoreapp31)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netcoreapp31)");
                 }
                 return _SystemThreading;
             }
@@ -3110,7 +3110,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (netcoreapp31)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (netcoreapp31)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -3127,7 +3127,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (netcoreapp31)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (netcoreapp31)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -3144,7 +3144,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netcoreapp31)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netcoreapp31)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -3161,7 +3161,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netcoreapp31)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netcoreapp31)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -3178,7 +3178,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (netcoreapp31)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (netcoreapp31)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -3195,7 +3195,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (netcoreapp31)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (netcoreapp31)");
                 }
                 return _SystemThreadingThread;
             }
@@ -3212,7 +3212,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (netcoreapp31)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (netcoreapp31)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -3229,7 +3229,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netcoreapp31)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netcoreapp31)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -3246,7 +3246,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (netcoreapp31)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (netcoreapp31)");
                 }
                 return _SystemTransactions;
             }
@@ -3263,7 +3263,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (netcoreapp31)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (netcoreapp31)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -3280,7 +3280,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netcoreapp31)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netcoreapp31)");
                 }
                 return _SystemValueTuple;
             }
@@ -3297,7 +3297,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (netcoreapp31)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (netcoreapp31)");
                 }
                 return _SystemWeb;
             }
@@ -3314,7 +3314,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (netcoreapp31)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (netcoreapp31)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -3331,7 +3331,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (netcoreapp31)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (netcoreapp31)");
                 }
                 return _SystemWindows;
             }
@@ -3348,7 +3348,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (netcoreapp31)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (netcoreapp31)");
                 }
                 return _SystemXml;
             }
@@ -3365,7 +3365,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (netcoreapp31)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (netcoreapp31)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3382,7 +3382,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netcoreapp31)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netcoreapp31)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -3399,7 +3399,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (netcoreapp31)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (netcoreapp31)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3416,7 +3416,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netcoreapp31)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netcoreapp31)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -3433,7 +3433,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netcoreapp31)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netcoreapp31)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -3450,7 +3450,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (netcoreapp31)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (netcoreapp31)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -3467,7 +3467,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netcoreapp31)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netcoreapp31)");
                 }
                 return _SystemXmlXPath;
             }
@@ -3484,7 +3484,7 @@ public static partial class NetCoreApp31
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netcoreapp31)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netcoreapp31)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -3501,7 +3501,7 @@ public static partial class NetCoreApp31
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (netcoreapp31)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netcoreapp31.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (netcoreapp31)");
                 }
                 return _WindowsBase;
             }

--- a/Src/Basic.Reference.Assemblies.NetStandard13/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard13/Generated.cs
@@ -393,7 +393,7 @@ public static partial class NetStandard13
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netstandard13)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netstandard13)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -410,7 +410,7 @@ public static partial class NetStandard13
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netstandard13)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netstandard13)");
                 }
                 return _SystemAppContext;
             }
@@ -427,7 +427,7 @@ public static partial class NetStandard13
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netstandard13)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netstandard13)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -444,7 +444,7 @@ public static partial class NetStandard13
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netstandard13)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netstandard13)");
                 }
                 return _SystemCollections;
             }
@@ -461,7 +461,7 @@ public static partial class NetStandard13
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (netstandard13)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (netstandard13)");
                 }
                 return _SystemConsole;
             }
@@ -478,7 +478,7 @@ public static partial class NetStandard13
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netstandard13)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netstandard13)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -495,7 +495,7 @@ public static partial class NetStandard13
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netstandard13)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netstandard13)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -512,7 +512,7 @@ public static partial class NetStandard13
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netstandard13)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netstandard13)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -529,7 +529,7 @@ public static partial class NetStandard13
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netstandard13)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netstandard13)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -546,7 +546,7 @@ public static partial class NetStandard13
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netstandard13)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netstandard13)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -563,7 +563,7 @@ public static partial class NetStandard13
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netstandard13)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netstandard13)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -580,7 +580,7 @@ public static partial class NetStandard13
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netstandard13)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netstandard13)");
                 }
                 return _SystemGlobalization;
             }
@@ -597,7 +597,7 @@ public static partial class NetStandard13
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netstandard13)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netstandard13)");
                 }
                 return _SystemIOCompression;
             }
@@ -614,7 +614,7 @@ public static partial class NetStandard13
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netstandard13)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netstandard13)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -631,7 +631,7 @@ public static partial class NetStandard13
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (netstandard13)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (netstandard13)");
                 }
                 return _SystemIO;
             }
@@ -648,7 +648,7 @@ public static partial class NetStandard13
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netstandard13)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netstandard13)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -665,7 +665,7 @@ public static partial class NetStandard13
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netstandard13)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netstandard13)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -682,7 +682,7 @@ public static partial class NetStandard13
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netstandard13)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netstandard13)");
                 }
                 return _SystemLinq;
             }
@@ -699,7 +699,7 @@ public static partial class NetStandard13
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netstandard13)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netstandard13)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -716,7 +716,7 @@ public static partial class NetStandard13
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netstandard13)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netstandard13)");
                 }
                 return _SystemNetHttp;
             }
@@ -733,7 +733,7 @@ public static partial class NetStandard13
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netstandard13)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netstandard13)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -750,7 +750,7 @@ public static partial class NetStandard13
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netstandard13)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netstandard13)");
                 }
                 return _SystemNetSecurity;
             }
@@ -767,7 +767,7 @@ public static partial class NetStandard13
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netstandard13)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netstandard13)");
                 }
                 return _SystemNetSockets;
             }
@@ -784,7 +784,7 @@ public static partial class NetStandard13
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netstandard13)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netstandard13)");
                 }
                 return _SystemObjectModel;
             }
@@ -801,7 +801,7 @@ public static partial class NetStandard13
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netstandard13)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netstandard13)");
                 }
                 return _SystemReflection;
             }
@@ -818,7 +818,7 @@ public static partial class NetStandard13
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netstandard13)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netstandard13)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -835,7 +835,7 @@ public static partial class NetStandard13
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netstandard13)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netstandard13)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -852,7 +852,7 @@ public static partial class NetStandard13
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netstandard13)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netstandard13)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -869,7 +869,7 @@ public static partial class NetStandard13
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netstandard13)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netstandard13)");
                 }
                 return _SystemRuntime;
             }
@@ -886,7 +886,7 @@ public static partial class NetStandard13
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netstandard13)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netstandard13)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -903,7 +903,7 @@ public static partial class NetStandard13
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netstandard13)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netstandard13)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -920,7 +920,7 @@ public static partial class NetStandard13
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netstandard13)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netstandard13)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -937,7 +937,7 @@ public static partial class NetStandard13
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netstandard13)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netstandard13)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -954,7 +954,7 @@ public static partial class NetStandard13
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netstandard13)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netstandard13)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -971,7 +971,7 @@ public static partial class NetStandard13
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netstandard13)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netstandard13)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -988,7 +988,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (netstandard13)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (netstandard13)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -1005,7 +1005,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netstandard13)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netstandard13)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -1022,7 +1022,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netstandard13)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netstandard13)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -1039,7 +1039,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netstandard13)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netstandard13)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -1056,7 +1056,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netstandard13)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netstandard13)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -1073,7 +1073,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netstandard13)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netstandard13)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -1090,7 +1090,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netstandard13)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netstandard13)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -1107,7 +1107,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netstandard13)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netstandard13)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -1124,7 +1124,7 @@ public static partial class NetStandard13
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (netstandard13)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (netstandard13)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -1141,7 +1141,7 @@ public static partial class NetStandard13
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (netstandard13)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (netstandard13)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -1158,7 +1158,7 @@ public static partial class NetStandard13
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netstandard13)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netstandard13)");
                 }
                 return _SystemTextEncoding;
             }
@@ -1175,7 +1175,7 @@ public static partial class NetStandard13
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netstandard13)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netstandard13)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -1192,7 +1192,7 @@ public static partial class NetStandard13
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netstandard13)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netstandard13)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -1209,7 +1209,7 @@ public static partial class NetStandard13
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netstandard13)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netstandard13)");
                 }
                 return _SystemThreading;
             }
@@ -1226,7 +1226,7 @@ public static partial class NetStandard13
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netstandard13)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netstandard13)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -1243,7 +1243,7 @@ public static partial class NetStandard13
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard13)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard13)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -1260,7 +1260,7 @@ public static partial class NetStandard13
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netstandard13)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netstandard13)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -1277,7 +1277,7 @@ public static partial class NetStandard13
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netstandard13)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netstandard13)");
                 }
                 return _SystemValueTuple;
             }
@@ -1294,7 +1294,7 @@ public static partial class NetStandard13
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netstandard13)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netstandard13)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -1311,7 +1311,7 @@ public static partial class NetStandard13
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netstandard13)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netstandard13)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -1328,7 +1328,7 @@ public static partial class NetStandard13
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netstandard13)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netstandard13)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -1345,7 +1345,7 @@ public static partial class NetStandard13
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netstandard13)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netstandard13)");
                 }
                 return _SystemXmlXPath;
             }
@@ -1362,7 +1362,7 @@ public static partial class NetStandard13
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netstandard13)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard13.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netstandard13)");
                 }
                 return _SystemXmlXPathXDocument;
             }

--- a/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
+++ b/Src/Basic.Reference.Assemblies.NetStandard20/Generated.cs
@@ -723,7 +723,7 @@ public static partial class NetStandard20
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netstandard20)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netstandard20)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -740,7 +740,7 @@ public static partial class NetStandard20
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (netstandard20)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (netstandard20)");
                 }
                 return _mscorlib;
             }
@@ -757,7 +757,7 @@ public static partial class NetStandard20
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (netstandard20)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (netstandard20)");
                 }
                 return _netstandard;
             }
@@ -774,7 +774,7 @@ public static partial class NetStandard20
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netstandard20)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netstandard20)");
                 }
                 return _SystemAppContext;
             }
@@ -791,7 +791,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netstandard20)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netstandard20)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -808,7 +808,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netstandard20)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netstandard20)");
                 }
                 return _SystemCollections;
             }
@@ -825,7 +825,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (netstandard20)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (netstandard20)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -842,7 +842,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (netstandard20)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (netstandard20)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -859,7 +859,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelComposition is null)
                 {
-                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelComposition).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (netstandard20)");
+                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.Composition")).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (netstandard20)");
                 }
                 return _SystemComponentModelComposition;
             }
@@ -876,7 +876,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (netstandard20)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (netstandard20)");
                 }
                 return _SystemComponentModel;
             }
@@ -893,7 +893,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (netstandard20)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (netstandard20)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -910,7 +910,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (netstandard20)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (netstandard20)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -927,7 +927,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (netstandard20)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (netstandard20)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -944,7 +944,7 @@ public static partial class NetStandard20
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (netstandard20)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (netstandard20)");
                 }
                 return _SystemConsole;
             }
@@ -961,7 +961,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (netstandard20)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (netstandard20)");
                 }
                 return _SystemCore;
             }
@@ -978,7 +978,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (netstandard20)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (netstandard20)");
                 }
                 return _SystemDataCommon;
             }
@@ -995,7 +995,7 @@ public static partial class NetStandard20
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (netstandard20)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (netstandard20)");
                 }
                 return _SystemData;
             }
@@ -1012,7 +1012,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (netstandard20)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (netstandard20)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1029,7 +1029,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netstandard20)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netstandard20)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1046,7 +1046,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netstandard20)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netstandard20)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1063,7 +1063,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netstandard20)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netstandard20)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1080,7 +1080,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (netstandard20)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (netstandard20)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1097,7 +1097,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (netstandard20)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (netstandard20)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1114,7 +1114,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netstandard20)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netstandard20)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1131,7 +1131,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (netstandard20)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (netstandard20)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1148,7 +1148,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netstandard20)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netstandard20)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1165,7 +1165,7 @@ public static partial class NetStandard20
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (netstandard20)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System")).GetReference(filePath: "System.dll", display: "System (netstandard20)");
                 }
                 return _System;
             }
@@ -1182,7 +1182,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (netstandard20)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (netstandard20)");
                 }
                 return _SystemDrawing;
             }
@@ -1199,7 +1199,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (netstandard20)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (netstandard20)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1216,7 +1216,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (netstandard20)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (netstandard20)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1233,7 +1233,7 @@ public static partial class NetStandard20
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netstandard20)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netstandard20)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1250,7 +1250,7 @@ public static partial class NetStandard20
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netstandard20)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netstandard20)");
                 }
                 return _SystemGlobalization;
             }
@@ -1267,7 +1267,7 @@ public static partial class NetStandard20
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (netstandard20)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (netstandard20)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1284,7 +1284,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netstandard20)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netstandard20)");
                 }
                 return _SystemIOCompression;
             }
@@ -1301,7 +1301,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (netstandard20)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (netstandard20)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1318,7 +1318,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netstandard20)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netstandard20)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1335,7 +1335,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (netstandard20)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (netstandard20)");
                 }
                 return _SystemIO;
             }
@@ -1352,7 +1352,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netstandard20)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netstandard20)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1369,7 +1369,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (netstandard20)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (netstandard20)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1386,7 +1386,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netstandard20)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netstandard20)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1403,7 +1403,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (netstandard20)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (netstandard20)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1420,7 +1420,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (netstandard20)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (netstandard20)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1437,7 +1437,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (netstandard20)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (netstandard20)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1454,7 +1454,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (netstandard20)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (netstandard20)");
                 }
                 return _SystemIOPipes;
             }
@@ -1471,7 +1471,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (netstandard20)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (netstandard20)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -1488,7 +1488,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netstandard20)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netstandard20)");
                 }
                 return _SystemLinq;
             }
@@ -1505,7 +1505,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netstandard20)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netstandard20)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -1522,7 +1522,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (netstandard20)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (netstandard20)");
                 }
                 return _SystemLinqParallel;
             }
@@ -1539,7 +1539,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (netstandard20)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (netstandard20)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -1556,7 +1556,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (netstandard20)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (netstandard20)");
                 }
                 return _SystemNet;
             }
@@ -1573,7 +1573,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netstandard20)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netstandard20)");
                 }
                 return _SystemNetHttp;
             }
@@ -1590,7 +1590,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (netstandard20)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (netstandard20)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -1607,7 +1607,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (netstandard20)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (netstandard20)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -1624,7 +1624,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (netstandard20)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (netstandard20)");
                 }
                 return _SystemNetPing;
             }
@@ -1641,7 +1641,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netstandard20)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netstandard20)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -1658,7 +1658,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (netstandard20)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (netstandard20)");
                 }
                 return _SystemNetRequests;
             }
@@ -1675,7 +1675,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netstandard20)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netstandard20)");
                 }
                 return _SystemNetSecurity;
             }
@@ -1692,7 +1692,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netstandard20)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netstandard20)");
                 }
                 return _SystemNetSockets;
             }
@@ -1709,7 +1709,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (netstandard20)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (netstandard20)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -1726,7 +1726,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (netstandard20)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (netstandard20)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -1743,7 +1743,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (netstandard20)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (netstandard20)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -1760,7 +1760,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (netstandard20)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (netstandard20)");
                 }
                 return _SystemNumerics;
             }
@@ -1777,7 +1777,7 @@ public static partial class NetStandard20
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netstandard20)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netstandard20)");
                 }
                 return _SystemObjectModel;
             }
@@ -1794,7 +1794,7 @@ public static partial class NetStandard20
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netstandard20)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netstandard20)");
                 }
                 return _SystemReflection;
             }
@@ -1811,7 +1811,7 @@ public static partial class NetStandard20
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netstandard20)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netstandard20)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -1828,7 +1828,7 @@ public static partial class NetStandard20
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netstandard20)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netstandard20)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -1845,7 +1845,7 @@ public static partial class NetStandard20
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (netstandard20)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (netstandard20)");
                 }
                 return _SystemResourcesReader;
             }
@@ -1862,7 +1862,7 @@ public static partial class NetStandard20
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netstandard20)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netstandard20)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -1879,7 +1879,7 @@ public static partial class NetStandard20
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (netstandard20)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (netstandard20)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -1896,7 +1896,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (netstandard20)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (netstandard20)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -1913,7 +1913,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netstandard20)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netstandard20)");
                 }
                 return _SystemRuntime;
             }
@@ -1930,7 +1930,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netstandard20)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netstandard20)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -1947,7 +1947,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netstandard20)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netstandard20)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -1964,7 +1964,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netstandard20)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netstandard20)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -1981,7 +1981,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netstandard20)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netstandard20)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -1998,7 +1998,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netstandard20)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netstandard20)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2015,7 +2015,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (netstandard20)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (netstandard20)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2032,7 +2032,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (netstandard20)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (netstandard20)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2049,7 +2049,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (netstandard20)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (netstandard20)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2066,7 +2066,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netstandard20)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netstandard20)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2083,7 +2083,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (netstandard20)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (netstandard20)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2100,7 +2100,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netstandard20)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netstandard20)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -2117,7 +2117,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netstandard20)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netstandard20)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -2134,7 +2134,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netstandard20)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netstandard20)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -2151,7 +2151,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netstandard20)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netstandard20)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -2168,7 +2168,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netstandard20)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netstandard20)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -2185,7 +2185,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netstandard20)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netstandard20)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -2202,7 +2202,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netstandard20)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netstandard20)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -2219,7 +2219,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (netstandard20)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (netstandard20)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -2236,7 +2236,7 @@ public static partial class NetStandard20
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (netstandard20)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (netstandard20)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -2253,7 +2253,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netstandard20)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netstandard20)");
                 }
                 return _SystemTextEncoding;
             }
@@ -2270,7 +2270,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netstandard20)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netstandard20)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -2287,7 +2287,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netstandard20)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netstandard20)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -2304,7 +2304,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netstandard20)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netstandard20)");
                 }
                 return _SystemThreading;
             }
@@ -2321,7 +2321,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (netstandard20)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (netstandard20)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -2338,7 +2338,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netstandard20)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netstandard20)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -2355,7 +2355,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (netstandard20)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (netstandard20)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -2372,7 +2372,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (netstandard20)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (netstandard20)");
                 }
                 return _SystemThreadingThread;
             }
@@ -2389,7 +2389,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (netstandard20)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (netstandard20)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -2406,7 +2406,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netstandard20)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netstandard20)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -2423,7 +2423,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (netstandard20)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (netstandard20)");
                 }
                 return _SystemTransactions;
             }
@@ -2440,7 +2440,7 @@ public static partial class NetStandard20
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netstandard20)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netstandard20)");
                 }
                 return _SystemValueTuple;
             }
@@ -2457,7 +2457,7 @@ public static partial class NetStandard20
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (netstandard20)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (netstandard20)");
                 }
                 return _SystemWeb;
             }
@@ -2474,7 +2474,7 @@ public static partial class NetStandard20
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (netstandard20)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (netstandard20)");
                 }
                 return _SystemWindows;
             }
@@ -2491,7 +2491,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (netstandard20)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (netstandard20)");
                 }
                 return _SystemXml;
             }
@@ -2508,7 +2508,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (netstandard20)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (netstandard20)");
                 }
                 return _SystemXmlLinq;
             }
@@ -2525,7 +2525,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netstandard20)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netstandard20)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -2542,7 +2542,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (netstandard20)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (netstandard20)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -2559,7 +2559,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netstandard20)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netstandard20)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -2576,7 +2576,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netstandard20)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netstandard20)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -2593,7 +2593,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (netstandard20)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (netstandard20)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -2610,7 +2610,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netstandard20)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netstandard20)");
                 }
                 return _SystemXmlXPath;
             }
@@ -2627,7 +2627,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netstandard20)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netstandard20)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -2819,7 +2819,7 @@ public static partial class NetStandard20
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -2836,7 +2836,7 @@ public static partial class NetStandard20
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -2853,7 +2853,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
                 }
                 return _SystemThreadingTasksExtensions;
             }

--- a/Src/Basic.Reference.Assemblies.UnitTests/Basic.Reference.Assemblies.UnitTests.csproj
+++ b/Src/Basic.Reference.Assemblies.UnitTests/Basic.Reference.Assemblies.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/Basic.Reference.Assemblies.UnitTests/SanityUnitTests.cs
+++ b/Src/Basic.Reference.Assemblies.UnitTests/SanityUnitTests.cs
@@ -203,4 +203,12 @@ static void Main()
         var actual = CompilationUtil.CompileAndRun(source, nameof(RunTuple), references);
         Assert.Equal("(1, 2)", actual);
     }
+
+    [Fact]
+    public void LoadAll()
+    {
+        Net461.References.All.ToList();
+        Net40.References.All.ToList();
+        Net70.References.All.ToList();
+    }
 }

--- a/Src/Basic.Reference.Assemblies/Generated.Net472.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.Net472.cs
@@ -1455,7 +1455,7 @@ public static partial class Net472
             {
                 if (_Accessibility is null)
                 {
-                    _Accessibility = AssemblyMetadata.CreateFromImage(Resources.Accessibility).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net472)");
+                    _Accessibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Accessibility")).GetReference(filePath: "Accessibility.dll", display: "Accessibility (net472)");
                 }
                 return _Accessibility;
             }
@@ -1472,7 +1472,7 @@ public static partial class Net472
             {
                 if (_CustomMarshalers is null)
                 {
-                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(Resources.CustomMarshalers).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net472)");
+                    _CustomMarshalers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.CustomMarshalers")).GetReference(filePath: "CustomMarshalers.dll", display: "CustomMarshalers (net472)");
                 }
                 return _CustomMarshalers;
             }
@@ -1489,7 +1489,7 @@ public static partial class Net472
             {
                 if (_ISymWrapper is null)
                 {
-                    _ISymWrapper = AssemblyMetadata.CreateFromImage(Resources.ISymWrapper).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net472)");
+                    _ISymWrapper = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.ISymWrapper")).GetReference(filePath: "ISymWrapper.dll", display: "ISymWrapper (net472)");
                 }
                 return _ISymWrapper;
             }
@@ -1506,7 +1506,7 @@ public static partial class Net472
             {
                 if (_MicrosoftActivitiesBuild is null)
                 {
-                    _MicrosoftActivitiesBuild = AssemblyMetadata.CreateFromImage(Resources.MicrosoftActivitiesBuild).GetReference(filePath: "Microsoft.Activities.Build.dll", display: "Microsoft.Activities.Build (net472)");
+                    _MicrosoftActivitiesBuild = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Activities.Build")).GetReference(filePath: "Microsoft.Activities.Build.dll", display: "Microsoft.Activities.Build (net472)");
                 }
                 return _MicrosoftActivitiesBuild;
             }
@@ -1523,7 +1523,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildConversionv40 is null)
                 {
-                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildConversionv40).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net472)");
+                    _MicrosoftBuildConversionv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Conversion.v4.0")).GetReference(filePath: "Microsoft.Build.Conversion.v4.0.dll", display: "Microsoft.Build.Conversion.v4.0 (net472)");
                 }
                 return _MicrosoftBuildConversionv40;
             }
@@ -1540,7 +1540,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuild is null)
                 {
-                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuild).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net472)");
+                    _MicrosoftBuild = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build")).GetReference(filePath: "Microsoft.Build.dll", display: "Microsoft.Build (net472)");
                 }
                 return _MicrosoftBuild;
             }
@@ -1557,7 +1557,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildEngine is null)
                 {
-                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildEngine).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net472)");
+                    _MicrosoftBuildEngine = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Engine")).GetReference(filePath: "Microsoft.Build.Engine.dll", display: "Microsoft.Build.Engine (net472)");
                 }
                 return _MicrosoftBuildEngine;
             }
@@ -1574,7 +1574,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildFramework is null)
                 {
-                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildFramework).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net472)");
+                    _MicrosoftBuildFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Framework")).GetReference(filePath: "Microsoft.Build.Framework.dll", display: "Microsoft.Build.Framework (net472)");
                 }
                 return _MicrosoftBuildFramework;
             }
@@ -1591,7 +1591,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildTasksv40 is null)
                 {
-                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildTasksv40).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net472)");
+                    _MicrosoftBuildTasksv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Tasks.v4.0")).GetReference(filePath: "Microsoft.Build.Tasks.v4.0.dll", display: "Microsoft.Build.Tasks.v4.0 (net472)");
                 }
                 return _MicrosoftBuildTasksv40;
             }
@@ -1608,7 +1608,7 @@ public static partial class Net472
             {
                 if (_MicrosoftBuildUtilitiesv40 is null)
                 {
-                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(Resources.MicrosoftBuildUtilitiesv40).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net472)");
+                    _MicrosoftBuildUtilitiesv40 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Build.Utilities.v4.0")).GetReference(filePath: "Microsoft.Build.Utilities.v4.0.dll", display: "Microsoft.Build.Utilities.v4.0 (net472)");
                 }
                 return _MicrosoftBuildUtilitiesv40;
             }
@@ -1625,7 +1625,7 @@ public static partial class Net472
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net472)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net472)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1642,7 +1642,7 @@ public static partial class Net472
             {
                 if (_MicrosoftJScript is null)
                 {
-                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(Resources.MicrosoftJScript).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net472)");
+                    _MicrosoftJScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.JScript")).GetReference(filePath: "Microsoft.JScript.dll", display: "Microsoft.JScript (net472)");
                 }
                 return _MicrosoftJScript;
             }
@@ -1659,7 +1659,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualBasicCompatibilityData is null)
                 {
-                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibilityData).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net472)");
+                    _MicrosoftVisualBasicCompatibilityData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualBasic.Compatibility.Data")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.Data.dll", display: "Microsoft.VisualBasic.Compatibility.Data (net472)");
                 }
                 return _MicrosoftVisualBasicCompatibilityData;
             }
@@ -1676,7 +1676,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualBasicCompatibility is null)
                 {
-                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCompatibility).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net472)");
+                    _MicrosoftVisualBasicCompatibility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualBasic.Compatibility")).GetReference(filePath: "Microsoft.VisualBasic.Compatibility.dll", display: "Microsoft.VisualBasic.Compatibility (net472)");
                 }
                 return _MicrosoftVisualBasicCompatibility;
             }
@@ -1693,7 +1693,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net472)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net472)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1710,7 +1710,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualC is null)
                 {
-                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualC).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net472)");
+                    _MicrosoftVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualC")).GetReference(filePath: "Microsoft.VisualC.dll", display: "Microsoft.VisualC (net472)");
                 }
                 return _MicrosoftVisualC;
             }
@@ -1727,7 +1727,7 @@ public static partial class Net472
             {
                 if (_MicrosoftVisualCSTLCLR is null)
                 {
-                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualCSTLCLR).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net472)");
+                    _MicrosoftVisualCSTLCLR = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.VisualC.STLCLR")).GetReference(filePath: "Microsoft.VisualC.STLCLR.dll", display: "Microsoft.VisualC.STLCLR (net472)");
                 }
                 return _MicrosoftVisualCSTLCLR;
             }
@@ -1744,7 +1744,7 @@ public static partial class Net472
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net472)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net472)");
                 }
                 return _mscorlib;
             }
@@ -1761,7 +1761,7 @@ public static partial class Net472
             {
                 if (_PresentationBuildTasks is null)
                 {
-                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(Resources.PresentationBuildTasks).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net472)");
+                    _PresentationBuildTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationBuildTasks")).GetReference(filePath: "PresentationBuildTasks.dll", display: "PresentationBuildTasks (net472)");
                 }
                 return _PresentationBuildTasks;
             }
@@ -1778,7 +1778,7 @@ public static partial class Net472
             {
                 if (_PresentationCore is null)
                 {
-                    _PresentationCore = AssemblyMetadata.CreateFromImage(Resources.PresentationCore).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net472)");
+                    _PresentationCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationCore")).GetReference(filePath: "PresentationCore.dll", display: "PresentationCore (net472)");
                 }
                 return _PresentationCore;
             }
@@ -1795,7 +1795,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkAero is null)
                 {
-                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net472)");
+                    _PresentationFrameworkAero = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Aero")).GetReference(filePath: "PresentationFramework.Aero.dll", display: "PresentationFramework.Aero (net472)");
                 }
                 return _PresentationFrameworkAero;
             }
@@ -1812,7 +1812,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkAero2 is null)
                 {
-                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAero2).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net472)");
+                    _PresentationFrameworkAero2 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Aero2")).GetReference(filePath: "PresentationFramework.Aero2.dll", display: "PresentationFramework.Aero2 (net472)");
                 }
                 return _PresentationFrameworkAero2;
             }
@@ -1829,7 +1829,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkAeroLite is null)
                 {
-                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkAeroLite).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net472)");
+                    _PresentationFrameworkAeroLite = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.AeroLite")).GetReference(filePath: "PresentationFramework.AeroLite.dll", display: "PresentationFramework.AeroLite (net472)");
                 }
                 return _PresentationFrameworkAeroLite;
             }
@@ -1846,7 +1846,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkClassic is null)
                 {
-                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkClassic).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net472)");
+                    _PresentationFrameworkClassic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Classic")).GetReference(filePath: "PresentationFramework.Classic.dll", display: "PresentationFramework.Classic (net472)");
                 }
                 return _PresentationFrameworkClassic;
             }
@@ -1863,7 +1863,7 @@ public static partial class Net472
             {
                 if (_PresentationFramework is null)
                 {
-                    _PresentationFramework = AssemblyMetadata.CreateFromImage(Resources.PresentationFramework).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net472)");
+                    _PresentationFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework")).GetReference(filePath: "PresentationFramework.dll", display: "PresentationFramework (net472)");
                 }
                 return _PresentationFramework;
             }
@@ -1880,7 +1880,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkLuna is null)
                 {
-                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkLuna).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net472)");
+                    _PresentationFrameworkLuna = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Luna")).GetReference(filePath: "PresentationFramework.Luna.dll", display: "PresentationFramework.Luna (net472)");
                 }
                 return _PresentationFrameworkLuna;
             }
@@ -1897,7 +1897,7 @@ public static partial class Net472
             {
                 if (_PresentationFrameworkRoyale is null)
                 {
-                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(Resources.PresentationFrameworkRoyale).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net472)");
+                    _PresentationFrameworkRoyale = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.PresentationFramework.Royale")).GetReference(filePath: "PresentationFramework.Royale.dll", display: "PresentationFramework.Royale (net472)");
                 }
                 return _PresentationFrameworkRoyale;
             }
@@ -1914,7 +1914,7 @@ public static partial class Net472
             {
                 if (_ReachFramework is null)
                 {
-                    _ReachFramework = AssemblyMetadata.CreateFromImage(Resources.ReachFramework).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net472)");
+                    _ReachFramework = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.ReachFramework")).GetReference(filePath: "ReachFramework.dll", display: "ReachFramework (net472)");
                 }
                 return _ReachFramework;
             }
@@ -1931,7 +1931,7 @@ public static partial class Net472
             {
                 if (_sysglobl is null)
                 {
-                    _sysglobl = AssemblyMetadata.CreateFromImage(Resources.sysglobl).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net472)");
+                    _sysglobl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.sysglobl")).GetReference(filePath: "sysglobl.dll", display: "sysglobl (net472)");
                 }
                 return _sysglobl;
             }
@@ -1948,7 +1948,7 @@ public static partial class Net472
             {
                 if (_SystemActivitiesCorePresentation is null)
                 {
-                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesCorePresentation).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net472)");
+                    _SystemActivitiesCorePresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities.Core.Presentation")).GetReference(filePath: "System.Activities.Core.Presentation.dll", display: "System.Activities.Core.Presentation (net472)");
                 }
                 return _SystemActivitiesCorePresentation;
             }
@@ -1965,7 +1965,7 @@ public static partial class Net472
             {
                 if (_SystemActivities is null)
                 {
-                    _SystemActivities = AssemblyMetadata.CreateFromImage(Resources.SystemActivities).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net472)");
+                    _SystemActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities")).GetReference(filePath: "System.Activities.dll", display: "System.Activities (net472)");
                 }
                 return _SystemActivities;
             }
@@ -1982,7 +1982,7 @@ public static partial class Net472
             {
                 if (_SystemActivitiesDurableInstancing is null)
                 {
-                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesDurableInstancing).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net472)");
+                    _SystemActivitiesDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities.DurableInstancing")).GetReference(filePath: "System.Activities.DurableInstancing.dll", display: "System.Activities.DurableInstancing (net472)");
                 }
                 return _SystemActivitiesDurableInstancing;
             }
@@ -1999,7 +1999,7 @@ public static partial class Net472
             {
                 if (_SystemActivitiesPresentation is null)
                 {
-                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemActivitiesPresentation).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net472)");
+                    _SystemActivitiesPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Activities.Presentation")).GetReference(filePath: "System.Activities.Presentation.dll", display: "System.Activities.Presentation (net472)");
                 }
                 return _SystemActivitiesPresentation;
             }
@@ -2016,7 +2016,7 @@ public static partial class Net472
             {
                 if (_SystemAddInContract is null)
                 {
-                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(Resources.SystemAddInContract).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net472)");
+                    _SystemAddInContract = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.AddIn.Contract")).GetReference(filePath: "System.AddIn.Contract.dll", display: "System.AddIn.Contract (net472)");
                 }
                 return _SystemAddInContract;
             }
@@ -2033,7 +2033,7 @@ public static partial class Net472
             {
                 if (_SystemAddIn is null)
                 {
-                    _SystemAddIn = AssemblyMetadata.CreateFromImage(Resources.SystemAddIn).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net472)");
+                    _SystemAddIn = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.AddIn")).GetReference(filePath: "System.AddIn.dll", display: "System.AddIn (net472)");
                 }
                 return _SystemAddIn;
             }
@@ -2050,7 +2050,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelComposition is null)
                 {
-                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelComposition).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net472)");
+                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Composition")).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (net472)");
                 }
                 return _SystemComponentModelComposition;
             }
@@ -2067,7 +2067,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelCompositionRegistration is null)
                 {
-                    _SystemComponentModelCompositionRegistration = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelCompositionRegistration).GetReference(filePath: "System.ComponentModel.Composition.Registration.dll", display: "System.ComponentModel.Composition.Registration (net472)");
+                    _SystemComponentModelCompositionRegistration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Composition.Registration")).GetReference(filePath: "System.ComponentModel.Composition.Registration.dll", display: "System.ComponentModel.Composition.Registration (net472)");
                 }
                 return _SystemComponentModelCompositionRegistration;
             }
@@ -2084,7 +2084,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net472)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net472)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -2101,7 +2101,7 @@ public static partial class Net472
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net472)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net472)");
                 }
                 return _SystemConfiguration;
             }
@@ -2118,7 +2118,7 @@ public static partial class Net472
             {
                 if (_SystemConfigurationInstall is null)
                 {
-                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(Resources.SystemConfigurationInstall).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net472)");
+                    _SystemConfigurationInstall = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Configuration.Install")).GetReference(filePath: "System.Configuration.Install.dll", display: "System.Configuration.Install (net472)");
                 }
                 return _SystemConfigurationInstall;
             }
@@ -2135,7 +2135,7 @@ public static partial class Net472
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net472)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net472)");
                 }
                 return _SystemCore;
             }
@@ -2152,7 +2152,7 @@ public static partial class Net472
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net472)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net472)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -2169,7 +2169,7 @@ public static partial class Net472
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net472)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net472)");
                 }
                 return _SystemData;
             }
@@ -2186,7 +2186,7 @@ public static partial class Net472
             {
                 if (_SystemDataEntityDesign is null)
                 {
-                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntityDesign).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net472)");
+                    _SystemDataEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Entity.Design")).GetReference(filePath: "System.Data.Entity.Design.dll", display: "System.Data.Entity.Design (net472)");
                 }
                 return _SystemDataEntityDesign;
             }
@@ -2203,7 +2203,7 @@ public static partial class Net472
             {
                 if (_SystemDataEntity is null)
                 {
-                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(Resources.SystemDataEntity).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net472)");
+                    _SystemDataEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Entity")).GetReference(filePath: "System.Data.Entity.dll", display: "System.Data.Entity (net472)");
                 }
                 return _SystemDataEntity;
             }
@@ -2220,7 +2220,7 @@ public static partial class Net472
             {
                 if (_SystemDataLinq is null)
                 {
-                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(Resources.SystemDataLinq).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net472)");
+                    _SystemDataLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Linq")).GetReference(filePath: "System.Data.Linq.dll", display: "System.Data.Linq (net472)");
                 }
                 return _SystemDataLinq;
             }
@@ -2237,7 +2237,7 @@ public static partial class Net472
             {
                 if (_SystemDataOracleClient is null)
                 {
-                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataOracleClient).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net472)");
+                    _SystemDataOracleClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.OracleClient")).GetReference(filePath: "System.Data.OracleClient.dll", display: "System.Data.OracleClient (net472)");
                 }
                 return _SystemDataOracleClient;
             }
@@ -2254,7 +2254,7 @@ public static partial class Net472
             {
                 if (_SystemDataServicesClient is null)
                 {
-                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesClient).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net472)");
+                    _SystemDataServicesClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Services.Client")).GetReference(filePath: "System.Data.Services.Client.dll", display: "System.Data.Services.Client (net472)");
                 }
                 return _SystemDataServicesClient;
             }
@@ -2271,7 +2271,7 @@ public static partial class Net472
             {
                 if (_SystemDataServicesDesign is null)
                 {
-                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDataServicesDesign).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net472)");
+                    _SystemDataServicesDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Services.Design")).GetReference(filePath: "System.Data.Services.Design.dll", display: "System.Data.Services.Design (net472)");
                 }
                 return _SystemDataServicesDesign;
             }
@@ -2288,7 +2288,7 @@ public static partial class Net472
             {
                 if (_SystemDataServices is null)
                 {
-                    _SystemDataServices = AssemblyMetadata.CreateFromImage(Resources.SystemDataServices).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net472)");
+                    _SystemDataServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Services")).GetReference(filePath: "System.Data.Services.dll", display: "System.Data.Services (net472)");
                 }
                 return _SystemDataServices;
             }
@@ -2305,7 +2305,7 @@ public static partial class Net472
             {
                 if (_SystemDataSqlXml is null)
                 {
-                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(Resources.SystemDataSqlXml).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net472)");
+                    _SystemDataSqlXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.SqlXml")).GetReference(filePath: "System.Data.SqlXml.dll", display: "System.Data.SqlXml (net472)");
                 }
                 return _SystemDataSqlXml;
             }
@@ -2322,7 +2322,7 @@ public static partial class Net472
             {
                 if (_SystemDeployment is null)
                 {
-                    _SystemDeployment = AssemblyMetadata.CreateFromImage(Resources.SystemDeployment).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net472)");
+                    _SystemDeployment = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Deployment")).GetReference(filePath: "System.Deployment.dll", display: "System.Deployment (net472)");
                 }
                 return _SystemDeployment;
             }
@@ -2339,7 +2339,7 @@ public static partial class Net472
             {
                 if (_SystemDesign is null)
                 {
-                    _SystemDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDesign).GetReference(filePath: "System.Design.dll", display: "System.Design (net472)");
+                    _SystemDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Design")).GetReference(filePath: "System.Design.dll", display: "System.Design (net472)");
                 }
                 return _SystemDesign;
             }
@@ -2356,7 +2356,7 @@ public static partial class Net472
             {
                 if (_SystemDevice is null)
                 {
-                    _SystemDevice = AssemblyMetadata.CreateFromImage(Resources.SystemDevice).GetReference(filePath: "System.Device.dll", display: "System.Device (net472)");
+                    _SystemDevice = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Device")).GetReference(filePath: "System.Device.dll", display: "System.Device (net472)");
                 }
                 return _SystemDevice;
             }
@@ -2373,7 +2373,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net472)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net472)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -2390,7 +2390,7 @@ public static partial class Net472
             {
                 if (_SystemDirectoryServicesAccountManagement is null)
                 {
-                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesAccountManagement).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net472)");
+                    _SystemDirectoryServicesAccountManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.DirectoryServices.AccountManagement")).GetReference(filePath: "System.DirectoryServices.AccountManagement.dll", display: "System.DirectoryServices.AccountManagement (net472)");
                 }
                 return _SystemDirectoryServicesAccountManagement;
             }
@@ -2407,7 +2407,7 @@ public static partial class Net472
             {
                 if (_SystemDirectoryServices is null)
                 {
-                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServices).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net472)");
+                    _SystemDirectoryServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.DirectoryServices")).GetReference(filePath: "System.DirectoryServices.dll", display: "System.DirectoryServices (net472)");
                 }
                 return _SystemDirectoryServices;
             }
@@ -2424,7 +2424,7 @@ public static partial class Net472
             {
                 if (_SystemDirectoryServicesProtocols is null)
                 {
-                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(Resources.SystemDirectoryServicesProtocols).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net472)");
+                    _SystemDirectoryServicesProtocols = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.DirectoryServices.Protocols")).GetReference(filePath: "System.DirectoryServices.Protocols.dll", display: "System.DirectoryServices.Protocols (net472)");
                 }
                 return _SystemDirectoryServicesProtocols;
             }
@@ -2441,7 +2441,7 @@ public static partial class Net472
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net472)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System")).GetReference(filePath: "System.dll", display: "System (net472)");
                 }
                 return _System;
             }
@@ -2458,7 +2458,7 @@ public static partial class Net472
             {
                 if (_SystemDrawingDesign is null)
                 {
-                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingDesign).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net472)");
+                    _SystemDrawingDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Drawing.Design")).GetReference(filePath: "System.Drawing.Design.dll", display: "System.Drawing.Design (net472)");
                 }
                 return _SystemDrawingDesign;
             }
@@ -2475,7 +2475,7 @@ public static partial class Net472
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net472)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net472)");
                 }
                 return _SystemDrawing;
             }
@@ -2492,7 +2492,7 @@ public static partial class Net472
             {
                 if (_SystemDynamic is null)
                 {
-                    _SystemDynamic = AssemblyMetadata.CreateFromImage(Resources.SystemDynamic).GetReference(filePath: "System.Dynamic.dll", display: "System.Dynamic (net472)");
+                    _SystemDynamic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Dynamic")).GetReference(filePath: "System.Dynamic.dll", display: "System.Dynamic (net472)");
                 }
                 return _SystemDynamic;
             }
@@ -2509,7 +2509,7 @@ public static partial class Net472
             {
                 if (_SystemEnterpriseServices is null)
                 {
-                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(Resources.SystemEnterpriseServices).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net472)");
+                    _SystemEnterpriseServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.EnterpriseServices")).GetReference(filePath: "System.EnterpriseServices.dll", display: "System.EnterpriseServices (net472)");
                 }
                 return _SystemEnterpriseServices;
             }
@@ -2526,7 +2526,7 @@ public static partial class Net472
             {
                 if (_SystemIdentityModel is null)
                 {
-                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModel).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net472)");
+                    _SystemIdentityModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IdentityModel")).GetReference(filePath: "System.IdentityModel.dll", display: "System.IdentityModel (net472)");
                 }
                 return _SystemIdentityModel;
             }
@@ -2543,7 +2543,7 @@ public static partial class Net472
             {
                 if (_SystemIdentityModelSelectors is null)
                 {
-                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelSelectors).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net472)");
+                    _SystemIdentityModelSelectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IdentityModel.Selectors")).GetReference(filePath: "System.IdentityModel.Selectors.dll", display: "System.IdentityModel.Selectors (net472)");
                 }
                 return _SystemIdentityModelSelectors;
             }
@@ -2560,7 +2560,7 @@ public static partial class Net472
             {
                 if (_SystemIdentityModelServices is null)
                 {
-                    _SystemIdentityModelServices = AssemblyMetadata.CreateFromImage(Resources.SystemIdentityModelServices).GetReference(filePath: "System.IdentityModel.Services.dll", display: "System.IdentityModel.Services (net472)");
+                    _SystemIdentityModelServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IdentityModel.Services")).GetReference(filePath: "System.IdentityModel.Services.dll", display: "System.IdentityModel.Services (net472)");
                 }
                 return _SystemIdentityModelServices;
             }
@@ -2577,7 +2577,7 @@ public static partial class Net472
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net472)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net472)");
                 }
                 return _SystemIOCompression;
             }
@@ -2594,7 +2594,7 @@ public static partial class Net472
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net472)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net472)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -2611,7 +2611,7 @@ public static partial class Net472
             {
                 if (_SystemIOLog is null)
                 {
-                    _SystemIOLog = AssemblyMetadata.CreateFromImage(Resources.SystemIOLog).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net472)");
+                    _SystemIOLog = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Log")).GetReference(filePath: "System.IO.Log.dll", display: "System.IO.Log (net472)");
                 }
                 return _SystemIOLog;
             }
@@ -2628,7 +2628,7 @@ public static partial class Net472
             {
                 if (_SystemManagement is null)
                 {
-                    _SystemManagement = AssemblyMetadata.CreateFromImage(Resources.SystemManagement).GetReference(filePath: "System.Management.dll", display: "System.Management (net472)");
+                    _SystemManagement = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Management")).GetReference(filePath: "System.Management.dll", display: "System.Management (net472)");
                 }
                 return _SystemManagement;
             }
@@ -2645,7 +2645,7 @@ public static partial class Net472
             {
                 if (_SystemManagementInstrumentation is null)
                 {
-                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(Resources.SystemManagementInstrumentation).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net472)");
+                    _SystemManagementInstrumentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Management.Instrumentation")).GetReference(filePath: "System.Management.Instrumentation.dll", display: "System.Management.Instrumentation (net472)");
                 }
                 return _SystemManagementInstrumentation;
             }
@@ -2662,7 +2662,7 @@ public static partial class Net472
             {
                 if (_SystemMessaging is null)
                 {
-                    _SystemMessaging = AssemblyMetadata.CreateFromImage(Resources.SystemMessaging).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net472)");
+                    _SystemMessaging = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Messaging")).GetReference(filePath: "System.Messaging.dll", display: "System.Messaging (net472)");
                 }
                 return _SystemMessaging;
             }
@@ -2679,7 +2679,7 @@ public static partial class Net472
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net472)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net472)");
                 }
                 return _SystemNet;
             }
@@ -2696,7 +2696,7 @@ public static partial class Net472
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net472)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net472)");
                 }
                 return _SystemNetHttp;
             }
@@ -2713,7 +2713,7 @@ public static partial class Net472
             {
                 if (_SystemNetHttpWebRequest is null)
                 {
-                    _SystemNetHttpWebRequest = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpWebRequest).GetReference(filePath: "System.Net.Http.WebRequest.dll", display: "System.Net.Http.WebRequest (net472)");
+                    _SystemNetHttpWebRequest = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Http.WebRequest")).GetReference(filePath: "System.Net.Http.WebRequest.dll", display: "System.Net.Http.WebRequest (net472)");
                 }
                 return _SystemNetHttpWebRequest;
             }
@@ -2730,7 +2730,7 @@ public static partial class Net472
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net472)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net472)");
                 }
                 return _SystemNumerics;
             }
@@ -2747,7 +2747,7 @@ public static partial class Net472
             {
                 if (_SystemPrinting is null)
                 {
-                    _SystemPrinting = AssemblyMetadata.CreateFromImage(Resources.SystemPrinting).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net472)");
+                    _SystemPrinting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Printing")).GetReference(filePath: "System.Printing.dll", display: "System.Printing (net472)");
                 }
                 return _SystemPrinting;
             }
@@ -2764,7 +2764,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionContext is null)
                 {
-                    _SystemReflectionContext = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionContext).GetReference(filePath: "System.Reflection.Context.dll", display: "System.Reflection.Context (net472)");
+                    _SystemReflectionContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Context")).GetReference(filePath: "System.Reflection.Context.dll", display: "System.Reflection.Context (net472)");
                 }
                 return _SystemReflectionContext;
             }
@@ -2781,7 +2781,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeCaching is null)
                 {
-                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCaching).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net472)");
+                    _SystemRuntimeCaching = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Caching")).GetReference(filePath: "System.Runtime.Caching.dll", display: "System.Runtime.Caching (net472)");
                 }
                 return _SystemRuntimeCaching;
             }
@@ -2798,7 +2798,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeDurableInstancing is null)
                 {
-                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeDurableInstancing).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net472)");
+                    _SystemRuntimeDurableInstancing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.DurableInstancing")).GetReference(filePath: "System.Runtime.DurableInstancing.dll", display: "System.Runtime.DurableInstancing (net472)");
                 }
                 return _SystemRuntimeDurableInstancing;
             }
@@ -2815,7 +2815,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeRemoting is null)
                 {
-                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeRemoting).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net472)");
+                    _SystemRuntimeRemoting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Remoting")).GetReference(filePath: "System.Runtime.Remoting.dll", display: "System.Runtime.Remoting (net472)");
                 }
                 return _SystemRuntimeRemoting;
             }
@@ -2832,7 +2832,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net472)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net472)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2849,7 +2849,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationFormattersSoap is null)
                 {
-                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormattersSoap).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net472)");
+                    _SystemRuntimeSerializationFormattersSoap = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Formatters.Soap")).GetReference(filePath: "System.Runtime.Serialization.Formatters.Soap.dll", display: "System.Runtime.Serialization.Formatters.Soap (net472)");
                 }
                 return _SystemRuntimeSerializationFormattersSoap;
             }
@@ -2866,7 +2866,7 @@ public static partial class Net472
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net472)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net472)");
                 }
                 return _SystemSecurity;
             }
@@ -2883,7 +2883,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelActivation is null)
                 {
-                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivation).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net472)");
+                    _SystemServiceModelActivation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Activation")).GetReference(filePath: "System.ServiceModel.Activation.dll", display: "System.ServiceModel.Activation (net472)");
                 }
                 return _SystemServiceModelActivation;
             }
@@ -2900,7 +2900,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelActivities is null)
                 {
-                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelActivities).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net472)");
+                    _SystemServiceModelActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Activities")).GetReference(filePath: "System.ServiceModel.Activities.dll", display: "System.ServiceModel.Activities (net472)");
                 }
                 return _SystemServiceModelActivities;
             }
@@ -2917,7 +2917,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelChannels is null)
                 {
-                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelChannels).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net472)");
+                    _SystemServiceModelChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Channels")).GetReference(filePath: "System.ServiceModel.Channels.dll", display: "System.ServiceModel.Channels (net472)");
                 }
                 return _SystemServiceModelChannels;
             }
@@ -2934,7 +2934,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelDiscovery is null)
                 {
-                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelDiscovery).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net472)");
+                    _SystemServiceModelDiscovery = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Discovery")).GetReference(filePath: "System.ServiceModel.Discovery.dll", display: "System.ServiceModel.Discovery (net472)");
                 }
                 return _SystemServiceModelDiscovery;
             }
@@ -2951,7 +2951,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModel is null)
                 {
-                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModel).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net472)");
+                    _SystemServiceModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel")).GetReference(filePath: "System.ServiceModel.dll", display: "System.ServiceModel (net472)");
                 }
                 return _SystemServiceModel;
             }
@@ -2968,7 +2968,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelRouting is null)
                 {
-                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelRouting).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net472)");
+                    _SystemServiceModelRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Routing")).GetReference(filePath: "System.ServiceModel.Routing.dll", display: "System.ServiceModel.Routing (net472)");
                 }
                 return _SystemServiceModelRouting;
             }
@@ -2985,7 +2985,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net472)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net472)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -3002,7 +3002,7 @@ public static partial class Net472
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net472)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net472)");
                 }
                 return _SystemServiceProcess;
             }
@@ -3019,7 +3019,7 @@ public static partial class Net472
             {
                 if (_SystemSpeech is null)
                 {
-                    _SystemSpeech = AssemblyMetadata.CreateFromImage(Resources.SystemSpeech).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net472)");
+                    _SystemSpeech = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Speech")).GetReference(filePath: "System.Speech.dll", display: "System.Speech (net472)");
                 }
                 return _SystemSpeech;
             }
@@ -3036,7 +3036,7 @@ public static partial class Net472
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net472)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net472)");
                 }
                 return _SystemTransactions;
             }
@@ -3053,7 +3053,7 @@ public static partial class Net472
             {
                 if (_SystemWebAbstractions is null)
                 {
-                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(Resources.SystemWebAbstractions).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net472)");
+                    _SystemWebAbstractions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Abstractions")).GetReference(filePath: "System.Web.Abstractions.dll", display: "System.Web.Abstractions (net472)");
                 }
                 return _SystemWebAbstractions;
             }
@@ -3070,7 +3070,7 @@ public static partial class Net472
             {
                 if (_SystemWebApplicationServices is null)
                 {
-                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebApplicationServices).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net472)");
+                    _SystemWebApplicationServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.ApplicationServices")).GetReference(filePath: "System.Web.ApplicationServices.dll", display: "System.Web.ApplicationServices (net472)");
                 }
                 return _SystemWebApplicationServices;
             }
@@ -3087,7 +3087,7 @@ public static partial class Net472
             {
                 if (_SystemWebDataVisualizationDesign is null)
                 {
-                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualizationDesign).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net472)");
+                    _SystemWebDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DataVisualization.Design")).GetReference(filePath: "System.Web.DataVisualization.Design.dll", display: "System.Web.DataVisualization.Design (net472)");
                 }
                 return _SystemWebDataVisualizationDesign;
             }
@@ -3104,7 +3104,7 @@ public static partial class Net472
             {
                 if (_SystemWebDataVisualization is null)
                 {
-                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWebDataVisualization).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net472)");
+                    _SystemWebDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DataVisualization")).GetReference(filePath: "System.Web.DataVisualization.dll", display: "System.Web.DataVisualization (net472)");
                 }
                 return _SystemWebDataVisualization;
             }
@@ -3121,7 +3121,7 @@ public static partial class Net472
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net472)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net472)");
                 }
                 return _SystemWeb;
             }
@@ -3138,7 +3138,7 @@ public static partial class Net472
             {
                 if (_SystemWebDynamicDataDesign is null)
                 {
-                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicDataDesign).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net472)");
+                    _SystemWebDynamicDataDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DynamicData.Design")).GetReference(filePath: "System.Web.DynamicData.Design.dll", display: "System.Web.DynamicData.Design (net472)");
                 }
                 return _SystemWebDynamicDataDesign;
             }
@@ -3155,7 +3155,7 @@ public static partial class Net472
             {
                 if (_SystemWebDynamicData is null)
                 {
-                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(Resources.SystemWebDynamicData).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net472)");
+                    _SystemWebDynamicData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.DynamicData")).GetReference(filePath: "System.Web.DynamicData.dll", display: "System.Web.DynamicData (net472)");
                 }
                 return _SystemWebDynamicData;
             }
@@ -3172,7 +3172,7 @@ public static partial class Net472
             {
                 if (_SystemWebEntityDesign is null)
                 {
-                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntityDesign).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net472)");
+                    _SystemWebEntityDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Entity.Design")).GetReference(filePath: "System.Web.Entity.Design.dll", display: "System.Web.Entity.Design (net472)");
                 }
                 return _SystemWebEntityDesign;
             }
@@ -3189,7 +3189,7 @@ public static partial class Net472
             {
                 if (_SystemWebEntity is null)
                 {
-                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(Resources.SystemWebEntity).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net472)");
+                    _SystemWebEntity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Entity")).GetReference(filePath: "System.Web.Entity.dll", display: "System.Web.Entity (net472)");
                 }
                 return _SystemWebEntity;
             }
@@ -3206,7 +3206,7 @@ public static partial class Net472
             {
                 if (_SystemWebExtensionsDesign is null)
                 {
-                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensionsDesign).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net472)");
+                    _SystemWebExtensionsDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Extensions.Design")).GetReference(filePath: "System.Web.Extensions.Design.dll", display: "System.Web.Extensions.Design (net472)");
                 }
                 return _SystemWebExtensionsDesign;
             }
@@ -3223,7 +3223,7 @@ public static partial class Net472
             {
                 if (_SystemWebExtensions is null)
                 {
-                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemWebExtensions).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net472)");
+                    _SystemWebExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Extensions")).GetReference(filePath: "System.Web.Extensions.dll", display: "System.Web.Extensions (net472)");
                 }
                 return _SystemWebExtensions;
             }
@@ -3240,7 +3240,7 @@ public static partial class Net472
             {
                 if (_SystemWebMobile is null)
                 {
-                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(Resources.SystemWebMobile).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net472)");
+                    _SystemWebMobile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Mobile")).GetReference(filePath: "System.Web.Mobile.dll", display: "System.Web.Mobile (net472)");
                 }
                 return _SystemWebMobile;
             }
@@ -3257,7 +3257,7 @@ public static partial class Net472
             {
                 if (_SystemWebRegularExpressions is null)
                 {
-                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemWebRegularExpressions).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net472)");
+                    _SystemWebRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.RegularExpressions")).GetReference(filePath: "System.Web.RegularExpressions.dll", display: "System.Web.RegularExpressions (net472)");
                 }
                 return _SystemWebRegularExpressions;
             }
@@ -3274,7 +3274,7 @@ public static partial class Net472
             {
                 if (_SystemWebRouting is null)
                 {
-                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(Resources.SystemWebRouting).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net472)");
+                    _SystemWebRouting = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Routing")).GetReference(filePath: "System.Web.Routing.dll", display: "System.Web.Routing (net472)");
                 }
                 return _SystemWebRouting;
             }
@@ -3291,7 +3291,7 @@ public static partial class Net472
             {
                 if (_SystemWebServices is null)
                 {
-                    _SystemWebServices = AssemblyMetadata.CreateFromImage(Resources.SystemWebServices).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net472)");
+                    _SystemWebServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Web.Services")).GetReference(filePath: "System.Web.Services.dll", display: "System.Web.Services (net472)");
                 }
                 return _SystemWebServices;
             }
@@ -3308,7 +3308,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsControlsRibbon is null)
                 {
-                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsControlsRibbon).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net472)");
+                    _SystemWindowsControlsRibbon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Controls.Ribbon")).GetReference(filePath: "System.Windows.Controls.Ribbon.dll", display: "System.Windows.Controls.Ribbon (net472)");
                 }
                 return _SystemWindowsControlsRibbon;
             }
@@ -3325,7 +3325,7 @@ public static partial class Net472
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net472)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net472)");
                 }
                 return _SystemWindows;
             }
@@ -3342,7 +3342,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsFormsDataVisualizationDesign is null)
                 {
-                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualizationDesign).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net472)");
+                    _SystemWindowsFormsDataVisualizationDesign = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Forms.DataVisualization.Design")).GetReference(filePath: "System.Windows.Forms.DataVisualization.Design.dll", display: "System.Windows.Forms.DataVisualization.Design (net472)");
                 }
                 return _SystemWindowsFormsDataVisualizationDesign;
             }
@@ -3359,7 +3359,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsFormsDataVisualization is null)
                 {
-                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsFormsDataVisualization).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net472)");
+                    _SystemWindowsFormsDataVisualization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Forms.DataVisualization")).GetReference(filePath: "System.Windows.Forms.DataVisualization.dll", display: "System.Windows.Forms.DataVisualization (net472)");
                 }
                 return _SystemWindowsFormsDataVisualization;
             }
@@ -3376,7 +3376,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsForms is null)
                 {
-                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsForms).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net472)");
+                    _SystemWindowsForms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Forms")).GetReference(filePath: "System.Windows.Forms.dll", display: "System.Windows.Forms (net472)");
                 }
                 return _SystemWindowsForms;
             }
@@ -3393,7 +3393,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsInputManipulations is null)
                 {
-                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsInputManipulations).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net472)");
+                    _SystemWindowsInputManipulations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Input.Manipulations")).GetReference(filePath: "System.Windows.Input.Manipulations.dll", display: "System.Windows.Input.Manipulations (net472)");
                 }
                 return _SystemWindowsInputManipulations;
             }
@@ -3410,7 +3410,7 @@ public static partial class Net472
             {
                 if (_SystemWindowsPresentation is null)
                 {
-                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(Resources.SystemWindowsPresentation).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net472)");
+                    _SystemWindowsPresentation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Windows.Presentation")).GetReference(filePath: "System.Windows.Presentation.dll", display: "System.Windows.Presentation (net472)");
                 }
                 return _SystemWindowsPresentation;
             }
@@ -3427,7 +3427,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowActivities is null)
                 {
-                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowActivities).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net472)");
+                    _SystemWorkflowActivities = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Workflow.Activities")).GetReference(filePath: "System.Workflow.Activities.dll", display: "System.Workflow.Activities (net472)");
                 }
                 return _SystemWorkflowActivities;
             }
@@ -3444,7 +3444,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowComponentModel is null)
                 {
-                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowComponentModel).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net472)");
+                    _SystemWorkflowComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Workflow.ComponentModel")).GetReference(filePath: "System.Workflow.ComponentModel.dll", display: "System.Workflow.ComponentModel (net472)");
                 }
                 return _SystemWorkflowComponentModel;
             }
@@ -3461,7 +3461,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowRuntime is null)
                 {
-                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowRuntime).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net472)");
+                    _SystemWorkflowRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Workflow.Runtime")).GetReference(filePath: "System.Workflow.Runtime.dll", display: "System.Workflow.Runtime (net472)");
                 }
                 return _SystemWorkflowRuntime;
             }
@@ -3478,7 +3478,7 @@ public static partial class Net472
             {
                 if (_SystemWorkflowServices is null)
                 {
-                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(Resources.SystemWorkflowServices).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net472)");
+                    _SystemWorkflowServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.WorkflowServices")).GetReference(filePath: "System.WorkflowServices.dll", display: "System.WorkflowServices (net472)");
                 }
                 return _SystemWorkflowServices;
             }
@@ -3495,7 +3495,7 @@ public static partial class Net472
             {
                 if (_SystemXaml is null)
                 {
-                    _SystemXaml = AssemblyMetadata.CreateFromImage(Resources.SystemXaml).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net472)");
+                    _SystemXaml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xaml")).GetReference(filePath: "System.Xaml.dll", display: "System.Xaml (net472)");
                 }
                 return _SystemXaml;
             }
@@ -3512,7 +3512,7 @@ public static partial class Net472
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net472)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net472)");
                 }
                 return _SystemXml;
             }
@@ -3529,7 +3529,7 @@ public static partial class Net472
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net472)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net472)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3546,7 +3546,7 @@ public static partial class Net472
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net472)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net472)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3563,7 +3563,7 @@ public static partial class Net472
             {
                 if (_UIAutomationClient is null)
                 {
-                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClient).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net472)");
+                    _UIAutomationClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationClient")).GetReference(filePath: "UIAutomationClient.dll", display: "UIAutomationClient (net472)");
                 }
                 return _UIAutomationClient;
             }
@@ -3580,7 +3580,7 @@ public static partial class Net472
             {
                 if (_UIAutomationClientsideProviders is null)
                 {
-                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(Resources.UIAutomationClientsideProviders).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net472)");
+                    _UIAutomationClientsideProviders = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationClientsideProviders")).GetReference(filePath: "UIAutomationClientsideProviders.dll", display: "UIAutomationClientsideProviders (net472)");
                 }
                 return _UIAutomationClientsideProviders;
             }
@@ -3597,7 +3597,7 @@ public static partial class Net472
             {
                 if (_UIAutomationProvider is null)
                 {
-                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(Resources.UIAutomationProvider).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net472)");
+                    _UIAutomationProvider = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationProvider")).GetReference(filePath: "UIAutomationProvider.dll", display: "UIAutomationProvider (net472)");
                 }
                 return _UIAutomationProvider;
             }
@@ -3614,7 +3614,7 @@ public static partial class Net472
             {
                 if (_UIAutomationTypes is null)
                 {
-                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(Resources.UIAutomationTypes).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net472)");
+                    _UIAutomationTypes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.UIAutomationTypes")).GetReference(filePath: "UIAutomationTypes.dll", display: "UIAutomationTypes (net472)");
                 }
                 return _UIAutomationTypes;
             }
@@ -3631,7 +3631,7 @@ public static partial class Net472
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net472)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net472)");
                 }
                 return _WindowsBase;
             }
@@ -3648,7 +3648,7 @@ public static partial class Net472
             {
                 if (_WindowsFormsIntegration is null)
                 {
-                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(Resources.WindowsFormsIntegration).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net472)");
+                    _WindowsFormsIntegration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.WindowsFormsIntegration")).GetReference(filePath: "WindowsFormsIntegration.dll", display: "WindowsFormsIntegration (net472)");
                 }
                 return _WindowsFormsIntegration;
             }
@@ -3665,7 +3665,7 @@ public static partial class Net472
             {
                 if (_XamlBuildTask is null)
                 {
-                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(Resources.XamlBuildTask).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net472)");
+                    _XamlBuildTask = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.XamlBuildTask")).GetReference(filePath: "XamlBuildTask.dll", display: "XamlBuildTask (net472)");
                 }
                 return _XamlBuildTask;
             }
@@ -3682,7 +3682,7 @@ public static partial class Net472
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net472)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net472)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -3699,7 +3699,7 @@ public static partial class Net472
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net472)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net472)");
                 }
                 return _netstandard;
             }
@@ -3716,7 +3716,7 @@ public static partial class Net472
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net472)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net472)");
                 }
                 return _SystemAppContext;
             }
@@ -3733,7 +3733,7 @@ public static partial class Net472
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net472)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net472)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -3750,7 +3750,7 @@ public static partial class Net472
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net472)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net472)");
                 }
                 return _SystemCollections;
             }
@@ -3767,7 +3767,7 @@ public static partial class Net472
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net472)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net472)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -3784,7 +3784,7 @@ public static partial class Net472
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net472)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net472)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -3801,7 +3801,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net472)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net472)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -3818,7 +3818,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net472)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net472)");
                 }
                 return _SystemComponentModel;
             }
@@ -3835,7 +3835,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net472)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net472)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -3852,7 +3852,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net472)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net472)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -3869,7 +3869,7 @@ public static partial class Net472
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net472)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net472)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -3886,7 +3886,7 @@ public static partial class Net472
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net472)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net472)");
                 }
                 return _SystemConsole;
             }
@@ -3903,7 +3903,7 @@ public static partial class Net472
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net472)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net472)");
                 }
                 return _SystemDataCommon;
             }
@@ -3920,7 +3920,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net472)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net472)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -3937,7 +3937,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net472)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net472)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -3954,7 +3954,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net472)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net472)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -3971,7 +3971,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net472)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net472)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -3988,7 +3988,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net472)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net472)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -4005,7 +4005,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net472)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net472)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -4022,7 +4022,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net472)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net472)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -4039,7 +4039,7 @@ public static partial class Net472
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net472)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net472)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -4056,7 +4056,7 @@ public static partial class Net472
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net472)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net472)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -4073,7 +4073,7 @@ public static partial class Net472
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net472)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net472)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -4090,7 +4090,7 @@ public static partial class Net472
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net472)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net472)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -4107,7 +4107,7 @@ public static partial class Net472
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net472)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net472)");
                 }
                 return _SystemGlobalization;
             }
@@ -4124,7 +4124,7 @@ public static partial class Net472
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net472)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net472)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -4141,7 +4141,7 @@ public static partial class Net472
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net472)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net472)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -4158,7 +4158,7 @@ public static partial class Net472
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net472)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net472)");
                 }
                 return _SystemIO;
             }
@@ -4175,7 +4175,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net472)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net472)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -4192,7 +4192,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net472)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net472)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -4209,7 +4209,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net472)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net472)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -4226,7 +4226,7 @@ public static partial class Net472
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net472)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net472)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -4243,7 +4243,7 @@ public static partial class Net472
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net472)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net472)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -4260,7 +4260,7 @@ public static partial class Net472
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net472)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net472)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -4277,7 +4277,7 @@ public static partial class Net472
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net472)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net472)");
                 }
                 return _SystemIOPipes;
             }
@@ -4294,7 +4294,7 @@ public static partial class Net472
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net472)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net472)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -4311,7 +4311,7 @@ public static partial class Net472
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net472)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net472)");
                 }
                 return _SystemLinq;
             }
@@ -4328,7 +4328,7 @@ public static partial class Net472
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net472)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net472)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -4345,7 +4345,7 @@ public static partial class Net472
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net472)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net472)");
                 }
                 return _SystemLinqParallel;
             }
@@ -4362,7 +4362,7 @@ public static partial class Net472
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net472)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net472)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -4379,7 +4379,7 @@ public static partial class Net472
             {
                 if (_SystemNetHttpRtc is null)
                 {
-                    _SystemNetHttpRtc = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpRtc).GetReference(filePath: "System.Net.Http.Rtc.dll", display: "System.Net.Http.Rtc (net472)");
+                    _SystemNetHttpRtc = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Http.Rtc")).GetReference(filePath: "System.Net.Http.Rtc.dll", display: "System.Net.Http.Rtc (net472)");
                 }
                 return _SystemNetHttpRtc;
             }
@@ -4396,7 +4396,7 @@ public static partial class Net472
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net472)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net472)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -4413,7 +4413,7 @@ public static partial class Net472
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net472)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net472)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -4430,7 +4430,7 @@ public static partial class Net472
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net472)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net472)");
                 }
                 return _SystemNetPing;
             }
@@ -4447,7 +4447,7 @@ public static partial class Net472
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net472)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net472)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -4464,7 +4464,7 @@ public static partial class Net472
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net472)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net472)");
                 }
                 return _SystemNetRequests;
             }
@@ -4481,7 +4481,7 @@ public static partial class Net472
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net472)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net472)");
                 }
                 return _SystemNetSecurity;
             }
@@ -4498,7 +4498,7 @@ public static partial class Net472
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net472)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net472)");
                 }
                 return _SystemNetSockets;
             }
@@ -4515,7 +4515,7 @@ public static partial class Net472
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net472)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net472)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -4532,7 +4532,7 @@ public static partial class Net472
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net472)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net472)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -4549,7 +4549,7 @@ public static partial class Net472
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net472)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net472)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -4566,7 +4566,7 @@ public static partial class Net472
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net472)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net472)");
                 }
                 return _SystemObjectModel;
             }
@@ -4583,7 +4583,7 @@ public static partial class Net472
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net472)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net472)");
                 }
                 return _SystemReflection;
             }
@@ -4600,7 +4600,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net472)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net472)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -4617,7 +4617,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net472)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net472)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -4634,7 +4634,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net472)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net472)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -4651,7 +4651,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net472)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net472)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -4668,7 +4668,7 @@ public static partial class Net472
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net472)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net472)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -4685,7 +4685,7 @@ public static partial class Net472
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net472)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net472)");
                 }
                 return _SystemResourcesReader;
             }
@@ -4702,7 +4702,7 @@ public static partial class Net472
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net472)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net472)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -4719,7 +4719,7 @@ public static partial class Net472
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net472)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net472)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -4736,7 +4736,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net472)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net472)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -4753,7 +4753,7 @@ public static partial class Net472
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net472)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net472)");
                 }
                 return _SystemRuntime;
             }
@@ -4770,7 +4770,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net472)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net472)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -4787,7 +4787,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net472)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net472)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -4804,7 +4804,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net472)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net472)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -4821,7 +4821,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net472)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net472)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -4838,7 +4838,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeInteropServicesWindowsRuntime is null)
                 {
-                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesWindowsRuntime).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (net472)");
+                    _SystemRuntimeInteropServicesWindowsRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.InteropServices.WindowsRuntime")).GetReference(filePath: "System.Runtime.InteropServices.WindowsRuntime.dll", display: "System.Runtime.InteropServices.WindowsRuntime (net472)");
                 }
                 return _SystemRuntimeInteropServicesWindowsRuntime;
             }
@@ -4855,7 +4855,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net472)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net472)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -4872,7 +4872,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net472)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net472)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -4889,7 +4889,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net472)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net472)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -4906,7 +4906,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net472)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net472)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -4923,7 +4923,7 @@ public static partial class Net472
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net472)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net472)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -4940,7 +4940,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net472)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net472)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -4957,7 +4957,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net472)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net472)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -4974,7 +4974,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net472)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net472)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -4991,7 +4991,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net472)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net472)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -5008,7 +5008,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net472)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net472)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -5025,7 +5025,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net472)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net472)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -5042,7 +5042,7 @@ public static partial class Net472
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net472)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net472)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -5059,7 +5059,7 @@ public static partial class Net472
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net472)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net472)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -5076,7 +5076,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelDuplex is null)
                 {
-                    _SystemServiceModelDuplex = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelDuplex).GetReference(filePath: "System.ServiceModel.Duplex.dll", display: "System.ServiceModel.Duplex (net472)");
+                    _SystemServiceModelDuplex = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Duplex")).GetReference(filePath: "System.ServiceModel.Duplex.dll", display: "System.ServiceModel.Duplex (net472)");
                 }
                 return _SystemServiceModelDuplex;
             }
@@ -5093,7 +5093,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelHttp is null)
                 {
-                    _SystemServiceModelHttp = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelHttp).GetReference(filePath: "System.ServiceModel.Http.dll", display: "System.ServiceModel.Http (net472)");
+                    _SystemServiceModelHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Http")).GetReference(filePath: "System.ServiceModel.Http.dll", display: "System.ServiceModel.Http (net472)");
                 }
                 return _SystemServiceModelHttp;
             }
@@ -5110,7 +5110,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelNetTcp is null)
                 {
-                    _SystemServiceModelNetTcp = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelNetTcp).GetReference(filePath: "System.ServiceModel.NetTcp.dll", display: "System.ServiceModel.NetTcp (net472)");
+                    _SystemServiceModelNetTcp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.NetTcp")).GetReference(filePath: "System.ServiceModel.NetTcp.dll", display: "System.ServiceModel.NetTcp (net472)");
                 }
                 return _SystemServiceModelNetTcp;
             }
@@ -5127,7 +5127,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelPrimitives is null)
                 {
-                    _SystemServiceModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelPrimitives).GetReference(filePath: "System.ServiceModel.Primitives.dll", display: "System.ServiceModel.Primitives (net472)");
+                    _SystemServiceModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Primitives")).GetReference(filePath: "System.ServiceModel.Primitives.dll", display: "System.ServiceModel.Primitives (net472)");
                 }
                 return _SystemServiceModelPrimitives;
             }
@@ -5144,7 +5144,7 @@ public static partial class Net472
             {
                 if (_SystemServiceModelSecurity is null)
                 {
-                    _SystemServiceModelSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelSecurity).GetReference(filePath: "System.ServiceModel.Security.dll", display: "System.ServiceModel.Security (net472)");
+                    _SystemServiceModelSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ServiceModel.Security")).GetReference(filePath: "System.ServiceModel.Security.dll", display: "System.ServiceModel.Security (net472)");
                 }
                 return _SystemServiceModelSecurity;
             }
@@ -5161,7 +5161,7 @@ public static partial class Net472
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net472)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net472)");
                 }
                 return _SystemTextEncoding;
             }
@@ -5178,7 +5178,7 @@ public static partial class Net472
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net472)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net472)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -5195,7 +5195,7 @@ public static partial class Net472
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net472)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net472)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -5212,7 +5212,7 @@ public static partial class Net472
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net472)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net472)");
                 }
                 return _SystemThreading;
             }
@@ -5229,7 +5229,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net472)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net472)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -5246,7 +5246,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net472)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net472)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -5263,7 +5263,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net472)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net472)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -5280,7 +5280,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net472)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net472)");
                 }
                 return _SystemThreadingThread;
             }
@@ -5297,7 +5297,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net472)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net472)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -5314,7 +5314,7 @@ public static partial class Net472
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net472)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net472)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -5331,7 +5331,7 @@ public static partial class Net472
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net472)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net472)");
                 }
                 return _SystemValueTuple;
             }
@@ -5348,7 +5348,7 @@ public static partial class Net472
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net472)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net472)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -5365,7 +5365,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net472)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net472)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -5382,7 +5382,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net472)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net472)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -5399,7 +5399,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net472)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net472)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -5416,7 +5416,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net472)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net472)");
                 }
                 return _SystemXmlXPath;
             }
@@ -5433,7 +5433,7 @@ public static partial class Net472
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net472)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net472.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net472)");
                 }
                 return _SystemXmlXPathXDocument;
             }

--- a/Src/Basic.Reference.Assemblies/Generated.Net80.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.Net80.cs
@@ -1023,7 +1023,7 @@ public static partial class Net80
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net80)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (net80)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -1040,7 +1040,7 @@ public static partial class Net80
             {
                 if (_MicrosoftVisualBasicCore is null)
                 {
-                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasicCore).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net80)");
+                    _MicrosoftVisualBasicCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.VisualBasic.Core")).GetReference(filePath: "Microsoft.VisualBasic.Core.dll", display: "Microsoft.VisualBasic.Core (net80)");
                 }
                 return _MicrosoftVisualBasicCore;
             }
@@ -1057,7 +1057,7 @@ public static partial class Net80
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net80)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (net80)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -1074,7 +1074,7 @@ public static partial class Net80
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net80)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (net80)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -1091,7 +1091,7 @@ public static partial class Net80
             {
                 if (_MicrosoftWin32Registry is null)
                 {
-                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Registry).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net80)");
+                    _MicrosoftWin32Registry = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.Microsoft.Win32.Registry")).GetReference(filePath: "Microsoft.Win32.Registry.dll", display: "Microsoft.Win32.Registry (net80)");
                 }
                 return _MicrosoftWin32Registry;
             }
@@ -1108,7 +1108,7 @@ public static partial class Net80
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net80)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (net80)");
                 }
                 return _mscorlib;
             }
@@ -1125,7 +1125,7 @@ public static partial class Net80
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (net80)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (net80)");
                 }
                 return _netstandard;
             }
@@ -1142,7 +1142,7 @@ public static partial class Net80
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net80)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (net80)");
                 }
                 return _SystemAppContext;
             }
@@ -1159,7 +1159,7 @@ public static partial class Net80
             {
                 if (_SystemBuffers is null)
                 {
-                    _SystemBuffers = AssemblyMetadata.CreateFromImage(Resources.SystemBuffers).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net80)");
+                    _SystemBuffers = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Buffers")).GetReference(filePath: "System.Buffers.dll", display: "System.Buffers (net80)");
                 }
                 return _SystemBuffers;
             }
@@ -1176,7 +1176,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net80)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (net80)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -1193,7 +1193,7 @@ public static partial class Net80
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net80)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (net80)");
                 }
                 return _SystemCollections;
             }
@@ -1210,7 +1210,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsImmutable is null)
                 {
-                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsImmutable).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net80)");
+                    _SystemCollectionsImmutable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.Immutable")).GetReference(filePath: "System.Collections.Immutable.dll", display: "System.Collections.Immutable (net80)");
                 }
                 return _SystemCollectionsImmutable;
             }
@@ -1227,7 +1227,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net80)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (net80)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -1244,7 +1244,7 @@ public static partial class Net80
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net80)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (net80)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -1261,7 +1261,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelAnnotations is null)
                 {
-                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelAnnotations).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net80)");
+                    _SystemComponentModelAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.Annotations")).GetReference(filePath: "System.ComponentModel.Annotations.dll", display: "System.ComponentModel.Annotations (net80)");
                 }
                 return _SystemComponentModelAnnotations;
             }
@@ -1278,7 +1278,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelDataAnnotations is null)
                 {
-                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelDataAnnotations).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net80)");
+                    _SystemComponentModelDataAnnotations = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.DataAnnotations")).GetReference(filePath: "System.ComponentModel.DataAnnotations.dll", display: "System.ComponentModel.DataAnnotations (net80)");
                 }
                 return _SystemComponentModelDataAnnotations;
             }
@@ -1295,7 +1295,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net80)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (net80)");
                 }
                 return _SystemComponentModel;
             }
@@ -1312,7 +1312,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net80)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (net80)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -1329,7 +1329,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net80)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (net80)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -1346,7 +1346,7 @@ public static partial class Net80
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net80)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (net80)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -1363,7 +1363,7 @@ public static partial class Net80
             {
                 if (_SystemConfiguration is null)
                 {
-                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(Resources.SystemConfiguration).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net80)");
+                    _SystemConfiguration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Configuration")).GetReference(filePath: "System.Configuration.dll", display: "System.Configuration (net80)");
                 }
                 return _SystemConfiguration;
             }
@@ -1380,7 +1380,7 @@ public static partial class Net80
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (net80)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (net80)");
                 }
                 return _SystemConsole;
             }
@@ -1397,7 +1397,7 @@ public static partial class Net80
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (net80)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (net80)");
                 }
                 return _SystemCore;
             }
@@ -1414,7 +1414,7 @@ public static partial class Net80
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net80)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (net80)");
                 }
                 return _SystemDataCommon;
             }
@@ -1431,7 +1431,7 @@ public static partial class Net80
             {
                 if (_SystemDataDataSetExtensions is null)
                 {
-                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemDataDataSetExtensions).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net80)");
+                    _SystemDataDataSetExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Data.DataSetExtensions")).GetReference(filePath: "System.Data.DataSetExtensions.dll", display: "System.Data.DataSetExtensions (net80)");
                 }
                 return _SystemDataDataSetExtensions;
             }
@@ -1448,7 +1448,7 @@ public static partial class Net80
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (net80)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (net80)");
                 }
                 return _SystemData;
             }
@@ -1465,7 +1465,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net80)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (net80)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1482,7 +1482,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net80)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (net80)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1499,7 +1499,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsDiagnosticSource is null)
                 {
-                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDiagnosticSource).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net80)");
+                    _SystemDiagnosticsDiagnosticSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.DiagnosticSource")).GetReference(filePath: "System.Diagnostics.DiagnosticSource.dll", display: "System.Diagnostics.DiagnosticSource (net80)");
                 }
                 return _SystemDiagnosticsDiagnosticSource;
             }
@@ -1516,7 +1516,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net80)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (net80)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1533,7 +1533,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net80)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (net80)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1550,7 +1550,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net80)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (net80)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1567,7 +1567,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net80)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (net80)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1584,7 +1584,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net80)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (net80)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1601,7 +1601,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net80)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (net80)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1618,7 +1618,7 @@ public static partial class Net80
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net80)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (net80)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1635,7 +1635,7 @@ public static partial class Net80
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (net80)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System")).GetReference(filePath: "System.dll", display: "System (net80)");
                 }
                 return _System;
             }
@@ -1652,7 +1652,7 @@ public static partial class Net80
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net80)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (net80)");
                 }
                 return _SystemDrawing;
             }
@@ -1669,7 +1669,7 @@ public static partial class Net80
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net80)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (net80)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1686,7 +1686,7 @@ public static partial class Net80
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net80)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (net80)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1703,7 +1703,7 @@ public static partial class Net80
             {
                 if (_SystemFormatsAsn1 is null)
                 {
-                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsAsn1).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net80)");
+                    _SystemFormatsAsn1 = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Formats.Asn1")).GetReference(filePath: "System.Formats.Asn1.dll", display: "System.Formats.Asn1 (net80)");
                 }
                 return _SystemFormatsAsn1;
             }
@@ -1720,7 +1720,7 @@ public static partial class Net80
             {
                 if (_SystemFormatsTar is null)
                 {
-                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(Resources.SystemFormatsTar).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net80)");
+                    _SystemFormatsTar = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Formats.Tar")).GetReference(filePath: "System.Formats.Tar.dll", display: "System.Formats.Tar (net80)");
                 }
                 return _SystemFormatsTar;
             }
@@ -1737,7 +1737,7 @@ public static partial class Net80
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net80)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (net80)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1754,7 +1754,7 @@ public static partial class Net80
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net80)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (net80)");
                 }
                 return _SystemGlobalization;
             }
@@ -1771,7 +1771,7 @@ public static partial class Net80
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net80)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (net80)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1788,7 +1788,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompressionBrotli is null)
                 {
-                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionBrotli).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net80)");
+                    _SystemIOCompressionBrotli = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression.Brotli")).GetReference(filePath: "System.IO.Compression.Brotli.dll", display: "System.IO.Compression.Brotli (net80)");
                 }
                 return _SystemIOCompressionBrotli;
             }
@@ -1805,7 +1805,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net80)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (net80)");
                 }
                 return _SystemIOCompression;
             }
@@ -1822,7 +1822,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net80)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (net80)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1839,7 +1839,7 @@ public static partial class Net80
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net80)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (net80)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1856,7 +1856,7 @@ public static partial class Net80
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (net80)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (net80)");
                 }
                 return _SystemIO;
             }
@@ -1873,7 +1873,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemAccessControl is null)
                 {
-                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemAccessControl).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net80)");
+                    _SystemIOFileSystemAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.AccessControl")).GetReference(filePath: "System.IO.FileSystem.AccessControl.dll", display: "System.IO.FileSystem.AccessControl (net80)");
                 }
                 return _SystemIOFileSystemAccessControl;
             }
@@ -1890,7 +1890,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net80)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (net80)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1907,7 +1907,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net80)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (net80)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1924,7 +1924,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net80)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (net80)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1941,7 +1941,7 @@ public static partial class Net80
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net80)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (net80)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1958,7 +1958,7 @@ public static partial class Net80
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net80)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (net80)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1975,7 +1975,7 @@ public static partial class Net80
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net80)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (net80)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1992,7 +1992,7 @@ public static partial class Net80
             {
                 if (_SystemIOPipesAccessControl is null)
                 {
-                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipesAccessControl).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net80)");
+                    _SystemIOPipesAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Pipes.AccessControl")).GetReference(filePath: "System.IO.Pipes.AccessControl.dll", display: "System.IO.Pipes.AccessControl (net80)");
                 }
                 return _SystemIOPipesAccessControl;
             }
@@ -2009,7 +2009,7 @@ public static partial class Net80
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net80)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (net80)");
                 }
                 return _SystemIOPipes;
             }
@@ -2026,7 +2026,7 @@ public static partial class Net80
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net80)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (net80)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -2043,7 +2043,7 @@ public static partial class Net80
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net80)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (net80)");
                 }
                 return _SystemLinq;
             }
@@ -2060,7 +2060,7 @@ public static partial class Net80
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net80)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (net80)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -2077,7 +2077,7 @@ public static partial class Net80
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net80)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (net80)");
                 }
                 return _SystemLinqParallel;
             }
@@ -2094,7 +2094,7 @@ public static partial class Net80
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net80)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (net80)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -2111,7 +2111,7 @@ public static partial class Net80
             {
                 if (_SystemMemory is null)
                 {
-                    _SystemMemory = AssemblyMetadata.CreateFromImage(Resources.SystemMemory).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net80)");
+                    _SystemMemory = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Memory")).GetReference(filePath: "System.Memory.dll", display: "System.Memory (net80)");
                 }
                 return _SystemMemory;
             }
@@ -2128,7 +2128,7 @@ public static partial class Net80
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (net80)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (net80)");
                 }
                 return _SystemNet;
             }
@@ -2145,7 +2145,7 @@ public static partial class Net80
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net80)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (net80)");
                 }
                 return _SystemNetHttp;
             }
@@ -2162,7 +2162,7 @@ public static partial class Net80
             {
                 if (_SystemNetHttpJson is null)
                 {
-                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpJson).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net80)");
+                    _SystemNetHttpJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Http.Json")).GetReference(filePath: "System.Net.Http.Json.dll", display: "System.Net.Http.Json (net80)");
                 }
                 return _SystemNetHttpJson;
             }
@@ -2179,7 +2179,7 @@ public static partial class Net80
             {
                 if (_SystemNetHttpListener is null)
                 {
-                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttpListener).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net80)");
+                    _SystemNetHttpListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.HttpListener")).GetReference(filePath: "System.Net.HttpListener.dll", display: "System.Net.HttpListener (net80)");
                 }
                 return _SystemNetHttpListener;
             }
@@ -2196,7 +2196,7 @@ public static partial class Net80
             {
                 if (_SystemNetMail is null)
                 {
-                    _SystemNetMail = AssemblyMetadata.CreateFromImage(Resources.SystemNetMail).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net80)");
+                    _SystemNetMail = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Mail")).GetReference(filePath: "System.Net.Mail.dll", display: "System.Net.Mail (net80)");
                 }
                 return _SystemNetMail;
             }
@@ -2213,7 +2213,7 @@ public static partial class Net80
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net80)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (net80)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -2230,7 +2230,7 @@ public static partial class Net80
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net80)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (net80)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -2247,7 +2247,7 @@ public static partial class Net80
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net80)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (net80)");
                 }
                 return _SystemNetPing;
             }
@@ -2264,7 +2264,7 @@ public static partial class Net80
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net80)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (net80)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -2281,7 +2281,7 @@ public static partial class Net80
             {
                 if (_SystemNetQuic is null)
                 {
-                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(Resources.SystemNetQuic).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net80)");
+                    _SystemNetQuic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Quic")).GetReference(filePath: "System.Net.Quic.dll", display: "System.Net.Quic (net80)");
                 }
                 return _SystemNetQuic;
             }
@@ -2298,7 +2298,7 @@ public static partial class Net80
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net80)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (net80)");
                 }
                 return _SystemNetRequests;
             }
@@ -2315,7 +2315,7 @@ public static partial class Net80
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net80)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (net80)");
                 }
                 return _SystemNetSecurity;
             }
@@ -2332,7 +2332,7 @@ public static partial class Net80
             {
                 if (_SystemNetServicePoint is null)
                 {
-                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(Resources.SystemNetServicePoint).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net80)");
+                    _SystemNetServicePoint = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.ServicePoint")).GetReference(filePath: "System.Net.ServicePoint.dll", display: "System.Net.ServicePoint (net80)");
                 }
                 return _SystemNetServicePoint;
             }
@@ -2349,7 +2349,7 @@ public static partial class Net80
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net80)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (net80)");
                 }
                 return _SystemNetSockets;
             }
@@ -2366,7 +2366,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebClient is null)
                 {
-                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebClient).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net80)");
+                    _SystemNetWebClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebClient")).GetReference(filePath: "System.Net.WebClient.dll", display: "System.Net.WebClient (net80)");
                 }
                 return _SystemNetWebClient;
             }
@@ -2383,7 +2383,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net80)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (net80)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -2400,7 +2400,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebProxy is null)
                 {
-                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebProxy).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net80)");
+                    _SystemNetWebProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebProxy")).GetReference(filePath: "System.Net.WebProxy.dll", display: "System.Net.WebProxy (net80)");
                 }
                 return _SystemNetWebProxy;
             }
@@ -2417,7 +2417,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net80)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (net80)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -2434,7 +2434,7 @@ public static partial class Net80
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net80)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (net80)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -2451,7 +2451,7 @@ public static partial class Net80
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net80)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (net80)");
                 }
                 return _SystemNumerics;
             }
@@ -2468,7 +2468,7 @@ public static partial class Net80
             {
                 if (_SystemNumericsVectors is null)
                 {
-                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(Resources.SystemNumericsVectors).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net80)");
+                    _SystemNumericsVectors = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Numerics.Vectors")).GetReference(filePath: "System.Numerics.Vectors.dll", display: "System.Numerics.Vectors (net80)");
                 }
                 return _SystemNumericsVectors;
             }
@@ -2485,7 +2485,7 @@ public static partial class Net80
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net80)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (net80)");
                 }
                 return _SystemObjectModel;
             }
@@ -2502,7 +2502,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionDispatchProxy is null)
                 {
-                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionDispatchProxy).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net80)");
+                    _SystemReflectionDispatchProxy = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.DispatchProxy")).GetReference(filePath: "System.Reflection.DispatchProxy.dll", display: "System.Reflection.DispatchProxy (net80)");
                 }
                 return _SystemReflectionDispatchProxy;
             }
@@ -2519,7 +2519,7 @@ public static partial class Net80
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net80)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (net80)");
                 }
                 return _SystemReflection;
             }
@@ -2536,7 +2536,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionEmit is null)
                 {
-                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmit).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net80)");
+                    _SystemReflectionEmit = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Emit")).GetReference(filePath: "System.Reflection.Emit.dll", display: "System.Reflection.Emit (net80)");
                 }
                 return _SystemReflectionEmit;
             }
@@ -2553,7 +2553,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionEmitILGeneration is null)
                 {
-                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitILGeneration).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net80)");
+                    _SystemReflectionEmitILGeneration = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Emit.ILGeneration")).GetReference(filePath: "System.Reflection.Emit.ILGeneration.dll", display: "System.Reflection.Emit.ILGeneration (net80)");
                 }
                 return _SystemReflectionEmitILGeneration;
             }
@@ -2570,7 +2570,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionEmitLightweight is null)
                 {
-                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionEmitLightweight).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net80)");
+                    _SystemReflectionEmitLightweight = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Emit.Lightweight")).GetReference(filePath: "System.Reflection.Emit.Lightweight.dll", display: "System.Reflection.Emit.Lightweight (net80)");
                 }
                 return _SystemReflectionEmitLightweight;
             }
@@ -2587,7 +2587,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net80)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (net80)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -2604,7 +2604,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionMetadata is null)
                 {
-                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionMetadata).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net80)");
+                    _SystemReflectionMetadata = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Metadata")).GetReference(filePath: "System.Reflection.Metadata.dll", display: "System.Reflection.Metadata (net80)");
                 }
                 return _SystemReflectionMetadata;
             }
@@ -2621,7 +2621,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net80)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (net80)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -2638,7 +2638,7 @@ public static partial class Net80
             {
                 if (_SystemReflectionTypeExtensions is null)
                 {
-                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionTypeExtensions).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net80)");
+                    _SystemReflectionTypeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Reflection.TypeExtensions")).GetReference(filePath: "System.Reflection.TypeExtensions.dll", display: "System.Reflection.TypeExtensions (net80)");
                 }
                 return _SystemReflectionTypeExtensions;
             }
@@ -2655,7 +2655,7 @@ public static partial class Net80
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net80)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (net80)");
                 }
                 return _SystemResourcesReader;
             }
@@ -2672,7 +2672,7 @@ public static partial class Net80
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net80)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (net80)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -2689,7 +2689,7 @@ public static partial class Net80
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net80)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (net80)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -2706,7 +2706,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeCompilerServicesUnsafe is null)
                 {
-                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesUnsafe).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net80)");
+                    _SystemRuntimeCompilerServicesUnsafe = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.CompilerServices.Unsafe")).GetReference(filePath: "System.Runtime.CompilerServices.Unsafe.dll", display: "System.Runtime.CompilerServices.Unsafe (net80)");
                 }
                 return _SystemRuntimeCompilerServicesUnsafe;
             }
@@ -2723,7 +2723,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net80)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (net80)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -2740,7 +2740,7 @@ public static partial class Net80
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net80)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (net80)");
                 }
                 return _SystemRuntime;
             }
@@ -2757,7 +2757,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net80)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (net80)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -2774,7 +2774,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net80)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (net80)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -2791,7 +2791,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net80)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (net80)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -2808,7 +2808,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeInteropServicesJavaScript is null)
                 {
-                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesJavaScript).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net80)");
+                    _SystemRuntimeInteropServicesJavaScript = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.InteropServices.JavaScript")).GetReference(filePath: "System.Runtime.InteropServices.JavaScript.dll", display: "System.Runtime.InteropServices.JavaScript (net80)");
                 }
                 return _SystemRuntimeInteropServicesJavaScript;
             }
@@ -2825,7 +2825,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net80)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (net80)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -2842,7 +2842,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeIntrinsics is null)
                 {
-                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeIntrinsics).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net80)");
+                    _SystemRuntimeIntrinsics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Intrinsics")).GetReference(filePath: "System.Runtime.Intrinsics.dll", display: "System.Runtime.Intrinsics (net80)");
                 }
                 return _SystemRuntimeIntrinsics;
             }
@@ -2859,7 +2859,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeLoader is null)
                 {
-                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeLoader).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net80)");
+                    _SystemRuntimeLoader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Loader")).GetReference(filePath: "System.Runtime.Loader.dll", display: "System.Runtime.Loader (net80)");
                 }
                 return _SystemRuntimeLoader;
             }
@@ -2876,7 +2876,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net80)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (net80)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2893,7 +2893,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net80)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (net80)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2910,7 +2910,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net80)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (net80)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2927,7 +2927,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net80)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (net80)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2944,7 +2944,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net80)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (net80)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2961,7 +2961,7 @@ public static partial class Net80
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net80)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (net80)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2978,7 +2978,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityAccessControl is null)
                 {
-                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityAccessControl).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net80)");
+                    _SystemSecurityAccessControl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.AccessControl")).GetReference(filePath: "System.Security.AccessControl.dll", display: "System.Security.AccessControl (net80)");
                 }
                 return _SystemSecurityAccessControl;
             }
@@ -2995,7 +2995,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net80)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (net80)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -3012,7 +3012,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net80)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (net80)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -3029,7 +3029,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyCng is null)
                 {
-                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCng).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net80)");
+                    _SystemSecurityCryptographyCng = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Cng")).GetReference(filePath: "System.Security.Cryptography.Cng.dll", display: "System.Security.Cryptography.Cng (net80)");
                 }
                 return _SystemSecurityCryptographyCng;
             }
@@ -3046,7 +3046,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net80)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (net80)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -3063,7 +3063,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptography is null)
                 {
-                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptography).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net80)");
+                    _SystemSecurityCryptography = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography")).GetReference(filePath: "System.Security.Cryptography.dll", display: "System.Security.Cryptography (net80)");
                 }
                 return _SystemSecurityCryptography;
             }
@@ -3080,7 +3080,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net80)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (net80)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -3097,7 +3097,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyOpenSsl is null)
                 {
-                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyOpenSsl).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net80)");
+                    _SystemSecurityCryptographyOpenSsl = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.OpenSsl")).GetReference(filePath: "System.Security.Cryptography.OpenSsl.dll", display: "System.Security.Cryptography.OpenSsl (net80)");
                 }
                 return _SystemSecurityCryptographyOpenSsl;
             }
@@ -3114,7 +3114,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net80)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (net80)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -3131,7 +3131,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net80)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (net80)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -3148,7 +3148,7 @@ public static partial class Net80
             {
                 if (_SystemSecurity is null)
                 {
-                    _SystemSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemSecurity).GetReference(filePath: "System.Security.dll", display: "System.Security (net80)");
+                    _SystemSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security")).GetReference(filePath: "System.Security.dll", display: "System.Security (net80)");
                 }
                 return _SystemSecurity;
             }
@@ -3165,7 +3165,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net80)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (net80)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -3182,7 +3182,7 @@ public static partial class Net80
             {
                 if (_SystemSecurityPrincipalWindows is null)
                 {
-                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipalWindows).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net80)");
+                    _SystemSecurityPrincipalWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.Principal.Windows")).GetReference(filePath: "System.Security.Principal.Windows.dll", display: "System.Security.Principal.Windows (net80)");
                 }
                 return _SystemSecurityPrincipalWindows;
             }
@@ -3199,7 +3199,7 @@ public static partial class Net80
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net80)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (net80)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -3216,7 +3216,7 @@ public static partial class Net80
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net80)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (net80)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -3233,7 +3233,7 @@ public static partial class Net80
             {
                 if (_SystemServiceProcess is null)
                 {
-                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(Resources.SystemServiceProcess).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net80)");
+                    _SystemServiceProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ServiceProcess")).GetReference(filePath: "System.ServiceProcess.dll", display: "System.ServiceProcess (net80)");
                 }
                 return _SystemServiceProcess;
             }
@@ -3250,7 +3250,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncodingCodePages is null)
                 {
-                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingCodePages).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net80)");
+                    _SystemTextEncodingCodePages = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encoding.CodePages")).GetReference(filePath: "System.Text.Encoding.CodePages.dll", display: "System.Text.Encoding.CodePages (net80)");
                 }
                 return _SystemTextEncodingCodePages;
             }
@@ -3267,7 +3267,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net80)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (net80)");
                 }
                 return _SystemTextEncoding;
             }
@@ -3284,7 +3284,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net80)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (net80)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -3301,7 +3301,7 @@ public static partial class Net80
             {
                 if (_SystemTextEncodingsWeb is null)
                 {
-                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingsWeb).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net80)");
+                    _SystemTextEncodingsWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Encodings.Web")).GetReference(filePath: "System.Text.Encodings.Web.dll", display: "System.Text.Encodings.Web (net80)");
                 }
                 return _SystemTextEncodingsWeb;
             }
@@ -3318,7 +3318,7 @@ public static partial class Net80
             {
                 if (_SystemTextJson is null)
                 {
-                    _SystemTextJson = AssemblyMetadata.CreateFromImage(Resources.SystemTextJson).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net80)");
+                    _SystemTextJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.Json")).GetReference(filePath: "System.Text.Json.dll", display: "System.Text.Json (net80)");
                 }
                 return _SystemTextJson;
             }
@@ -3335,7 +3335,7 @@ public static partial class Net80
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net80)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (net80)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -3352,7 +3352,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingChannels is null)
                 {
-                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingChannels).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net80)");
+                    _SystemThreadingChannels = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Channels")).GetReference(filePath: "System.Threading.Channels.dll", display: "System.Threading.Channels (net80)");
                 }
                 return _SystemThreadingChannels;
             }
@@ -3369,7 +3369,7 @@ public static partial class Net80
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net80)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (net80)");
                 }
                 return _SystemThreading;
             }
@@ -3386,7 +3386,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net80)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (net80)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -3403,7 +3403,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasksDataflow is null)
                 {
-                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksDataflow).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net80)");
+                    _SystemThreadingTasksDataflow = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks.Dataflow")).GetReference(filePath: "System.Threading.Tasks.Dataflow.dll", display: "System.Threading.Tasks.Dataflow (net80)");
                 }
                 return _SystemThreadingTasksDataflow;
             }
@@ -3420,7 +3420,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net80)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (net80)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -3437,7 +3437,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net80)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (net80)");
                 }
                 return _SystemThreadingTasksExtensions;
             }
@@ -3454,7 +3454,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net80)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (net80)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -3471,7 +3471,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net80)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (net80)");
                 }
                 return _SystemThreadingThread;
             }
@@ -3488,7 +3488,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net80)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (net80)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -3505,7 +3505,7 @@ public static partial class Net80
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net80)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (net80)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -3522,7 +3522,7 @@ public static partial class Net80
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net80)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (net80)");
                 }
                 return _SystemTransactions;
             }
@@ -3539,7 +3539,7 @@ public static partial class Net80
             {
                 if (_SystemTransactionsLocal is null)
                 {
-                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(Resources.SystemTransactionsLocal).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net80)");
+                    _SystemTransactionsLocal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Transactions.Local")).GetReference(filePath: "System.Transactions.Local.dll", display: "System.Transactions.Local (net80)");
                 }
                 return _SystemTransactionsLocal;
             }
@@ -3556,7 +3556,7 @@ public static partial class Net80
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net80)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (net80)");
                 }
                 return _SystemValueTuple;
             }
@@ -3573,7 +3573,7 @@ public static partial class Net80
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (net80)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (net80)");
                 }
                 return _SystemWeb;
             }
@@ -3590,7 +3590,7 @@ public static partial class Net80
             {
                 if (_SystemWebHttpUtility is null)
                 {
-                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(Resources.SystemWebHttpUtility).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net80)");
+                    _SystemWebHttpUtility = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Web.HttpUtility")).GetReference(filePath: "System.Web.HttpUtility.dll", display: "System.Web.HttpUtility (net80)");
                 }
                 return _SystemWebHttpUtility;
             }
@@ -3607,7 +3607,7 @@ public static partial class Net80
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net80)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (net80)");
                 }
                 return _SystemWindows;
             }
@@ -3624,7 +3624,7 @@ public static partial class Net80
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net80)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (net80)");
                 }
                 return _SystemXml;
             }
@@ -3641,7 +3641,7 @@ public static partial class Net80
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net80)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (net80)");
                 }
                 return _SystemXmlLinq;
             }
@@ -3658,7 +3658,7 @@ public static partial class Net80
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net80)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (net80)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -3675,7 +3675,7 @@ public static partial class Net80
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net80)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (net80)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -3692,7 +3692,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net80)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (net80)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -3709,7 +3709,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net80)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (net80)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -3726,7 +3726,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net80)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (net80)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -3743,7 +3743,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net80)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (net80)");
                 }
                 return _SystemXmlXPath;
             }
@@ -3760,7 +3760,7 @@ public static partial class Net80
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net80)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (net80)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -3777,7 +3777,7 @@ public static partial class Net80
             {
                 if (_WindowsBase is null)
                 {
-                    _WindowsBase = AssemblyMetadata.CreateFromImage(Resources.WindowsBase).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net80)");
+                    _WindowsBase = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("net80.WindowsBase")).GetReference(filePath: "WindowsBase.dll", display: "WindowsBase (net80)");
                 }
                 return _WindowsBase;
             }

--- a/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
+++ b/Src/Basic.Reference.Assemblies/Generated.NetStandard20.cs
@@ -723,7 +723,7 @@ public static partial class NetStandard20
             {
                 if (_MicrosoftWin32Primitives is null)
                 {
-                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(Resources.MicrosoftWin32Primitives).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netstandard20)");
+                    _MicrosoftWin32Primitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.Microsoft.Win32.Primitives")).GetReference(filePath: "Microsoft.Win32.Primitives.dll", display: "Microsoft.Win32.Primitives (netstandard20)");
                 }
                 return _MicrosoftWin32Primitives;
             }
@@ -740,7 +740,7 @@ public static partial class NetStandard20
             {
                 if (_mscorlib is null)
                 {
-                    _mscorlib = AssemblyMetadata.CreateFromImage(Resources.mscorlib).GetReference(filePath: "mscorlib.dll", display: "mscorlib (netstandard20)");
+                    _mscorlib = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.mscorlib")).GetReference(filePath: "mscorlib.dll", display: "mscorlib (netstandard20)");
                 }
                 return _mscorlib;
             }
@@ -757,7 +757,7 @@ public static partial class NetStandard20
             {
                 if (_netstandard is null)
                 {
-                    _netstandard = AssemblyMetadata.CreateFromImage(Resources.netstandard).GetReference(filePath: "netstandard.dll", display: "netstandard (netstandard20)");
+                    _netstandard = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.netstandard")).GetReference(filePath: "netstandard.dll", display: "netstandard (netstandard20)");
                 }
                 return _netstandard;
             }
@@ -774,7 +774,7 @@ public static partial class NetStandard20
             {
                 if (_SystemAppContext is null)
                 {
-                    _SystemAppContext = AssemblyMetadata.CreateFromImage(Resources.SystemAppContext).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netstandard20)");
+                    _SystemAppContext = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.AppContext")).GetReference(filePath: "System.AppContext.dll", display: "System.AppContext (netstandard20)");
                 }
                 return _SystemAppContext;
             }
@@ -791,7 +791,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollectionsConcurrent is null)
                 {
-                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsConcurrent).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netstandard20)");
+                    _SystemCollectionsConcurrent = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections.Concurrent")).GetReference(filePath: "System.Collections.Concurrent.dll", display: "System.Collections.Concurrent (netstandard20)");
                 }
                 return _SystemCollectionsConcurrent;
             }
@@ -808,7 +808,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollections is null)
                 {
-                    _SystemCollections = AssemblyMetadata.CreateFromImage(Resources.SystemCollections).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netstandard20)");
+                    _SystemCollections = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections")).GetReference(filePath: "System.Collections.dll", display: "System.Collections (netstandard20)");
                 }
                 return _SystemCollections;
             }
@@ -825,7 +825,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollectionsNonGeneric is null)
                 {
-                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsNonGeneric).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (netstandard20)");
+                    _SystemCollectionsNonGeneric = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections.NonGeneric")).GetReference(filePath: "System.Collections.NonGeneric.dll", display: "System.Collections.NonGeneric (netstandard20)");
                 }
                 return _SystemCollectionsNonGeneric;
             }
@@ -842,7 +842,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCollectionsSpecialized is null)
                 {
-                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(Resources.SystemCollectionsSpecialized).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (netstandard20)");
+                    _SystemCollectionsSpecialized = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Collections.Specialized")).GetReference(filePath: "System.Collections.Specialized.dll", display: "System.Collections.Specialized (netstandard20)");
                 }
                 return _SystemCollectionsSpecialized;
             }
@@ -859,7 +859,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelComposition is null)
                 {
-                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelComposition).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (netstandard20)");
+                    _SystemComponentModelComposition = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.Composition")).GetReference(filePath: "System.ComponentModel.Composition.dll", display: "System.ComponentModel.Composition (netstandard20)");
                 }
                 return _SystemComponentModelComposition;
             }
@@ -876,7 +876,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModel is null)
                 {
-                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModel).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (netstandard20)");
+                    _SystemComponentModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel")).GetReference(filePath: "System.ComponentModel.dll", display: "System.ComponentModel (netstandard20)");
                 }
                 return _SystemComponentModel;
             }
@@ -893,7 +893,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelEventBasedAsync is null)
                 {
-                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelEventBasedAsync).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (netstandard20)");
+                    _SystemComponentModelEventBasedAsync = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.EventBasedAsync")).GetReference(filePath: "System.ComponentModel.EventBasedAsync.dll", display: "System.ComponentModel.EventBasedAsync (netstandard20)");
                 }
                 return _SystemComponentModelEventBasedAsync;
             }
@@ -910,7 +910,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelPrimitives is null)
                 {
-                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelPrimitives).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (netstandard20)");
+                    _SystemComponentModelPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.Primitives")).GetReference(filePath: "System.ComponentModel.Primitives.dll", display: "System.ComponentModel.Primitives (netstandard20)");
                 }
                 return _SystemComponentModelPrimitives;
             }
@@ -927,7 +927,7 @@ public static partial class NetStandard20
             {
                 if (_SystemComponentModelTypeConverter is null)
                 {
-                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(Resources.SystemComponentModelTypeConverter).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (netstandard20)");
+                    _SystemComponentModelTypeConverter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ComponentModel.TypeConverter")).GetReference(filePath: "System.ComponentModel.TypeConverter.dll", display: "System.ComponentModel.TypeConverter (netstandard20)");
                 }
                 return _SystemComponentModelTypeConverter;
             }
@@ -944,7 +944,7 @@ public static partial class NetStandard20
             {
                 if (_SystemConsole is null)
                 {
-                    _SystemConsole = AssemblyMetadata.CreateFromImage(Resources.SystemConsole).GetReference(filePath: "System.Console.dll", display: "System.Console (netstandard20)");
+                    _SystemConsole = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Console")).GetReference(filePath: "System.Console.dll", display: "System.Console (netstandard20)");
                 }
                 return _SystemConsole;
             }
@@ -961,7 +961,7 @@ public static partial class NetStandard20
             {
                 if (_SystemCore is null)
                 {
-                    _SystemCore = AssemblyMetadata.CreateFromImage(Resources.SystemCore).GetReference(filePath: "System.Core.dll", display: "System.Core (netstandard20)");
+                    _SystemCore = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Core")).GetReference(filePath: "System.Core.dll", display: "System.Core (netstandard20)");
                 }
                 return _SystemCore;
             }
@@ -978,7 +978,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDataCommon is null)
                 {
-                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(Resources.SystemDataCommon).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (netstandard20)");
+                    _SystemDataCommon = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Data.Common")).GetReference(filePath: "System.Data.Common.dll", display: "System.Data.Common (netstandard20)");
                 }
                 return _SystemDataCommon;
             }
@@ -995,7 +995,7 @@ public static partial class NetStandard20
             {
                 if (_SystemData is null)
                 {
-                    _SystemData = AssemblyMetadata.CreateFromImage(Resources.SystemData).GetReference(filePath: "System.Data.dll", display: "System.Data (netstandard20)");
+                    _SystemData = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Data")).GetReference(filePath: "System.Data.dll", display: "System.Data (netstandard20)");
                 }
                 return _SystemData;
             }
@@ -1012,7 +1012,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsContracts is null)
                 {
-                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsContracts).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (netstandard20)");
+                    _SystemDiagnosticsContracts = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Contracts")).GetReference(filePath: "System.Diagnostics.Contracts.dll", display: "System.Diagnostics.Contracts (netstandard20)");
                 }
                 return _SystemDiagnosticsContracts;
             }
@@ -1029,7 +1029,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsDebug is null)
                 {
-                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsDebug).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netstandard20)");
+                    _SystemDiagnosticsDebug = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Debug")).GetReference(filePath: "System.Diagnostics.Debug.dll", display: "System.Diagnostics.Debug (netstandard20)");
                 }
                 return _SystemDiagnosticsDebug;
             }
@@ -1046,7 +1046,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsFileVersionInfo is null)
                 {
-                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsFileVersionInfo).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netstandard20)");
+                    _SystemDiagnosticsFileVersionInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.FileVersionInfo")).GetReference(filePath: "System.Diagnostics.FileVersionInfo.dll", display: "System.Diagnostics.FileVersionInfo (netstandard20)");
                 }
                 return _SystemDiagnosticsFileVersionInfo;
             }
@@ -1063,7 +1063,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsProcess is null)
                 {
-                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsProcess).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netstandard20)");
+                    _SystemDiagnosticsProcess = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Process")).GetReference(filePath: "System.Diagnostics.Process.dll", display: "System.Diagnostics.Process (netstandard20)");
                 }
                 return _SystemDiagnosticsProcess;
             }
@@ -1080,7 +1080,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsStackTrace is null)
                 {
-                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsStackTrace).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (netstandard20)");
+                    _SystemDiagnosticsStackTrace = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.StackTrace")).GetReference(filePath: "System.Diagnostics.StackTrace.dll", display: "System.Diagnostics.StackTrace (netstandard20)");
                 }
                 return _SystemDiagnosticsStackTrace;
             }
@@ -1097,7 +1097,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTextWriterTraceListener is null)
                 {
-                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTextWriterTraceListener).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (netstandard20)");
+                    _SystemDiagnosticsTextWriterTraceListener = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.TextWriterTraceListener")).GetReference(filePath: "System.Diagnostics.TextWriterTraceListener.dll", display: "System.Diagnostics.TextWriterTraceListener (netstandard20)");
                 }
                 return _SystemDiagnosticsTextWriterTraceListener;
             }
@@ -1114,7 +1114,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTools is null)
                 {
-                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTools).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netstandard20)");
+                    _SystemDiagnosticsTools = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Tools")).GetReference(filePath: "System.Diagnostics.Tools.dll", display: "System.Diagnostics.Tools (netstandard20)");
                 }
                 return _SystemDiagnosticsTools;
             }
@@ -1131,7 +1131,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTraceSource is null)
                 {
-                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTraceSource).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (netstandard20)");
+                    _SystemDiagnosticsTraceSource = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.TraceSource")).GetReference(filePath: "System.Diagnostics.TraceSource.dll", display: "System.Diagnostics.TraceSource (netstandard20)");
                 }
                 return _SystemDiagnosticsTraceSource;
             }
@@ -1148,7 +1148,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDiagnosticsTracing is null)
                 {
-                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(Resources.SystemDiagnosticsTracing).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netstandard20)");
+                    _SystemDiagnosticsTracing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Diagnostics.Tracing")).GetReference(filePath: "System.Diagnostics.Tracing.dll", display: "System.Diagnostics.Tracing (netstandard20)");
                 }
                 return _SystemDiagnosticsTracing;
             }
@@ -1165,7 +1165,7 @@ public static partial class NetStandard20
             {
                 if (_System is null)
                 {
-                    _System = AssemblyMetadata.CreateFromImage(Resources.System).GetReference(filePath: "System.dll", display: "System (netstandard20)");
+                    _System = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System")).GetReference(filePath: "System.dll", display: "System (netstandard20)");
                 }
                 return _System;
             }
@@ -1182,7 +1182,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDrawing is null)
                 {
-                    _SystemDrawing = AssemblyMetadata.CreateFromImage(Resources.SystemDrawing).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (netstandard20)");
+                    _SystemDrawing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Drawing")).GetReference(filePath: "System.Drawing.dll", display: "System.Drawing (netstandard20)");
                 }
                 return _SystemDrawing;
             }
@@ -1199,7 +1199,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDrawingPrimitives is null)
                 {
-                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemDrawingPrimitives).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (netstandard20)");
+                    _SystemDrawingPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Drawing.Primitives")).GetReference(filePath: "System.Drawing.Primitives.dll", display: "System.Drawing.Primitives (netstandard20)");
                 }
                 return _SystemDrawingPrimitives;
             }
@@ -1216,7 +1216,7 @@ public static partial class NetStandard20
             {
                 if (_SystemDynamicRuntime is null)
                 {
-                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemDynamicRuntime).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (netstandard20)");
+                    _SystemDynamicRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Dynamic.Runtime")).GetReference(filePath: "System.Dynamic.Runtime.dll", display: "System.Dynamic.Runtime (netstandard20)");
                 }
                 return _SystemDynamicRuntime;
             }
@@ -1233,7 +1233,7 @@ public static partial class NetStandard20
             {
                 if (_SystemGlobalizationCalendars is null)
                 {
-                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationCalendars).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netstandard20)");
+                    _SystemGlobalizationCalendars = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Globalization.Calendars")).GetReference(filePath: "System.Globalization.Calendars.dll", display: "System.Globalization.Calendars (netstandard20)");
                 }
                 return _SystemGlobalizationCalendars;
             }
@@ -1250,7 +1250,7 @@ public static partial class NetStandard20
             {
                 if (_SystemGlobalization is null)
                 {
-                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalization).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netstandard20)");
+                    _SystemGlobalization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Globalization")).GetReference(filePath: "System.Globalization.dll", display: "System.Globalization (netstandard20)");
                 }
                 return _SystemGlobalization;
             }
@@ -1267,7 +1267,7 @@ public static partial class NetStandard20
             {
                 if (_SystemGlobalizationExtensions is null)
                 {
-                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemGlobalizationExtensions).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (netstandard20)");
+                    _SystemGlobalizationExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Globalization.Extensions")).GetReference(filePath: "System.Globalization.Extensions.dll", display: "System.Globalization.Extensions (netstandard20)");
                 }
                 return _SystemGlobalizationExtensions;
             }
@@ -1284,7 +1284,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOCompression is null)
                 {
-                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompression).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netstandard20)");
+                    _SystemIOCompression = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Compression")).GetReference(filePath: "System.IO.Compression.dll", display: "System.IO.Compression (netstandard20)");
                 }
                 return _SystemIOCompression;
             }
@@ -1301,7 +1301,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOCompressionFileSystem is null)
                 {
-                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionFileSystem).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (netstandard20)");
+                    _SystemIOCompressionFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Compression.FileSystem")).GetReference(filePath: "System.IO.Compression.FileSystem.dll", display: "System.IO.Compression.FileSystem (netstandard20)");
                 }
                 return _SystemIOCompressionFileSystem;
             }
@@ -1318,7 +1318,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOCompressionZipFile is null)
                 {
-                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(Resources.SystemIOCompressionZipFile).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netstandard20)");
+                    _SystemIOCompressionZipFile = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Compression.ZipFile")).GetReference(filePath: "System.IO.Compression.ZipFile.dll", display: "System.IO.Compression.ZipFile (netstandard20)");
                 }
                 return _SystemIOCompressionZipFile;
             }
@@ -1335,7 +1335,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIO is null)
                 {
-                    _SystemIO = AssemblyMetadata.CreateFromImage(Resources.SystemIO).GetReference(filePath: "System.IO.dll", display: "System.IO (netstandard20)");
+                    _SystemIO = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO")).GetReference(filePath: "System.IO.dll", display: "System.IO (netstandard20)");
                 }
                 return _SystemIO;
             }
@@ -1352,7 +1352,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystem is null)
                 {
-                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystem).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netstandard20)");
+                    _SystemIOFileSystem = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem")).GetReference(filePath: "System.IO.FileSystem.dll", display: "System.IO.FileSystem (netstandard20)");
                 }
                 return _SystemIOFileSystem;
             }
@@ -1369,7 +1369,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystemDriveInfo is null)
                 {
-                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemDriveInfo).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (netstandard20)");
+                    _SystemIOFileSystemDriveInfo = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem.DriveInfo")).GetReference(filePath: "System.IO.FileSystem.DriveInfo.dll", display: "System.IO.FileSystem.DriveInfo (netstandard20)");
                 }
                 return _SystemIOFileSystemDriveInfo;
             }
@@ -1386,7 +1386,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystemPrimitives is null)
                 {
-                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemPrimitives).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netstandard20)");
+                    _SystemIOFileSystemPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem.Primitives")).GetReference(filePath: "System.IO.FileSystem.Primitives.dll", display: "System.IO.FileSystem.Primitives (netstandard20)");
                 }
                 return _SystemIOFileSystemPrimitives;
             }
@@ -1403,7 +1403,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOFileSystemWatcher is null)
                 {
-                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(Resources.SystemIOFileSystemWatcher).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (netstandard20)");
+                    _SystemIOFileSystemWatcher = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.FileSystem.Watcher")).GetReference(filePath: "System.IO.FileSystem.Watcher.dll", display: "System.IO.FileSystem.Watcher (netstandard20)");
                 }
                 return _SystemIOFileSystemWatcher;
             }
@@ -1420,7 +1420,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOIsolatedStorage is null)
                 {
-                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(Resources.SystemIOIsolatedStorage).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (netstandard20)");
+                    _SystemIOIsolatedStorage = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.IsolatedStorage")).GetReference(filePath: "System.IO.IsolatedStorage.dll", display: "System.IO.IsolatedStorage (netstandard20)");
                 }
                 return _SystemIOIsolatedStorage;
             }
@@ -1437,7 +1437,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOMemoryMappedFiles is null)
                 {
-                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(Resources.SystemIOMemoryMappedFiles).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (netstandard20)");
+                    _SystemIOMemoryMappedFiles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.MemoryMappedFiles")).GetReference(filePath: "System.IO.MemoryMappedFiles.dll", display: "System.IO.MemoryMappedFiles (netstandard20)");
                 }
                 return _SystemIOMemoryMappedFiles;
             }
@@ -1454,7 +1454,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOPipes is null)
                 {
-                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(Resources.SystemIOPipes).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (netstandard20)");
+                    _SystemIOPipes = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.Pipes")).GetReference(filePath: "System.IO.Pipes.dll", display: "System.IO.Pipes (netstandard20)");
                 }
                 return _SystemIOPipes;
             }
@@ -1471,7 +1471,7 @@ public static partial class NetStandard20
             {
                 if (_SystemIOUnmanagedMemoryStream is null)
                 {
-                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(Resources.SystemIOUnmanagedMemoryStream).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (netstandard20)");
+                    _SystemIOUnmanagedMemoryStream = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.IO.UnmanagedMemoryStream")).GetReference(filePath: "System.IO.UnmanagedMemoryStream.dll", display: "System.IO.UnmanagedMemoryStream (netstandard20)");
                 }
                 return _SystemIOUnmanagedMemoryStream;
             }
@@ -1488,7 +1488,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinq is null)
                 {
-                    _SystemLinq = AssemblyMetadata.CreateFromImage(Resources.SystemLinq).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netstandard20)");
+                    _SystemLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq")).GetReference(filePath: "System.Linq.dll", display: "System.Linq (netstandard20)");
                 }
                 return _SystemLinq;
             }
@@ -1505,7 +1505,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinqExpressions is null)
                 {
-                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemLinqExpressions).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netstandard20)");
+                    _SystemLinqExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq.Expressions")).GetReference(filePath: "System.Linq.Expressions.dll", display: "System.Linq.Expressions (netstandard20)");
                 }
                 return _SystemLinqExpressions;
             }
@@ -1522,7 +1522,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinqParallel is null)
                 {
-                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(Resources.SystemLinqParallel).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (netstandard20)");
+                    _SystemLinqParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq.Parallel")).GetReference(filePath: "System.Linq.Parallel.dll", display: "System.Linq.Parallel (netstandard20)");
                 }
                 return _SystemLinqParallel;
             }
@@ -1539,7 +1539,7 @@ public static partial class NetStandard20
             {
                 if (_SystemLinqQueryable is null)
                 {
-                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(Resources.SystemLinqQueryable).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (netstandard20)");
+                    _SystemLinqQueryable = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Linq.Queryable")).GetReference(filePath: "System.Linq.Queryable.dll", display: "System.Linq.Queryable (netstandard20)");
                 }
                 return _SystemLinqQueryable;
             }
@@ -1556,7 +1556,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNet is null)
                 {
-                    _SystemNet = AssemblyMetadata.CreateFromImage(Resources.SystemNet).GetReference(filePath: "System.Net.dll", display: "System.Net (netstandard20)");
+                    _SystemNet = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net")).GetReference(filePath: "System.Net.dll", display: "System.Net (netstandard20)");
                 }
                 return _SystemNet;
             }
@@ -1573,7 +1573,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetHttp is null)
                 {
-                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(Resources.SystemNetHttp).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netstandard20)");
+                    _SystemNetHttp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Http")).GetReference(filePath: "System.Net.Http.dll", display: "System.Net.Http (netstandard20)");
                 }
                 return _SystemNetHttp;
             }
@@ -1590,7 +1590,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetNameResolution is null)
                 {
-                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(Resources.SystemNetNameResolution).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (netstandard20)");
+                    _SystemNetNameResolution = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.NameResolution")).GetReference(filePath: "System.Net.NameResolution.dll", display: "System.Net.NameResolution (netstandard20)");
                 }
                 return _SystemNetNameResolution;
             }
@@ -1607,7 +1607,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetNetworkInformation is null)
                 {
-                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(Resources.SystemNetNetworkInformation).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (netstandard20)");
+                    _SystemNetNetworkInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.NetworkInformation")).GetReference(filePath: "System.Net.NetworkInformation.dll", display: "System.Net.NetworkInformation (netstandard20)");
                 }
                 return _SystemNetNetworkInformation;
             }
@@ -1624,7 +1624,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetPing is null)
                 {
-                    _SystemNetPing = AssemblyMetadata.CreateFromImage(Resources.SystemNetPing).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (netstandard20)");
+                    _SystemNetPing = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Ping")).GetReference(filePath: "System.Net.Ping.dll", display: "System.Net.Ping (netstandard20)");
                 }
                 return _SystemNetPing;
             }
@@ -1641,7 +1641,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetPrimitives is null)
                 {
-                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemNetPrimitives).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netstandard20)");
+                    _SystemNetPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Primitives")).GetReference(filePath: "System.Net.Primitives.dll", display: "System.Net.Primitives (netstandard20)");
                 }
                 return _SystemNetPrimitives;
             }
@@ -1658,7 +1658,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetRequests is null)
                 {
-                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(Resources.SystemNetRequests).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (netstandard20)");
+                    _SystemNetRequests = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Requests")).GetReference(filePath: "System.Net.Requests.dll", display: "System.Net.Requests (netstandard20)");
                 }
                 return _SystemNetRequests;
             }
@@ -1675,7 +1675,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetSecurity is null)
                 {
-                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(Resources.SystemNetSecurity).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netstandard20)");
+                    _SystemNetSecurity = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Security")).GetReference(filePath: "System.Net.Security.dll", display: "System.Net.Security (netstandard20)");
                 }
                 return _SystemNetSecurity;
             }
@@ -1692,7 +1692,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetSockets is null)
                 {
-                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetSockets).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netstandard20)");
+                    _SystemNetSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.Sockets")).GetReference(filePath: "System.Net.Sockets.dll", display: "System.Net.Sockets (netstandard20)");
                 }
                 return _SystemNetSockets;
             }
@@ -1709,7 +1709,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetWebHeaderCollection is null)
                 {
-                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebHeaderCollection).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (netstandard20)");
+                    _SystemNetWebHeaderCollection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.WebHeaderCollection")).GetReference(filePath: "System.Net.WebHeaderCollection.dll", display: "System.Net.WebHeaderCollection (netstandard20)");
                 }
                 return _SystemNetWebHeaderCollection;
             }
@@ -1726,7 +1726,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetWebSocketsClient is null)
                 {
-                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSocketsClient).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (netstandard20)");
+                    _SystemNetWebSocketsClient = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.WebSockets.Client")).GetReference(filePath: "System.Net.WebSockets.Client.dll", display: "System.Net.WebSockets.Client (netstandard20)");
                 }
                 return _SystemNetWebSocketsClient;
             }
@@ -1743,7 +1743,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNetWebSockets is null)
                 {
-                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(Resources.SystemNetWebSockets).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (netstandard20)");
+                    _SystemNetWebSockets = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Net.WebSockets")).GetReference(filePath: "System.Net.WebSockets.dll", display: "System.Net.WebSockets (netstandard20)");
                 }
                 return _SystemNetWebSockets;
             }
@@ -1760,7 +1760,7 @@ public static partial class NetStandard20
             {
                 if (_SystemNumerics is null)
                 {
-                    _SystemNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemNumerics).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (netstandard20)");
+                    _SystemNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Numerics")).GetReference(filePath: "System.Numerics.dll", display: "System.Numerics (netstandard20)");
                 }
                 return _SystemNumerics;
             }
@@ -1777,7 +1777,7 @@ public static partial class NetStandard20
             {
                 if (_SystemObjectModel is null)
                 {
-                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(Resources.SystemObjectModel).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netstandard20)");
+                    _SystemObjectModel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ObjectModel")).GetReference(filePath: "System.ObjectModel.dll", display: "System.ObjectModel (netstandard20)");
                 }
                 return _SystemObjectModel;
             }
@@ -1794,7 +1794,7 @@ public static partial class NetStandard20
             {
                 if (_SystemReflection is null)
                 {
-                    _SystemReflection = AssemblyMetadata.CreateFromImage(Resources.SystemReflection).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netstandard20)");
+                    _SystemReflection = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Reflection")).GetReference(filePath: "System.Reflection.dll", display: "System.Reflection (netstandard20)");
                 }
                 return _SystemReflection;
             }
@@ -1811,7 +1811,7 @@ public static partial class NetStandard20
             {
                 if (_SystemReflectionExtensions is null)
                 {
-                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionExtensions).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netstandard20)");
+                    _SystemReflectionExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Reflection.Extensions")).GetReference(filePath: "System.Reflection.Extensions.dll", display: "System.Reflection.Extensions (netstandard20)");
                 }
                 return _SystemReflectionExtensions;
             }
@@ -1828,7 +1828,7 @@ public static partial class NetStandard20
             {
                 if (_SystemReflectionPrimitives is null)
                 {
-                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemReflectionPrimitives).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netstandard20)");
+                    _SystemReflectionPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Reflection.Primitives")).GetReference(filePath: "System.Reflection.Primitives.dll", display: "System.Reflection.Primitives (netstandard20)");
                 }
                 return _SystemReflectionPrimitives;
             }
@@ -1845,7 +1845,7 @@ public static partial class NetStandard20
             {
                 if (_SystemResourcesReader is null)
                 {
-                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesReader).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (netstandard20)");
+                    _SystemResourcesReader = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Resources.Reader")).GetReference(filePath: "System.Resources.Reader.dll", display: "System.Resources.Reader (netstandard20)");
                 }
                 return _SystemResourcesReader;
             }
@@ -1862,7 +1862,7 @@ public static partial class NetStandard20
             {
                 if (_SystemResourcesResourceManager is null)
                 {
-                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesResourceManager).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netstandard20)");
+                    _SystemResourcesResourceManager = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Resources.ResourceManager")).GetReference(filePath: "System.Resources.ResourceManager.dll", display: "System.Resources.ResourceManager (netstandard20)");
                 }
                 return _SystemResourcesResourceManager;
             }
@@ -1879,7 +1879,7 @@ public static partial class NetStandard20
             {
                 if (_SystemResourcesWriter is null)
                 {
-                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(Resources.SystemResourcesWriter).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (netstandard20)");
+                    _SystemResourcesWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Resources.Writer")).GetReference(filePath: "System.Resources.Writer.dll", display: "System.Resources.Writer (netstandard20)");
                 }
                 return _SystemResourcesWriter;
             }
@@ -1896,7 +1896,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeCompilerServicesVisualC is null)
                 {
-                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeCompilerServicesVisualC).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (netstandard20)");
+                    _SystemRuntimeCompilerServicesVisualC = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.CompilerServices.VisualC")).GetReference(filePath: "System.Runtime.CompilerServices.VisualC.dll", display: "System.Runtime.CompilerServices.VisualC (netstandard20)");
                 }
                 return _SystemRuntimeCompilerServicesVisualC;
             }
@@ -1913,7 +1913,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntime is null)
                 {
-                    _SystemRuntime = AssemblyMetadata.CreateFromImage(Resources.SystemRuntime).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netstandard20)");
+                    _SystemRuntime = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime")).GetReference(filePath: "System.Runtime.dll", display: "System.Runtime (netstandard20)");
                 }
                 return _SystemRuntime;
             }
@@ -1930,7 +1930,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeExtensions is null)
                 {
-                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeExtensions).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netstandard20)");
+                    _SystemRuntimeExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Extensions")).GetReference(filePath: "System.Runtime.Extensions.dll", display: "System.Runtime.Extensions (netstandard20)");
                 }
                 return _SystemRuntimeExtensions;
             }
@@ -1947,7 +1947,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeHandles is null)
                 {
-                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeHandles).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netstandard20)");
+                    _SystemRuntimeHandles = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Handles")).GetReference(filePath: "System.Runtime.Handles.dll", display: "System.Runtime.Handles (netstandard20)");
                 }
                 return _SystemRuntimeHandles;
             }
@@ -1964,7 +1964,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeInteropServices is null)
                 {
-                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServices).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netstandard20)");
+                    _SystemRuntimeInteropServices = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.InteropServices")).GetReference(filePath: "System.Runtime.InteropServices.dll", display: "System.Runtime.InteropServices (netstandard20)");
                 }
                 return _SystemRuntimeInteropServices;
             }
@@ -1981,7 +1981,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeInteropServicesRuntimeInformation is null)
                 {
-                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeInteropServicesRuntimeInformation).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netstandard20)");
+                    _SystemRuntimeInteropServicesRuntimeInformation = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.InteropServices.RuntimeInformation")).GetReference(filePath: "System.Runtime.InteropServices.RuntimeInformation.dll", display: "System.Runtime.InteropServices.RuntimeInformation (netstandard20)");
                 }
                 return _SystemRuntimeInteropServicesRuntimeInformation;
             }
@@ -1998,7 +1998,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeNumerics is null)
                 {
-                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeNumerics).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netstandard20)");
+                    _SystemRuntimeNumerics = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Numerics")).GetReference(filePath: "System.Runtime.Numerics.dll", display: "System.Runtime.Numerics (netstandard20)");
                 }
                 return _SystemRuntimeNumerics;
             }
@@ -2015,7 +2015,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerialization is null)
                 {
-                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerialization).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (netstandard20)");
+                    _SystemRuntimeSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization")).GetReference(filePath: "System.Runtime.Serialization.dll", display: "System.Runtime.Serialization (netstandard20)");
                 }
                 return _SystemRuntimeSerialization;
             }
@@ -2032,7 +2032,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationFormatters is null)
                 {
-                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationFormatters).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (netstandard20)");
+                    _SystemRuntimeSerializationFormatters = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Formatters")).GetReference(filePath: "System.Runtime.Serialization.Formatters.dll", display: "System.Runtime.Serialization.Formatters (netstandard20)");
                 }
                 return _SystemRuntimeSerializationFormatters;
             }
@@ -2049,7 +2049,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationJson is null)
                 {
-                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationJson).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (netstandard20)");
+                    _SystemRuntimeSerializationJson = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Json")).GetReference(filePath: "System.Runtime.Serialization.Json.dll", display: "System.Runtime.Serialization.Json (netstandard20)");
                 }
                 return _SystemRuntimeSerializationJson;
             }
@@ -2066,7 +2066,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationPrimitives is null)
                 {
-                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationPrimitives).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netstandard20)");
+                    _SystemRuntimeSerializationPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Primitives")).GetReference(filePath: "System.Runtime.Serialization.Primitives.dll", display: "System.Runtime.Serialization.Primitives (netstandard20)");
                 }
                 return _SystemRuntimeSerializationPrimitives;
             }
@@ -2083,7 +2083,7 @@ public static partial class NetStandard20
             {
                 if (_SystemRuntimeSerializationXml is null)
                 {
-                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(Resources.SystemRuntimeSerializationXml).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (netstandard20)");
+                    _SystemRuntimeSerializationXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Runtime.Serialization.Xml")).GetReference(filePath: "System.Runtime.Serialization.Xml.dll", display: "System.Runtime.Serialization.Xml (netstandard20)");
                 }
                 return _SystemRuntimeSerializationXml;
             }
@@ -2100,7 +2100,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityClaims is null)
                 {
-                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityClaims).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netstandard20)");
+                    _SystemSecurityClaims = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Claims")).GetReference(filePath: "System.Security.Claims.dll", display: "System.Security.Claims (netstandard20)");
                 }
                 return _SystemSecurityClaims;
             }
@@ -2117,7 +2117,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyAlgorithms is null)
                 {
-                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyAlgorithms).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netstandard20)");
+                    _SystemSecurityCryptographyAlgorithms = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Algorithms")).GetReference(filePath: "System.Security.Cryptography.Algorithms.dll", display: "System.Security.Cryptography.Algorithms (netstandard20)");
                 }
                 return _SystemSecurityCryptographyAlgorithms;
             }
@@ -2134,7 +2134,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyCsp is null)
                 {
-                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyCsp).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netstandard20)");
+                    _SystemSecurityCryptographyCsp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Csp")).GetReference(filePath: "System.Security.Cryptography.Csp.dll", display: "System.Security.Cryptography.Csp (netstandard20)");
                 }
                 return _SystemSecurityCryptographyCsp;
             }
@@ -2151,7 +2151,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyEncoding is null)
                 {
-                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyEncoding).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netstandard20)");
+                    _SystemSecurityCryptographyEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Encoding")).GetReference(filePath: "System.Security.Cryptography.Encoding.dll", display: "System.Security.Cryptography.Encoding (netstandard20)");
                 }
                 return _SystemSecurityCryptographyEncoding;
             }
@@ -2168,7 +2168,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyPrimitives is null)
                 {
-                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyPrimitives).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netstandard20)");
+                    _SystemSecurityCryptographyPrimitives = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.Primitives")).GetReference(filePath: "System.Security.Cryptography.Primitives.dll", display: "System.Security.Cryptography.Primitives (netstandard20)");
                 }
                 return _SystemSecurityCryptographyPrimitives;
             }
@@ -2185,7 +2185,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityCryptographyX509Certificates is null)
                 {
-                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityCryptographyX509Certificates).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netstandard20)");
+                    _SystemSecurityCryptographyX509Certificates = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Cryptography.X509Certificates")).GetReference(filePath: "System.Security.Cryptography.X509Certificates.dll", display: "System.Security.Cryptography.X509Certificates (netstandard20)");
                 }
                 return _SystemSecurityCryptographyX509Certificates;
             }
@@ -2202,7 +2202,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecurityPrincipal is null)
                 {
-                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(Resources.SystemSecurityPrincipal).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netstandard20)");
+                    _SystemSecurityPrincipal = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.Principal")).GetReference(filePath: "System.Security.Principal.dll", display: "System.Security.Principal (netstandard20)");
                 }
                 return _SystemSecurityPrincipal;
             }
@@ -2219,7 +2219,7 @@ public static partial class NetStandard20
             {
                 if (_SystemSecuritySecureString is null)
                 {
-                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(Resources.SystemSecuritySecureString).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (netstandard20)");
+                    _SystemSecuritySecureString = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Security.SecureString")).GetReference(filePath: "System.Security.SecureString.dll", display: "System.Security.SecureString (netstandard20)");
                 }
                 return _SystemSecuritySecureString;
             }
@@ -2236,7 +2236,7 @@ public static partial class NetStandard20
             {
                 if (_SystemServiceModelWeb is null)
                 {
-                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(Resources.SystemServiceModelWeb).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (netstandard20)");
+                    _SystemServiceModelWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ServiceModel.Web")).GetReference(filePath: "System.ServiceModel.Web.dll", display: "System.ServiceModel.Web (netstandard20)");
                 }
                 return _SystemServiceModelWeb;
             }
@@ -2253,7 +2253,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTextEncoding is null)
                 {
-                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncoding).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netstandard20)");
+                    _SystemTextEncoding = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Text.Encoding")).GetReference(filePath: "System.Text.Encoding.dll", display: "System.Text.Encoding (netstandard20)");
                 }
                 return _SystemTextEncoding;
             }
@@ -2270,7 +2270,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTextEncodingExtensions is null)
                 {
-                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemTextEncodingExtensions).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netstandard20)");
+                    _SystemTextEncodingExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Text.Encoding.Extensions")).GetReference(filePath: "System.Text.Encoding.Extensions.dll", display: "System.Text.Encoding.Extensions (netstandard20)");
                 }
                 return _SystemTextEncodingExtensions;
             }
@@ -2287,7 +2287,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTextRegularExpressions is null)
                 {
-                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(Resources.SystemTextRegularExpressions).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netstandard20)");
+                    _SystemTextRegularExpressions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Text.RegularExpressions")).GetReference(filePath: "System.Text.RegularExpressions.dll", display: "System.Text.RegularExpressions (netstandard20)");
                 }
                 return _SystemTextRegularExpressions;
             }
@@ -2304,7 +2304,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreading is null)
                 {
-                    _SystemThreading = AssemblyMetadata.CreateFromImage(Resources.SystemThreading).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netstandard20)");
+                    _SystemThreading = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading")).GetReference(filePath: "System.Threading.dll", display: "System.Threading (netstandard20)");
                 }
                 return _SystemThreading;
             }
@@ -2321,7 +2321,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingOverlapped is null)
                 {
-                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingOverlapped).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (netstandard20)");
+                    _SystemThreadingOverlapped = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Overlapped")).GetReference(filePath: "System.Threading.Overlapped.dll", display: "System.Threading.Overlapped (netstandard20)");
                 }
                 return _SystemThreadingOverlapped;
             }
@@ -2338,7 +2338,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTasks is null)
                 {
-                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasks).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netstandard20)");
+                    _SystemThreadingTasks = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Tasks")).GetReference(filePath: "System.Threading.Tasks.dll", display: "System.Threading.Tasks (netstandard20)");
                 }
                 return _SystemThreadingTasks;
             }
@@ -2355,7 +2355,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTasksParallel is null)
                 {
-                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksParallel).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (netstandard20)");
+                    _SystemThreadingTasksParallel = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Tasks.Parallel")).GetReference(filePath: "System.Threading.Tasks.Parallel.dll", display: "System.Threading.Tasks.Parallel (netstandard20)");
                 }
                 return _SystemThreadingTasksParallel;
             }
@@ -2372,7 +2372,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingThread is null)
                 {
-                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThread).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (netstandard20)");
+                    _SystemThreadingThread = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Thread")).GetReference(filePath: "System.Threading.Thread.dll", display: "System.Threading.Thread (netstandard20)");
                 }
                 return _SystemThreadingThread;
             }
@@ -2389,7 +2389,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingThreadPool is null)
                 {
-                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingThreadPool).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (netstandard20)");
+                    _SystemThreadingThreadPool = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.ThreadPool")).GetReference(filePath: "System.Threading.ThreadPool.dll", display: "System.Threading.ThreadPool (netstandard20)");
                 }
                 return _SystemThreadingThreadPool;
             }
@@ -2406,7 +2406,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTimer is null)
                 {
-                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTimer).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netstandard20)");
+                    _SystemThreadingTimer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Timer")).GetReference(filePath: "System.Threading.Timer.dll", display: "System.Threading.Timer (netstandard20)");
                 }
                 return _SystemThreadingTimer;
             }
@@ -2423,7 +2423,7 @@ public static partial class NetStandard20
             {
                 if (_SystemTransactions is null)
                 {
-                    _SystemTransactions = AssemblyMetadata.CreateFromImage(Resources.SystemTransactions).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (netstandard20)");
+                    _SystemTransactions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Transactions")).GetReference(filePath: "System.Transactions.dll", display: "System.Transactions (netstandard20)");
                 }
                 return _SystemTransactions;
             }
@@ -2440,7 +2440,7 @@ public static partial class NetStandard20
             {
                 if (_SystemValueTuple is null)
                 {
-                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(Resources.SystemValueTuple).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netstandard20)");
+                    _SystemValueTuple = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.ValueTuple")).GetReference(filePath: "System.ValueTuple.dll", display: "System.ValueTuple (netstandard20)");
                 }
                 return _SystemValueTuple;
             }
@@ -2457,7 +2457,7 @@ public static partial class NetStandard20
             {
                 if (_SystemWeb is null)
                 {
-                    _SystemWeb = AssemblyMetadata.CreateFromImage(Resources.SystemWeb).GetReference(filePath: "System.Web.dll", display: "System.Web (netstandard20)");
+                    _SystemWeb = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Web")).GetReference(filePath: "System.Web.dll", display: "System.Web (netstandard20)");
                 }
                 return _SystemWeb;
             }
@@ -2474,7 +2474,7 @@ public static partial class NetStandard20
             {
                 if (_SystemWindows is null)
                 {
-                    _SystemWindows = AssemblyMetadata.CreateFromImage(Resources.SystemWindows).GetReference(filePath: "System.Windows.dll", display: "System.Windows (netstandard20)");
+                    _SystemWindows = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Windows")).GetReference(filePath: "System.Windows.dll", display: "System.Windows (netstandard20)");
                 }
                 return _SystemWindows;
             }
@@ -2491,7 +2491,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXml is null)
                 {
-                    _SystemXml = AssemblyMetadata.CreateFromImage(Resources.SystemXml).GetReference(filePath: "System.Xml.dll", display: "System.Xml (netstandard20)");
+                    _SystemXml = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml")).GetReference(filePath: "System.Xml.dll", display: "System.Xml (netstandard20)");
                 }
                 return _SystemXml;
             }
@@ -2508,7 +2508,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlLinq is null)
                 {
-                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(Resources.SystemXmlLinq).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (netstandard20)");
+                    _SystemXmlLinq = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.Linq")).GetReference(filePath: "System.Xml.Linq.dll", display: "System.Xml.Linq (netstandard20)");
                 }
                 return _SystemXmlLinq;
             }
@@ -2525,7 +2525,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlReaderWriter is null)
                 {
-                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(Resources.SystemXmlReaderWriter).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netstandard20)");
+                    _SystemXmlReaderWriter = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.ReaderWriter")).GetReference(filePath: "System.Xml.ReaderWriter.dll", display: "System.Xml.ReaderWriter (netstandard20)");
                 }
                 return _SystemXmlReaderWriter;
             }
@@ -2542,7 +2542,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlSerialization is null)
                 {
-                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(Resources.SystemXmlSerialization).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (netstandard20)");
+                    _SystemXmlSerialization = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.Serialization")).GetReference(filePath: "System.Xml.Serialization.dll", display: "System.Xml.Serialization (netstandard20)");
                 }
                 return _SystemXmlSerialization;
             }
@@ -2559,7 +2559,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXDocument is null)
                 {
-                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXDocument).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netstandard20)");
+                    _SystemXmlXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XDocument")).GetReference(filePath: "System.Xml.XDocument.dll", display: "System.Xml.XDocument (netstandard20)");
                 }
                 return _SystemXmlXDocument;
             }
@@ -2576,7 +2576,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXmlDocument is null)
                 {
-                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlDocument).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netstandard20)");
+                    _SystemXmlXmlDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XmlDocument")).GetReference(filePath: "System.Xml.XmlDocument.dll", display: "System.Xml.XmlDocument (netstandard20)");
                 }
                 return _SystemXmlXmlDocument;
             }
@@ -2593,7 +2593,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXmlSerializer is null)
                 {
-                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXmlSerializer).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (netstandard20)");
+                    _SystemXmlXmlSerializer = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XmlSerializer")).GetReference(filePath: "System.Xml.XmlSerializer.dll", display: "System.Xml.XmlSerializer (netstandard20)");
                 }
                 return _SystemXmlXmlSerializer;
             }
@@ -2610,7 +2610,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXPath is null)
                 {
-                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPath).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netstandard20)");
+                    _SystemXmlXPath = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XPath")).GetReference(filePath: "System.Xml.XPath.dll", display: "System.Xml.XPath (netstandard20)");
                 }
                 return _SystemXmlXPath;
             }
@@ -2627,7 +2627,7 @@ public static partial class NetStandard20
             {
                 if (_SystemXmlXPathXDocument is null)
                 {
-                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(Resources.SystemXmlXPathXDocument).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netstandard20)");
+                    _SystemXmlXPathXDocument = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Xml.XPath.XDocument")).GetReference(filePath: "System.Xml.XPath.XDocument.dll", display: "System.Xml.XPath.XDocument (netstandard20)");
                 }
                 return _SystemXmlXPathXDocument;
             }
@@ -2819,7 +2819,7 @@ public static partial class NetStandard20
             {
                 if (_MicrosoftCSharp is null)
                 {
-                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(Resources.MicrosoftCSharp).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
+                    _MicrosoftCSharp = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.Microsoft.CSharp")).GetReference(filePath: "Microsoft.CSharp.dll", display: "Microsoft.CSharp (netstandard20)");
                 }
                 return _MicrosoftCSharp;
             }
@@ -2836,7 +2836,7 @@ public static partial class NetStandard20
             {
                 if (_MicrosoftVisualBasic is null)
                 {
-                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(Resources.MicrosoftVisualBasic).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
+                    _MicrosoftVisualBasic = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.Microsoft.VisualBasic")).GetReference(filePath: "Microsoft.VisualBasic.dll", display: "Microsoft.VisualBasic (netstandard20)");
                 }
                 return _MicrosoftVisualBasic;
             }
@@ -2853,7 +2853,7 @@ public static partial class NetStandard20
             {
                 if (_SystemThreadingTasksExtensions is null)
                 {
-                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(Resources.SystemThreadingTasksExtensions).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
+                    _SystemThreadingTasksExtensions = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("netstandard20.System.Threading.Tasks.Extensions")).GetReference(filePath: "System.Threading.Tasks.Extensions.dll", display: "System.Threading.Tasks.Extensions (netstandard20)");
                 }
                 return _SystemThreadingTasksExtensions;
             }

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -10,6 +10,7 @@
     <SignAssembly>true</SignAssembly>
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
+    <RoslynVersion>4.11.0</RoslynVersion>
 
     <!-- NuGet Properties -->
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Src/Directory.Build.targets
+++ b/Src/Directory.Build.targets
@@ -5,7 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.9.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(RoslynVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsPackable)' == 'true'">

--- a/Src/Generate/Program.cs
+++ b/Src/Generate/Program.cs
@@ -478,7 +478,7 @@ static (string CodeContent, string TargetsContent) GetGeneratedContentCore(strin
                             {
                                 if ({{fieldName}} is null)
                                 {
-                                    {{fieldName}} = AssemblyMetadata.CreateFromImage(Resources.{{propName}}).GetReference(filePath: "{{dllName}}", display: "{{dll}} ({{lowerName}})");
+                                    {{fieldName}} = AssemblyMetadata.CreateFromImage(ResourceLoader.GetResourceBlobAsImmutable("{{logicalName}}")).GetReference(filePath: "{{dllName}}", display: "{{dll}} ({{lowerName}})");
                                 }
                                 return {{fieldName}};
                             }


### PR DESCRIPTION
The structure of getting a `PortableExecutableReference` meant that we were essentially paying for `byte[]` twice. The first is generating the `byte[]` for the resource and then when that was passed to `CreateFromImage` it was converted to an `ImmutableArray<byte>` which means there is yet another `byte[]` allocation. To avoid this the code now just directly allocates the `ImmutableArray<byte>` and passes that to `CreateFromImage`.

This can save up to 45MB in certain cases I was looking at in the Roslyn tests.