### PR TITLE
Add [skip publish] support to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      (github.event_name == 'workflow_run' && 
+       github.event.workflow_run.conclusion == 'success' &&
+       !contains(github.event.workflow_run.head_commit.message, '[skip publish]'))
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
When a commit message on main contains `[skip publish]`, the publish workflow will skip the NuGet push. This is useful for:

- Documentation-only changes
- Batching a series of PRs before a single release
- Any merge where you don't want a new package version

**Usage:** Include `[skip publish]` anywhere in your merge/squash commit message.

The `workflow_dispatch` path is unaffected — manual publishes always proceed.