### PR TITLE
Switch publish workflow to NuGet trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
   publish:
     name: Publish NuGet 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && 
@@ -52,8 +55,13 @@ jobs:
       - name: Pack Solution
         run: dotnet pack -p:PackageOutputPath="${GITHUB_WORKSPACE}/packages" -p:IncludeSymbols=false -p:RepositoryCommit=${GITHUB_SHA} -p:PackageVersion="${{ steps.version.outputs.version }}" -c Release 
 
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@v1
+        with:
+          user: jaredpar
+
       - name: Publish NuPkg Files
-        run: dotnet nuget push "$GITHUB_WORKSPACE/packages/*.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json 
+        run: dotnet nuget push "$GITHUB_WORKSPACE/packages/*.nupkg" -s https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create Tag and Release
         env:


### PR DESCRIPTION
Replaces the long-lived `NUGET_API_KEY` secret with OIDC-based trusted publishing via `NuGet/login@v1`. This eliminates the need to rotate or manage API keys -- the workflow exchanges a short-lived GitHub OIDC token for a scoped NuGet credential at publish time.

**Changes:**

- Added `id-token: write` permission (required for OIDC token exchange)
- Added `contents: write` permission (explicit, since setting `permissions` overrides defaults and the release step needs it)
- Added `NuGet/login@v1` step before push
- Removed `-k ${{ secrets.NUGET_API_KEY }}` from the push command
- Added `--skip-duplicate` to avoid failures on re-runs

**After merging:** once the first publish succeeds, the `NUGET_API_KEY` repo secret can be safely deleted.